### PR TITLE
chore: remove response_id field from feedback records

### DIFF
--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -27,7 +27,6 @@ type FeedbackRecord struct {
 	Language       *string         `json:"language,omitempty"`
 	UserIdentifier *string         `json:"user_identifier,omitempty"`
 	TenantID       *string         `json:"tenant_id,omitempty"`
-	ResponseID     *string         `json:"response_id,omitempty"`
 }
 
 // CreateFeedbackRecordRequest represents the request to create a feedback record
@@ -47,7 +46,6 @@ type CreateFeedbackRecordRequest struct {
 	Language       *string         `json:"language,omitempty" validate:"omitempty,no_null_bytes,max=10"`
 	UserIdentifier *string         `json:"user_identifier,omitempty"`
 	TenantID       *string         `json:"tenant_id,omitempty" validate:"omitempty,no_null_bytes,max=255"`
-	ResponseID     *string         `json:"response_id,omitempty" validate:"omitempty,max=255"`
 }
 
 // UpdateFeedbackRecordRequest represents the request to update a feedback record
@@ -65,7 +63,6 @@ type UpdateFeedbackRecordRequest struct {
 // ListFeedbackRecordsFilters represents filters for listing feedback records
 type ListFeedbackRecordsFilters struct {
 	TenantID       *string    `form:"tenant_id" validate:"omitempty,no_null_bytes"`
-	ResponseID     *string    `form:"response_id" validate:"omitempty,no_null_bytes"`
 	SourceType     *string    `form:"source_type" validate:"omitempty,no_null_bytes"`
 	SourceID       *string    `form:"source_id" validate:"omitempty,no_null_bytes"`
 	FieldID        *string    `form:"field_id" validate:"omitempty,no_null_bytes"`

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -35,14 +35,14 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 			collected_at, source_type, source_id, source_name,
 			field_id, field_label, field_type,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_identifier, tenant_id, response_id
+			metadata, language, user_identifier, tenant_id
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 		RETURNING id, collected_at, created_at, updated_at,
 			source_type, source_id, source_name,
 			field_id, field_label, field_type,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_identifier, tenant_id, response_id
+			metadata, language, user_identifier, tenant_id
 	`
 
 	var record models.FeedbackRecord
@@ -50,13 +50,13 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 		collectedAt, req.SourceType, req.SourceID, req.SourceName,
 		req.FieldID, req.FieldLabel, req.FieldType,
 		req.ValueText, req.ValueNumber, req.ValueBoolean, req.ValueDate,
-		req.Metadata, req.Language, req.UserIdentifier, req.TenantID, req.ResponseID,
+		req.Metadata, req.Language, req.UserIdentifier, req.TenantID,
 	).Scan(
 		&record.ID, &record.CollectedAt, &record.CreatedAt, &record.UpdatedAt,
 		&record.SourceType, &record.SourceID, &record.SourceName,
 		&record.FieldID, &record.FieldLabel, &record.FieldType,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
-		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
+		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create feedback record: %w", err)
@@ -72,7 +72,7 @@ func (r *FeedbackRecordsRepository) GetByID(ctx context.Context, id uuid.UUID) (
 			source_type, source_id, source_name,
 			field_id, field_label, field_type,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_identifier, tenant_id, response_id
+			metadata, language, user_identifier, tenant_id
 		FROM feedback_records
 		WHERE id = $1
 	`
@@ -83,7 +83,7 @@ func (r *FeedbackRecordsRepository) GetByID(ctx context.Context, id uuid.UUID) (
 		&record.SourceType, &record.SourceID, &record.SourceName,
 		&record.FieldID, &record.FieldLabel, &record.FieldType,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
-		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
+		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -105,12 +105,6 @@ func buildFilterConditions(filters *models.ListFeedbackRecordsFilters) (string, 
 	if filters.TenantID != nil {
 		conditions = append(conditions, fmt.Sprintf("tenant_id = $%d", argCount))
 		args = append(args, *filters.TenantID)
-		argCount++
-	}
-
-	if filters.ResponseID != nil {
-		conditions = append(conditions, fmt.Sprintf("response_id = $%d", argCount))
-		args = append(args, *filters.ResponseID)
 		argCount++
 	}
 
@@ -170,7 +164,7 @@ func (r *FeedbackRecordsRepository) List(ctx context.Context, filters *models.Li
 			source_type, source_id, source_name,
 			field_id, field_label, field_type,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_identifier, tenant_id, response_id
+			metadata, language, user_identifier, tenant_id
 		FROM feedback_records
 	`
 
@@ -205,7 +199,7 @@ func (r *FeedbackRecordsRepository) List(ctx context.Context, filters *models.Li
 			&record.SourceType, &record.SourceID, &record.SourceName,
 			&record.FieldID, &record.FieldLabel, &record.FieldType,
 			&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
-			&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
+			&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feedback record: %w", err)
@@ -303,7 +297,7 @@ func buildUpdateQuery(req *models.UpdateFeedbackRecordRequest, id uuid.UUID, upd
 			source_type, source_id, source_name,
 			field_id, field_label, field_type,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_identifier, tenant_id, response_id
+			metadata, language, user_identifier, tenant_id
 	`, strings.Join(updates, ", "), argCount)
 
 	return query, args, true
@@ -323,7 +317,7 @@ func (r *FeedbackRecordsRepository) Update(ctx context.Context, id uuid.UUID, re
 		&record.SourceType, &record.SourceID, &record.SourceName,
 		&record.FieldID, &record.FieldLabel, &record.FieldType,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
-		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
+		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,13 +47,6 @@ paths:
                     type: string
                     description: Filter by tenant ID (for multi-tenant deployments). NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
-                - name: response_id
-                  in: query
-                  description: Filter by response ID (get all answers from one submission). NULL bytes not allowed.
-                  schema:
-                    type: string
-                    description: Filter by response ID (get all answers from one submission). NULL bytes not allowed.
-                    pattern: '^[^\x00]*$'
                 - name: source_type
                   in: query
                   description: Filter by source type. NULL bytes not allowed.
@@ -143,7 +136,6 @@ paths:
                                               field_type: "rating"
                                               field_label: "How satisfied are you?"
                                               value_number: 9
-                                              response_id: "resp-abc-123"
                                               source_id: "survey-123"
                                               source_name: "Q1 NPS Survey"
                                               user_identifier: "user-abc-123"
@@ -190,7 +182,6 @@ paths:
                                     field_type: "rating"
                                     field_label: "How satisfied are you?"
                                     value_number: 9
-                                    response_id: "resp-abc-123"
                                     source_id: "survey-123"
                                     source_name: "Q1 NPS Survey"
                                     user_identifier: "user-abc-123"
@@ -204,7 +195,6 @@ paths:
                                     field_type: "text"
                                     field_label: "What can we improve?"
                                     value_text: "Great service! Keep it up."
-                                    response_id: "resp-abc-123"
                                     source_id: "survey-123"
                                     source_name: "Q1 NPS Survey"
                                     user_identifier: "user-abc-123"
@@ -218,7 +208,6 @@ paths:
                                     field_type: "nps"
                                     field_label: "How likely are you to recommend us?"
                                     value_number: 8
-                                    response_id: "resp-abc-123"
                                     source_id: "survey-123"
                                     source_name: "NPS Survey"
                                     user_identifier: "user-abc-123"
@@ -232,7 +221,6 @@ paths:
                                     field_type: "boolean"
                                     field_label: "Would you use our service again?"
                                     value_boolean: true
-                                    response_id: "resp-abc-123"
                                     source_id: "survey-123"
                                     source_name: "Q1 NPS Survey"
                                     user_identifier: "user-abc-123"
@@ -259,7 +247,6 @@ paths:
                                         field_type: "rating"
                                         field_label: "How satisfied are you?"
                                         value_number: 9
-                                        response_id: "resp-abc-123"
                                         source_id: "survey-123"
                                         source_name: "Q1 NPS Survey"
                                         user_identifier: "user-abc-123"
@@ -453,7 +440,6 @@ paths:
                                         field_type: "rating"
                                         field_label: "How satisfied are you?"
                                         value_number: 10
-                                        response_id: "resp-abc-123"
                                         source_id: "survey-123"
                                         source_name: "Q1 NPS Survey"
                                         user_identifier: "user-abc-123"
@@ -561,12 +547,6 @@ components:
                     type: object
                     description: User agent, device, location, referrer, tags, etc. NULL bytes (\x00 or \u0000) are not allowed in JSON keys or values.
                     additionalProperties: {}
-                response_id:
-                    type: string
-                    description: Groups multiple answers from a single submission/session
-                    examples:
-                        - resp-abc-123
-                    maxLength: 255
                 source_id:
                     type: string
                     description: Reference to survey/form/ticket ID
@@ -707,9 +687,6 @@ components:
                     type: object
                     description: Additional context
                     additionalProperties: {}
-                response_id:
-                    type: string
-                    description: Groups answers from a single submission
                 source_id:
                     type: string
                     description: Reference to survey/form/ticket ID

--- a/sql/001_initial_schema.sql
+++ b/sql/001_initial_schema.sql
@@ -30,14 +30,12 @@ CREATE TABLE feedback_records (
   user_identifier VARCHAR(255),
 
   -- Multi-tenancy fields
-  tenant_id VARCHAR(255),
-  response_id VARCHAR(255)
+  tenant_id VARCHAR(255)
 );
 
 -- Indexes
 -- Multi-tenancy indexes
 CREATE INDEX idx_feedback_records_tenant_id ON feedback_records(tenant_id);
-CREATE INDEX idx_feedback_records_response_id ON feedback_records(response_id);
 
 -- Single-column indexes for common filter operations
 -- Required for analytics performance

--- a/sql/002_remove_response_id.sql
+++ b/sql/002_remove_response_id.sql
@@ -1,0 +1,8 @@
+-- Remove response_id column from feedback_records table
+-- This field is no longer needed
+
+-- Drop the index first
+DROP INDEX IF EXISTS idx_feedback_records_response_id;
+
+-- Drop the column
+ALTER TABLE feedback_records DROP COLUMN IF EXISTS response_id;


### PR DESCRIPTION
## Summary
- Remove `response_id` column from feedback_records table schema
- Remove `response_id` from Go models and repository layer
- Remove `response_id` from OpenAPI specification
- Add migration file (002_remove_response_id.sql) for existing deployments

## Test plan
- [ ] Verify the application builds successfully
- [ ] Run existing tests to ensure no regressions
- [ ] Test API endpoints still work without response_id field
- [ ] For existing deployments, run the migration to drop the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)