### PR TITLE
chore: Use host port 5433 for Postgres to avoid conflict with Formbricks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@
 API_KEY=your-secret-api-key-here
 
 # Database connection URL (optional)
-# Default: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
+# Default: postgres://postgres:postgres@localhost:5433/test_db?sslmode=disable (compose exposes 5433 on host)
 # Format: postgres://username:password@host:port/database?sslmode=disable
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
+DATABASE_URL=postgres://postgres:postgres@localhost:5433/test_db?sslmode=disable
 
 # HTTP server port (optional)
 # Default: 8080

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ run:
 		echo "API_KEY=test-api-key-12345" >> .env; \
 		echo "" >> .env; \
 		echo "# Database connection URL" >> .env; \
-		echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable" >> .env; \
+		echo "DATABASE_URL=postgres://postgres:postgres@localhost:5433/test_db?sslmode=disable" >> .env; \
 		echo "" >> .env; \
 		echo "# Server port (default: 8080)" >> .env; \
 		echo "PORT=8080" >> .env; \

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: test_db
     ports:
-      - '5432:5432'
+      - '5433:5432'
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ This directory contains integration tests for the Formbricks Hub API.
 
 Before running the tests, ensure:
 
-1. **PostgreSQL is running** with the default test credentials (e.g. `make docker-up`). The tests use `postgres://postgres:postgres@localhost:5432/test_db` by default. If you see `password authentication failed for user "postgres"`, start the stack with `make docker-up` and run `make init-db`.
+1. **PostgreSQL is running** with the default test credentials (e.g. `make docker-up`). The tests use `postgres://postgres:postgres@localhost:5433/test_db` by default (compose exposes Postgres on host port 5433). If you see `password authentication failed for user "postgres"`, start the stack with `make docker-up` and run `make init-db`.
 2. **Database schema** has been initialized (`make init-db`).
 3. **API_KEY** is set automatically by the tests; you do not need to set it.
 


### PR DESCRIPTION
**Description:**

To avoid port conflicts when running Hub and the main Formbricks project (both using Postgres on 5432), the default Postgres host port is now **5433**.

- **compose.yml**: map `5433:5432` so Postgres is exposed on 5433 on the host  
- **.env.example**, **Makefile** (default `.env`), **tests/README.md**: `DATABASE_URL` and docs updated to use `localhost:5433`

Existing `.env` files must be updated to use port 5433 (or recreated from `.env.example`). CI is unchanged and still uses 5432 in its own environment.