### PR TITLE
fix: use default service account for migrations job

### DIFF
--- a/charts/hub/templates/migrations-job.yaml
+++ b/charts/hub/templates/migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         {{- include "hub.checksumAnnotations" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "hub.serviceAccountName" . }}
+      serviceAccountName: default
       restartPolicy: OnFailure
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Summary

- The migrations Helm hook Job runs in the `PreSync` phase but references ServiceAccount `hub` which is only created during the `Sync` phase
- This causes the migration pod to fail with: `serviceaccount "hub" not found`
- Fix: use the `default` service account for the migrations job since it only needs database access via env vars, not AWS Pod Identity

## Test plan

- [ ] ArgoCD sync completes successfully
- [ ] Migrations job runs and completes
- [ ] Hub pods start and pass health checks

Made with [Cursor](https://cursor.com)