### PR TITLE
feat: add field grouping support for ranking and matrix questions

### DIFF
--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -9,45 +9,49 @@ import (
 
 // FeedbackRecord represents a single feedback record
 type FeedbackRecord struct {
-	ID             uuid.UUID       `json:"id"`
-	CollectedAt    time.Time       `json:"collected_at"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
-	SourceType     string          `json:"source_type"`
-	SourceID       *string         `json:"source_id,omitempty"`
-	SourceName     *string         `json:"source_name,omitempty"`
-	FieldID        string          `json:"field_id"`
-	FieldLabel     *string         `json:"field_label,omitempty"`
-	FieldType      string          `json:"field_type"`
-	ValueText      *string         `json:"value_text,omitempty"`
-	ValueNumber    *float64        `json:"value_number,omitempty"`
-	ValueBoolean   *bool           `json:"value_boolean,omitempty"`
-	ValueDate      *time.Time      `json:"value_date,omitempty"`
-	Metadata       json.RawMessage `json:"metadata,omitempty"`
-	Language       *string         `json:"language,omitempty"`
-	UserIdentifier *string         `json:"user_identifier,omitempty"`
-	TenantID       *string         `json:"tenant_id,omitempty"`
-	ResponseID     *string         `json:"response_id,omitempty"`
+	ID              uuid.UUID       `json:"id"`
+	CollectedAt     time.Time       `json:"collected_at"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
+	SourceType      string          `json:"source_type"`
+	SourceID        *string         `json:"source_id,omitempty"`
+	SourceName      *string         `json:"source_name,omitempty"`
+	FieldID         string          `json:"field_id"`
+	FieldLabel      *string         `json:"field_label,omitempty"`
+	FieldType       string          `json:"field_type"`
+	FieldGroupID    *string         `json:"field_group_id,omitempty"`
+	FieldGroupLabel *string         `json:"field_group_label,omitempty"`
+	ValueText       *string         `json:"value_text,omitempty"`
+	ValueNumber     *float64        `json:"value_number,omitempty"`
+	ValueBoolean    *bool           `json:"value_boolean,omitempty"`
+	ValueDate       *time.Time      `json:"value_date,omitempty"`
+	Metadata        json.RawMessage `json:"metadata,omitempty"`
+	Language        *string         `json:"language,omitempty"`
+	UserIdentifier  *string         `json:"user_identifier,omitempty"`
+	TenantID        *string         `json:"tenant_id,omitempty"`
+	ResponseID      *string         `json:"response_id,omitempty"`
 }
 
 // CreateFeedbackRecordRequest represents the request to create a feedback record
 type CreateFeedbackRecordRequest struct {
-	CollectedAt    *time.Time      `json:"collected_at,omitempty"`
-	SourceType     string          `json:"source_type" validate:"required,no_null_bytes,min=1,max=255"`
-	SourceID       *string         `json:"source_id,omitempty" validate:"omitempty,no_null_bytes"`
-	SourceName     *string         `json:"source_name,omitempty"`
-	FieldID        string          `json:"field_id" validate:"required,no_null_bytes,min=1,max=255"`
-	FieldLabel     *string         `json:"field_label,omitempty"`
-	FieldType      string          `json:"field_type" validate:"required,field_type,min=1,max=255"`
-	ValueText      *string         `json:"value_text,omitempty" validate:"omitempty,no_null_bytes"`
-	ValueNumber    *float64        `json:"value_number,omitempty"`
-	ValueBoolean   *bool           `json:"value_boolean,omitempty"`
-	ValueDate      *time.Time      `json:"value_date,omitempty"`
-	Metadata       json.RawMessage `json:"metadata,omitempty"`
-	Language       *string         `json:"language,omitempty" validate:"omitempty,no_null_bytes,max=10"`
-	UserIdentifier *string         `json:"user_identifier,omitempty"`
-	TenantID       *string         `json:"tenant_id,omitempty" validate:"omitempty,no_null_bytes,max=255"`
-	ResponseID     *string         `json:"response_id,omitempty" validate:"omitempty,max=255"`
+	CollectedAt     *time.Time      `json:"collected_at,omitempty"`
+	SourceType      string          `json:"source_type" validate:"required,no_null_bytes,min=1,max=255"`
+	SourceID        *string         `json:"source_id,omitempty" validate:"omitempty,no_null_bytes"`
+	SourceName      *string         `json:"source_name,omitempty"`
+	FieldID         string          `json:"field_id" validate:"required,no_null_bytes,min=1,max=255"`
+	FieldLabel      *string         `json:"field_label,omitempty"`
+	FieldType       string          `json:"field_type" validate:"required,field_type,min=1,max=255"`
+	FieldGroupID    *string         `json:"field_group_id,omitempty" validate:"omitempty,no_null_bytes,max=255"`
+	FieldGroupLabel *string         `json:"field_group_label,omitempty"`
+	ValueText       *string         `json:"value_text,omitempty" validate:"omitempty,no_null_bytes"`
+	ValueNumber     *float64        `json:"value_number,omitempty"`
+	ValueBoolean    *bool           `json:"value_boolean,omitempty"`
+	ValueDate       *time.Time      `json:"value_date,omitempty"`
+	Metadata        json.RawMessage `json:"metadata,omitempty"`
+	Language        *string         `json:"language,omitempty" validate:"omitempty,no_null_bytes,max=10"`
+	UserIdentifier  *string         `json:"user_identifier,omitempty"`
+	TenantID        *string         `json:"tenant_id,omitempty" validate:"omitempty,no_null_bytes,max=255"`
+	ResponseID      *string         `json:"response_id,omitempty" validate:"omitempty,max=255"`
 }
 
 // UpdateFeedbackRecordRequest represents the request to update a feedback record
@@ -69,6 +73,7 @@ type ListFeedbackRecordsFilters struct {
 	SourceType     *string    `form:"source_type" validate:"omitempty,no_null_bytes"`
 	SourceID       *string    `form:"source_id" validate:"omitempty,no_null_bytes"`
 	FieldID        *string    `form:"field_id" validate:"omitempty,no_null_bytes"`
+	FieldGroupID   *string    `form:"field_group_id" validate:"omitempty,no_null_bytes"`
 	FieldType      *string    `form:"field_type" validate:"omitempty,no_null_bytes"`
 	UserIdentifier *string    `form:"user_identifier" validate:"omitempty,no_null_bytes"`
 	Since          *time.Time `form:"since" validate:"omitempty"`

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -33,14 +33,14 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 	query := `
 		INSERT INTO feedback_records (
 			collected_at, source_type, source_id, source_name,
-			field_id, field_label, field_type,
+			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
 			metadata, language, user_identifier, tenant_id, response_id
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 		RETURNING id, collected_at, created_at, updated_at,
 			source_type, source_id, source_name,
-			field_id, field_label, field_type,
+			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
 			metadata, language, user_identifier, tenant_id, response_id
 	`
@@ -48,13 +48,13 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 	var record models.FeedbackRecord
 	err := r.db.QueryRow(ctx, query,
 		collectedAt, req.SourceType, req.SourceID, req.SourceName,
-		req.FieldID, req.FieldLabel, req.FieldType,
+		req.FieldID, req.FieldLabel, req.FieldType, req.FieldGroupID, req.FieldGroupLabel,
 		req.ValueText, req.ValueNumber, req.ValueBoolean, req.ValueDate,
 		req.Metadata, req.Language, req.UserIdentifier, req.TenantID, req.ResponseID,
 	).Scan(
 		&record.ID, &record.CollectedAt, &record.CreatedAt, &record.UpdatedAt,
 		&record.SourceType, &record.SourceID, &record.SourceName,
-		&record.FieldID, &record.FieldLabel, &record.FieldType,
+		&record.FieldID, &record.FieldLabel, &record.FieldType, &record.FieldGroupID, &record.FieldGroupLabel,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
 		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
 	)
@@ -70,7 +70,7 @@ func (r *FeedbackRecordsRepository) GetByID(ctx context.Context, id uuid.UUID) (
 	query := `
 		SELECT id, collected_at, created_at, updated_at,
 			source_type, source_id, source_name,
-			field_id, field_label, field_type,
+			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
 			metadata, language, user_identifier, tenant_id, response_id
 		FROM feedback_records
@@ -81,7 +81,7 @@ func (r *FeedbackRecordsRepository) GetByID(ctx context.Context, id uuid.UUID) (
 	err := r.db.QueryRow(ctx, query, id).Scan(
 		&record.ID, &record.CollectedAt, &record.CreatedAt, &record.UpdatedAt,
 		&record.SourceType, &record.SourceID, &record.SourceName,
-		&record.FieldID, &record.FieldLabel, &record.FieldType,
+		&record.FieldID, &record.FieldLabel, &record.FieldType, &record.FieldGroupID, &record.FieldGroupLabel,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
 		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
 	)
@@ -132,6 +132,12 @@ func buildFilterConditions(filters *models.ListFeedbackRecordsFilters) (string, 
 		argCount++
 	}
 
+	if filters.FieldGroupID != nil {
+		conditions = append(conditions, fmt.Sprintf("field_group_id = $%d", argCount))
+		args = append(args, *filters.FieldGroupID)
+		argCount++
+	}
+
 	if filters.FieldType != nil {
 		conditions = append(conditions, fmt.Sprintf("field_type = $%d", argCount))
 		args = append(args, *filters.FieldType)
@@ -168,7 +174,7 @@ func (r *FeedbackRecordsRepository) List(ctx context.Context, filters *models.Li
 	query := `
 		SELECT id, collected_at, created_at, updated_at,
 			source_type, source_id, source_name,
-			field_id, field_label, field_type,
+			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
 			metadata, language, user_identifier, tenant_id, response_id
 		FROM feedback_records
@@ -203,7 +209,7 @@ func (r *FeedbackRecordsRepository) List(ctx context.Context, filters *models.Li
 		err := rows.Scan(
 			&record.ID, &record.CollectedAt, &record.CreatedAt, &record.UpdatedAt,
 			&record.SourceType, &record.SourceID, &record.SourceName,
-			&record.FieldID, &record.FieldLabel, &record.FieldType,
+			&record.FieldID, &record.FieldLabel, &record.FieldType, &record.FieldGroupID, &record.FieldGroupLabel,
 			&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
 			&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
 		)
@@ -301,7 +307,7 @@ func buildUpdateQuery(req *models.UpdateFeedbackRecordRequest, id uuid.UUID, upd
 		WHERE id = $%d
 		RETURNING id, collected_at, created_at, updated_at,
 			source_type, source_id, source_name,
-			field_id, field_label, field_type,
+			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
 			metadata, language, user_identifier, tenant_id, response_id
 	`, strings.Join(updates, ", "), argCount)
@@ -321,7 +327,7 @@ func (r *FeedbackRecordsRepository) Update(ctx context.Context, id uuid.UUID, re
 	err := r.db.QueryRow(ctx, query, args...).Scan(
 		&record.ID, &record.CollectedAt, &record.CreatedAt, &record.UpdatedAt,
 		&record.SourceType, &record.SourceID, &record.SourceName,
-		&record.FieldID, &record.FieldLabel, &record.FieldType,
+		&record.FieldID, &record.FieldLabel, &record.FieldType, &record.FieldGroupID, &record.FieldGroupLabel,
 		&record.ValueText, &record.ValueNumber, &record.ValueBoolean, &record.ValueDate,
 		&record.Metadata, &record.Language, &record.UserIdentifier, &record.TenantID, &record.ResponseID,
 	)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -74,6 +74,13 @@ paths:
                   schema:
                     type: string
                     pattern: '^[^\x00]*$'
+                - name: field_group_id
+                  in: query
+                  description: Filter by field group ID (for ranking/matrix questions). NULL bytes not allowed.
+                  schema:
+                    type: string
+                    description: Filter by field group ID (for ranking/matrix questions). NULL bytes not allowed.
+                    pattern: '^[^\x00]*$'
                 - name: field_type
                   in: query
                   description: Filter by field type. NULL bytes not allowed.
@@ -238,6 +245,41 @@ paths:
                                     user_identifier: "user-abc-123"
                                     tenant_id: "org-123"
                                     language: "en"
+                            ranking:
+                                summary: Ranking question item
+                                value:
+                                    source_type: "survey"
+                                    field_id: "feature_priority__reports"
+                                    field_type: "number"
+                                    field_label: "Reports"
+                                    field_group_id: "feature_priority"
+                                    field_group_label: "Rank these features by importance"
+                                    value_number: 1
+                                    response_id: "resp-abc-123"
+                                    source_id: "survey-123"
+                                    source_name: "Feature Priority Survey"
+                                    user_identifier: "user-abc-123"
+                                    tenant_id: "org-123"
+                                    metadata:
+                                        question_type: "ranking"
+                                        total_items: 3
+                            matrix:
+                                summary: Matrix rating item
+                                value:
+                                    source_type: "survey"
+                                    field_id: "feature_satisfaction__ease_of_use"
+                                    field_type: "rating"
+                                    field_label: "Ease of Use"
+                                    field_group_id: "feature_satisfaction"
+                                    field_group_label: "Rate your satisfaction with each feature"
+                                    value_number: 4
+                                    response_id: "resp-abc-123"
+                                    source_id: "survey-123"
+                                    source_name: "Feature Satisfaction Survey"
+                                    user_identifier: "user-abc-123"
+                                    tenant_id: "org-123"
+                                    metadata:
+                                        question_type: "matrix"
                 required: true
             responses:
                 "201":
@@ -533,6 +575,18 @@ components:
                     description: The actual question text
                     examples:
                         - How satisfied are you?
+                field_group_id:
+                    type: string
+                    description: Stable identifier grouping related fields (for ranking, matrix, grid questions). NULL bytes not allowed.
+                    examples:
+                        - feature_priority
+                    maxLength: 255
+                    pattern: '^[^\x00]*$'
+                field_group_label:
+                    type: string
+                    description: Human-readable question text for the group
+                    examples:
+                        - Rank these features by importance
                 field_type:
                     type: string
                     description: 'Field type: text (enrichable), categorical, nps, csat, ces, rating, number, boolean, date'
@@ -692,6 +746,12 @@ components:
                 field_label:
                     type: string
                     description: The actual question text
+                field_group_id:
+                    type: string
+                    description: Stable identifier grouping related fields (for ranking, matrix, grid questions)
+                field_group_label:
+                    type: string
+                    description: Human-readable question text for the group
                 field_type:
                     type: string
                     description: Type of field

--- a/sql/001_initial_schema.sql
+++ b/sql/001_initial_schema.sql
@@ -20,6 +20,10 @@ CREATE TABLE feedback_records (
   field_label VARCHAR,
   field_type VARCHAR NOT NULL,
 
+  -- Field grouping for composite questions (ranking, matrix, grid)
+  field_group_id VARCHAR(255),
+  field_group_label VARCHAR,
+
   value_text TEXT,
   value_number DOUBLE PRECISION,
   value_boolean BOOLEAN,
@@ -46,6 +50,7 @@ CREATE INDEX idx_feedback_records_source_id ON feedback_records(source_id);
 CREATE INDEX idx_feedback_records_collected_at ON feedback_records(collected_at);
 CREATE INDEX idx_feedback_records_field_type ON feedback_records(field_type);
 CREATE INDEX idx_feedback_records_field_id ON feedback_records(field_id);
+CREATE INDEX idx_feedback_records_field_group_id ON feedback_records(field_group_id);
 CREATE INDEX idx_feedback_records_value_number ON feedback_records(value_number);
 CREATE INDEX idx_feedback_records_user_identifier ON feedback_records(user_identifier);
 

--- a/sql/002_add_field_group.sql
+++ b/sql/002_add_field_group.sql
@@ -1,0 +1,8 @@
+-- Add field grouping support for composite questions (ranking, matrix, grid)
+
+-- Add new columns
+ALTER TABLE feedback_records ADD COLUMN IF NOT EXISTS field_group_id VARCHAR(255);
+ALTER TABLE feedback_records ADD COLUMN IF NOT EXISTS field_group_label VARCHAR;
+
+-- Add index for field_group_id (commonly filtered on for analytics)
+CREATE INDEX IF NOT EXISTS idx_feedback_records_field_group_id ON feedback_records(field_group_id);


### PR DESCRIPTION
## Summary
- Add `field_group_id` and `field_group_label` fields to support composite question types (ranking, matrix, grid)
- Add index on `field_group_id` for efficient filtering in analytics queries
- Add `field_group_id` filter parameter to the list endpoint
- Include examples for ranking and matrix question types in OpenAPI spec

## How It Works

### Ranking Question
```json
{
  "field_group_id": "feature_priority",
  "field_group_label": "Rank these features by importance",
  "field_id": "feature_priority__reports",
  "field_label": "Reports",
  "field_type": "number",
  "value_number": 1,
  "metadata": {"question_type": "ranking", "total_items": 3}
}
```

### Matrix Rating Question
```json
{
  "field_group_id": "feature_satisfaction",
  "field_group_label": "Rate your satisfaction with each feature",
  "field_id": "feature_satisfaction__ease_of_use",
  "field_label": "Ease of Use",
  "field_type": "rating",
  "value_number": 4,
  "metadata": {"question_type": "matrix"}
}
```

## Analytics Examples
```sql
-- Average rank per feature
SELECT field_label, AVG(value_number) as avg_rank
FROM feedback_records
WHERE field_group_id = 'feature_priority'
GROUP BY field_label
ORDER BY avg_rank;

-- Matrix: average rating per row item
SELECT field_label, AVG(value_number) as avg_rating
FROM feedback_records
WHERE field_group_id = 'feature_satisfaction'
GROUP BY field_label;
```

## Test plan
- [ ] Verify the application builds successfully
- [ ] Run existing tests to ensure no regressions
- [ ] Test creating feedback records with field_group_id and field_group_label
- [ ] Test filtering by field_group_id in list endpoint
- [ ] For existing deployments, run 002_add_field_group.sql migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)