### PR TITLE
chore: Convert field_type from VARCHAR to PostgreSQL ENUM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 	@echo "  make test-all     - Run all tests (unit + integration)"
 	@echo "  make tests-coverage - Run tests with coverage report"
 	@echo "  make init-db      - Initialize database schema"
+	@echo "  make migrate      - Run migration on existing database"
 	@echo "  make fmt          - Format code with gofumpt"
 	@echo "  make fmt-check    - Check if code is formatted"
 	@echo "  make lint         - Run linter"
@@ -92,6 +93,25 @@ init-db:
 	fi
 	@echo "Database schema initialized successfully"
 
+# Run migration on existing database
+migrate:
+	@echo "Running migration on existing database..."
+	@if [ -f .env ]; then \
+		export $$(grep -v '^#' .env | xargs) && \
+		if [ -z "$$DATABASE_URL" ]; then \
+			echo "Error: DATABASE_URL not found in .env file"; \
+			exit 1; \
+		fi && \
+		psql "$$DATABASE_URL" -f sql/002_convert_to_enums.sql; \
+	else \
+		if [ -z "$$DATABASE_URL" ]; then \
+			echo "Error: DATABASE_URL environment variable is not set"; \
+			echo "Please set it or create a .env file with DATABASE_URL"; \
+			exit 1; \
+		fi && \
+		psql "$$DATABASE_URL" -f sql/002_convert_to_enums.sql; \
+	fi
+	@echo "Migration completed successfully"
 
 # Start Docker containers
 docker-up:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ help:
 	@echo "  make test-all     - Run all tests (unit + integration)"
 	@echo "  make tests-coverage - Run tests with coverage report"
 	@echo "  make init-db      - Initialize database schema"
-	@echo "  make migrate      - Run migration on existing database"
 	@echo "  make fmt          - Format code with gofumpt"
 	@echo "  make fmt-check    - Check if code is formatted"
 	@echo "  make lint         - Run linter"
@@ -92,26 +91,6 @@ init-db:
 		psql "$$DATABASE_URL" -f sql/001_initial_schema.sql; \
 	fi
 	@echo "Database schema initialized successfully"
