### PR TITLE
fix: use ArgoCD sync waves for migration ordering

### DIFF
--- a/charts/hub/templates/configmap.yaml
+++ b/charts/hub/templates/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "hub.configMapName" . }}
   labels:
     {{- include "hub.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   {{- range $key, $val := .Values.config.data }}
   {{ $key }}: {{ $val | quote }}

--- a/charts/hub/templates/externalsecret.yaml
+++ b/charts/hub/templates/externalsecret.yaml
@@ -8,10 +8,11 @@ metadata:
   name: {{ include "hub.secretName" . }}
   labels:
     {{- include "hub.labels" . | nindent 4 }}
-  {{- with .Values.secrets.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    {{- with .Values.secrets.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   refreshInterval: {{ .Values.secrets.externalSecrets.refreshInterval | default "1h" }}
   secretStoreRef:

--- a/charts/hub/templates/migrations-job.yaml
+++ b/charts/hub/templates/migrations-job.yaml
@@ -2,15 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ printf "%s-migrations" (include "hub.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-migrations-%s" (include "hub.fullname" .) (.Values.image.tag | default .Chart.AppVersion) | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "hub.labels" . | nindent 4 }}
-  {{- if .Values.migrations.hook.enabled }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: {{ .Values.migrations.hook.weight | quote }}
-    helm.sh/hook-delete-policy: {{ .Values.migrations.hook.deletePolicy | quote }}
-  {{- end }}
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
   {{- if .Values.migrations.ttlSecondsAfterFinished }}
@@ -20,8 +18,6 @@ spec:
     metadata:
       labels:
         {{- include "hub.selectorLabels" . | nindent 8 }}
-      annotations:
-        {{- include "hub.checksumAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: default
       restartPolicy: OnFailure
@@ -43,24 +39,12 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (and .Values.config.create (not .Values.config.existingConfigMap)) .Values.config.existingConfigMap (and .Values.secrets.create (not .Values.secrets.existingSecret) (not .Values.secrets.externalSecrets.enabled)) .Values.secrets.existingSecret .Values.secrets.externalSecrets.enabled .Values.extraEnvFrom }}
-          envFrom:
-            {{- if or (and .Values.config.create (not .Values.config.existingConfigMap)) .Values.config.existingConfigMap }}
-            - configMapRef:
-                name: {{ include "hub.configMapName" . }}
-            {{- end }}
-            {{- if or (and .Values.secrets.create (not .Values.secrets.existingSecret) (not .Values.secrets.externalSecrets.enabled)) .Values.secrets.existingSecret .Values.secrets.externalSecrets.enabled }}
-            - secretRef:
-                name: {{ include "hub.secretName" . }}
-            {{- end }}
-            {{- with .Values.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- with .Values.extraEnv }}
           env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hub.secretName" . }}
+                  key: DATABASE_URL
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/charts/hub/templates/serviceaccount.yaml
+++ b/charts/hub/templates/serviceaccount.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "hub.serviceAccountName" . }}
   labels:
     {{- include "hub.labels" . | nindent 8 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- The migrations Job needs the ExternalSecret (K8s Secret) and ConfigMap to exist before it can start
- Helm `pre-install/pre-upgrade` hooks run in ArgoCD's PreSync phase, before any regular resources are created
- This caused `configmap "hub-stage-config" not found` errors

**Fix:** Replace Helm hooks with ArgoCD sync waves:
- **Wave -1**: ServiceAccount, ConfigMap, ExternalSecret (created first)
- **Wave 1**: Migrations Job as ArgoCD Sync hook (runs after wave -1 resources exist, only needs `DATABASE_URL`)
- **Wave 2**: Deployment (starts after migrations complete)

## Test plan

- [ ] ArgoCD sync completes without `configmap not found` errors
- [ ] Migrations job runs successfully (goose + river)
- [ ] Hub pods start and `/health` returns 200

Made with [Cursor](https://cursor.com)