### PR TITLE
ci: add Stainless OpenAPI workflow for Stainless preview/merge builds

### DIFF
--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -27,12 +27,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
 
       - name: Run preview builds
-        uses: stainless-api/upload-openapi-spec-action/preview@574dfd13ae0a31b75c78570b19811e0f03c66c64
+        uses: stainless-api/upload-openapi-spec-action/preview@574dfd13ae0a31b75c78570b19811e0f03c66c64 # v1
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}
@@ -47,12 +47,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
 
       - name: Run merge build
-        uses: stainless-api/upload-openapi-spec-action/merge@574dfd13ae0a31b75c78570b19811e0f03c66c64
+        uses: stainless-api/upload-openapi-spec-action/merge@574dfd13ae0a31b75c78570b19811e0f03c66c64 # v1
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}

--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -1,0 +1,59 @@
+name: Build SDKs for pull request
+
+env:
+  OAS_PATH: ./openapi.yaml
+  STAINLESS_ORG: formbricks
+  STAINLESS_PROJECT: hub
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Run preview builds
+        uses: stainless-api/upload-openapi-spec-action/preview@v1
+        with:
+          org: ${{ env.STAINLESS_ORG }}
+          project: ${{ env.STAINLESS_PROJECT }}
+          oas_path: ${{ env.OAS_PATH }}
+
+  merge:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Run merge build
+        uses: stainless-api/upload-openapi-spec-action/merge@v1
+        with:
+          org: ${{ env.STAINLESS_ORG }}
+          project: ${{ env.STAINLESS_PROJECT }}
+          oas_path: ${{ env.OAS_PATH }}

--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -27,12 +27,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 2
 
       - name: Run preview builds
-        uses: stainless-api/upload-openapi-spec-action/preview@v1
+        uses: stainless-api/upload-openapi-spec-action/preview@574dfd13ae0a31b75c78570b19811e0f03c66c64
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}
@@ -47,12 +47,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 2
 
       - name: Run merge build
-        uses: stainless-api/upload-openapi-spec-action/merge@v1
+        uses: stainless-api/upload-openapi-spec-action/merge@574dfd13ae0a31b75c78570b19811e0f03c66c64
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}


### PR DESCRIPTION
We are going to use stainless.com for our documentation as well as automated SDK generation. This Github workflows enables auto-updating the openapi.yml at Stainless for automated docs and SDK updates.

## Summary
- add `.github/workflows/stainless-action.yml`
- run Stainless preview builds on PR open/sync/reopen
- run Stainless merge build when a PR is merged
- configure workflow concurrency and OIDC permissions (`id-token: write`)

## GitHub/Stainless setup needed
This workflow uses **OIDC** auth with `stainless-api/upload-openapi-spec-action`.

1. Install the Stainless GitHub App
- In Stainless dashboard: `Project settings -> Integrations -> GitHub`, install the app and connect this repo.

2. Keep workflow permissions as configured
- Job permission must include `id-token: write` (already set), so GitHub can mint OIDC tokens for Stainless.

3. Optional fallback (only if not using OIDC)
- You can create a GitHub secret `STAINLESS_API_KEY` and pass it as `stainless_api_key` input, but this is not required when OIDC is set up.

## About `STAINLESS_ORG`, `STAINLESS_PROJECT`, and `OAS_PATH`
- `STAINLESS_ORG`: your Stainless organization slug.
- `STAINLESS_PROJECT`: your Stainless project slug.
- `OAS_PATH`: path to the OpenAPI file in this repo (currently `./openapi.yaml`).

Right now they are defined in workflow-level `env`, so they are sourced directly from this file.

## Should org/project be GitHub variables?
- Yes, that can make sense if you want centralized config shared across multiple workflows.
- They are **not secrets**, so repository/org variables are appropriate.
- If this is the only workflow using them and values are stable, keeping them in-file is also perfectly fine and simpler.

## Validation
- committed and pushed branch `codex/stainless-openapi-workflow`
- OpenAPI path exists: `openapi.yaml`