-
-# Run migration on existing database
-migrate:
-	@echo "Running migration on existing database..."
-	@if [ -f .env ]; then \
-		export $$(grep -v '^#' .env | xargs) && \
-		if [ -z "$$DATABASE_URL" ]; then \
-			echo "Error: DATABASE_URL not found in .env file"; \
-			exit 1; \
-		fi && \
-		psql "$$DATABASE_URL" -f sql/002_convert_to_enums.sql; \
-	else \
-		if [ -z "$$DATABASE_URL" ]; then \
-			echo "Error: DATABASE_URL environment variable is not set"; \
-			echo "Please set it or create a .env file with DATABASE_URL"; \
-			exit 1; \
-		fi && \
-		psql "$$DATABASE_URL" -f sql/002_convert_to_enums.sql; \
-	fi
-	@echo "Migration completed successfully"
 
 # Start Docker containers
 docker-up:

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -2,10 +2,68 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// FieldType represents the type of feedback field
+type FieldType string
+
+const (
+	FieldTypeText        FieldType = "text"
+	FieldTypeCategorical FieldType = "categorical"
+	FieldTypeNPS         FieldType = "nps"
+	FieldTypeCSAT        FieldType = "csat"
+	FieldTypeCES         FieldType = "ces"
+	FieldTypeRating      FieldType = "rating"
+	FieldTypeNumber      FieldType = "number"
+	FieldTypeBoolean     FieldType = "boolean"
+	FieldTypeDate        FieldType = "date"
+)
+
+// ValidFieldTypes contains all valid field type values (set membership)
+var ValidFieldTypes = map[FieldType]struct{}{
+	FieldTypeText:        {},
+	FieldTypeCategorical: {},
+	FieldTypeNPS:         {},
+	FieldTypeCSAT:        {},
+	FieldTypeCES:         {},
+	FieldTypeRating:      {},
+	FieldTypeNumber:      {},
+	FieldTypeBoolean:     {},
+	FieldTypeDate:        {},
+}
+
+// IsValid returns true if the FieldType is valid
+func (ft FieldType) IsValid() bool {
+	_, valid := ValidFieldTypes[ft]
+	return valid
+}
+
+// ParseFieldType parses a string to FieldType, returns error if invalid
+func ParseFieldType(s string) (FieldType, error) {
+	ft := FieldType(s)
+	if !ft.IsValid() {
+		return "", fmt.Errorf("invalid field type: %s", s)
+	}
+	return ft, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler to validate field type during JSON unmarshaling
+func (ft *FieldType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseFieldType(s)
+	if err != nil {
+		return err
+	}
+	*ft = parsed
+	return nil
+}
 
 // FeedbackRecord represents a single feedback record
 type FeedbackRecord struct {
@@ -18,7 +76,7 @@ type FeedbackRecord struct {
 	SourceName     *string         `json:"source_name,omitempty"`
 	FieldID        string          `json:"field_id"`
 	FieldLabel     *string         `json:"field_label,omitempty"`
-	FieldType      string          `json:"field_type"`
+	FieldType      FieldType       `json:"field_type"`
 	ValueText      *string         `json:"value_text,omitempty"`
 	ValueNumber    *float64        `json:"value_number,omitempty"`
 	ValueBoolean   *bool           `json:"value_boolean,omitempty"`
@@ -38,7 +96,7 @@ type CreateFeedbackRecordRequest struct {
 	SourceName     *string         `json:"source_name,omitempty"`
 	FieldID        string          `json:"field_id" validate:"required,no_null_bytes,min=1,max=255"`
 	FieldLabel     *string         `json:"field_label,omitempty"`
-	FieldType      string          `json:"field_type" validate:"required,field_type,min=1,max=255"`
+	FieldType      FieldType       `json:"field_type" validate:"required,field_type"`
 	ValueText      *string         `json:"value_text,omitempty" validate:"omitempty,no_null_bytes"`
 	ValueNumber    *float64        `json:"value_number,omitempty"`
 	ValueBoolean   *bool           `json:"value_boolean,omitempty"`
@@ -69,7 +127,7 @@ type ListFeedbackRecordsFilters struct {
 	SourceType     *string    `form:"source_type" validate:"omitempty,no_null_bytes"`
 	SourceID       *string    `form:"source_id" validate:"omitempty,no_null_bytes"`
 	FieldID        *string    `form:"field_id" validate:"omitempty,no_null_bytes"`
-	FieldType      *string    `form:"field_type" validate:"omitempty,no_null_bytes"`
+	FieldType      *FieldType `form:"field_type" validate:"omitempty,field_type"`
 	UserIdentifier *string    `form:"user_identifier" validate:"omitempty,no_null_bytes"`
 	Since          *time.Time `form:"since" validate:"omitempty"`
 	Until          *time.Time `form:"until" validate:"omitempty"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -80,6 +80,16 @@ paths:
                   schema:
                     type: string
                     description: Filter by field type. NULL bytes not allowed.
+                    enum:
+                        - text
+                        - categorical
+                        - nps
+                        - csat
+                        - ces
+                        - rating
+                        - number
+                        - boolean
+                        - date
                     pattern: '^[^\x00]*$'
                 - name: user_identifier
                   in: query
@@ -695,6 +705,16 @@ components:
                 field_type:
                     type: string
                     description: Type of field
+                    enum:
+                        - text
+                        - categorical
+                        - nps
+                        - csat
+                        - ces
+                        - rating
+                        - number
+                        - boolean
+                        - date
                 id:
                     type: string
                     format: uuid

--- a/sql/001_initial_schema.sql
+++ b/sql/001_initial_schema.sql
@@ -4,6 +4,11 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
+-- Create ENUM types
+CREATE TYPE field_type_enum AS ENUM (
+    'text', 'categorical', 'nps', 'csat', 'ces', 'rating', 'number', 'boolean', 'date'
+);
+
 -- Feedback records table
 CREATE TABLE feedback_records (
   id UUID PRIMARY KEY DEFAULT uuidv7(),
@@ -18,7 +23,7 @@ CREATE TABLE feedback_records (
 
   field_id VARCHAR(255) NOT NULL,
   field_label VARCHAR,
-  field_type VARCHAR NOT NULL,
+  field_type field_type_enum NOT NULL,
 
   value_text TEXT,
   value_number DOUBLE PRECISION,

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,9 +6,9 @@ This directory contains integration tests for the Formbricks Hub API.
 
 Before running the tests, ensure:
 
-1. PostgreSQL is running (via docker-compose)
-2. Database schema has been initialized
-3. The `API_KEY` environment variable is set (tests will set it automatically)
+1. **PostgreSQL is running** with the default test credentials (e.g. `make docker-up`). The tests use `postgres://postgres:postgres@localhost:5432/test_db` by default. If you see `password authentication failed for user "postgres"`, start the stack with `make docker-up` and run `make init-db`.
+2. **Database schema** has been initialized (`make init-db`).
+3. **API_KEY** is set automatically by the tests; you do not need to set it.
 
 ## Running Tests
 


### PR DESCRIPTION
### Summary
Converts the `field_type` column from VARCHAR to a PostgreSQL ENUM type, and implements a type-safe string-based enum in Go to ensure only valid field types can be used.

### Changes

#### Database Schema
- **`sql/001_initial_schema.sql`**: Updated to use `field_type_enum` instead of VARCHAR

#### Go Models (`internal/models/feedback_records.go`)
- Added `FieldType` string-based enum type with constants
- Implemented `ValidFieldTypes` map using `map[FieldType]struct{}` for efficient set membership checks
- Added `IsValid()` and `ParseFieldType()` methods
- Added `UnmarshalJSON()` for JSON validation
- Updated structs to use `FieldType` instead of `string`:
  - `FeedbackRecord.FieldType`
  - `CreateFeedbackRecordRequest.FieldType`
  - `ListFeedbackRecordsFilters.FieldType`

#### Validation (`internal/api/validation/validation.go`)
- Updated `validateFieldType` to use `models.ParseFieldType()` and `ValidFieldTypes` map
- Added form decoder support for `*FieldType` in query parameters

#### OpenAPI Specification
- Added enum values to `field_type` in response schema
- Added enum values to `field_type` query parameter
- Request schema already had correct enum values

### Benefits
- **Type Safety**: Compile-time and runtime validation ensures only valid field types
- **Data Integrity**: PostgreSQL ENUM enforces constraints at database level
- **Better Documentation**: OpenAPI spec clearly shows valid values
- **Performance**: Efficient set membership checks using `struct{}` map values
