### PR TITLE
feat: Add Power BI documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,7 +16,7 @@
       },
       {
         "group": "Quickstart",
-        "pages": ["quickstart", "hub-superset"]
+        "pages": ["quickstart", "hub-superset", "hub-powerbi"]
       },
       {
         "group": "Core Concepts",

--- a/docs/hub-powerbi.mdx
+++ b/docs/hub-powerbi.mdx
@@ -1,0 +1,134 @@
+---
+title: "Connecting Hub to Power BI"
+description: "Connect Formbricks Hub to Microsoft Power BI and build reports on your feedback data—no ETL, just point Power BI at Hub's database."
+---
+
+Hub stores all data in a single PostgreSQL database. You can report on it with **Microsoft Power BI** by connecting Power BI to Hub’s database and building reports from the `feedback_records` table.
+
+## Summary
+
+| Step | Action |
+|------|--------|
+| 1 | Run Hub + Postgres ([Quick Start](/quickstart)) |
+| 2 | Install [Power BI Desktop](https://powerbi.microsoft.com/desktop/) (free); optionally sign in to Power BI Service for sharing |
+| 3 | In Power BI Desktop: **Get Data → PostgreSQL database** → enter Hub’s server, database, and credentials (see [Step 1](#step-1-get-hub-running) table) |
+| 4 | In the Navigator: select **feedback_records** → **Load** (or **Transform data** to shape in Power Query) |
+| 5 | Build reports using the same dimensions and metrics as in the [Quick reference](#quick-reference-dimensions-and-metrics) below |
+
+## Why Hub + Power BI?
+
+- **Direct access** — Power BI connects to Hub’s Postgres database; no data copying or sync required (or use Import for a local snapshot).
+- **Microsoft ecosystem** — [Power BI](https://powerbi.microsoft.com/) is the de facto standard for many organizations; Desktop is free for authoring.
+- **Same data model** — Hub’s [Data Model](/core-concepts/data-model) uses one row per response in a single table; easy to aggregate and visualize.
+
+### Quick test
+
+1. [Download Power BI Desktop](https://powerbi.microsoft.com/desktop/) (free) and install it.
+2. Run Hub and Postgres locally ([Quick Start](/quickstart)).
+3. In Power BI Desktop: **Get Data → PostgreSQL database** → use the same host, database, and credentials as Hub (e.g. Server `localhost`, Database `hub`, and your Postgres user/password).
+4. Select the **feedback_records** table → **Load**, then build a chart (e.g. bar chart with **Axis** `source_type`, **Values** Count of `id`).
+
+<Info>
+  Power BI Desktop is only available on Windows. For Mac or Linux, we recommend using [Apache Superset](hub-superset.mdx) with Hub — it connects to the same data.
+</Info>
+
+## Step 1: Get Hub running
+
+If Formbricks Hub isn’t running yet, follow the [Quick Start Guide](/quickstart) to start Hub and Postgres (e.g. `docker compose up -d`).
+
+Note the **database connection details** you use for Hub (host, port, database name, user, password). You’ll need them for Power BI. If you use the [compose file](/quickstart#option-1-docker-compose-recommended) from the docs, that’s typically:
+
+| Setting        | Example value        |
+|----------------|----------------------|
+| Host           | `localhost` (if Hub and Postgres run on the same machine as Power BI Desktop) |
+| Port           | `5432`               |
+| Database name  | `hub`                |
+| Username       | `formbricks`         |
+| Password       | Your Postgres password (in the [Quick Start](/quickstart) compose setup this is `POSTGRES_PASSWORD` in `.env`; default is `formbricks_dev`) |
+
+## Step 2: Get Power BI
+
+- **Power BI Desktop** — Free Windows app for authoring reports. [Download Power BI Desktop](https://powerbi.microsoft.com/desktop/).
+- **Power BI Service** (optional) — For sharing reports and dashboards, scheduled refresh, and collaboration. Sign in at [powerbi.microsoft.com](https://powerbi.microsoft.com/). For scheduled refresh when the database is not publicly reachable, you may need an [on-premises data gateway](https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem).
+
+## Step 3: Add Hub’s database in Power BI
+
+1. Open **Power BI Desktop**.
+2. Click **Get data** (or **Home → Get data**) and choose **PostgreSQL database**.
+3. Enter:
+   - **Server** — The host and port of Hub’s Postgres (e.g. `localhost` or `localhost,5432`; if port is 5432 you can often omit it).
+   - **Database** — The database name from the [Step 1](#step-1-get-hub-running) table (e.g. `hub`).
+4. Choose **Data connectivity mode**: **Import** (copy data into the report) or **DirectQuery** (query live). Import is simpler for small to medium datasets.
+5. Under **Authentication**, select **Database** and enter the **Username** and **Password** from the Step 1 table.
+6. Click **OK**. If Power BI prompts to test the connection, confirm it succeeds.
+
+<Info>
+  If Postgres is on another machine or in the cloud, use that host and ensure the firewall or security groups allow Power BI (or the on-premises data gateway) to reach port 5432.
+</Info>
+
+<Info>
+  For scheduled refresh or sharing in Power BI Service when the database is not publicly reachable, configure an [on-premises data gateway](https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem) and use it for the PostgreSQL connection.
+</Info>
+
+## Step 4: Select the `feedback_records` table
+
+1. In the **Navigator** dialog, expand the database and select **feedback_records**.
+2. Optionally click **Transform data** to open Power Query and remove columns or add filters before loading; otherwise click **Load**.
+3. Once loaded, `feedback_records` appears in the **Data** pane on the right. You can now use it to build report visuals.
+
+For the full table schema—column names, types, and field semantics (e.g. `field_type`, `value_number`, `value_text`)—see the [Data Model](/core-concepts/data-model) doc.
+
+## Step 5: Build reports
+
+Use the **Visualizations** pane to add charts and the **Data** pane to drag fields into **Axis**, **Values**, and **Filters**.
+
+### Example: NPS over time (line or area chart)
+
+1. Add a **Line chart** or **Area chart**.
+2. **Axis** — Drag `collected_at`; in the field’s dropdown set the date hierarchy to **Date** and change to **Week** or **Month** if needed.
+3. **Values** — Drag `value_number` and set the aggregation to **Average** (or add a measure).
+4. **Filters** — Add a filter on **field_type** and set it to `nps` so only NPS questions are included.
+5. Optionally add **Count of rows** or a custom NPS measure; the same logic as in the [Data Model](/core-concepts/data-model) can be implemented in Power Query or DAX if needed.
+
+### Example: Count by source (bar or pie chart)
+
+1. Add a **Clustered bar chart** or **Pie chart**.
+2. **Axis** (or **Legend**) — Drag `source_type`.
+3. **Values** — Use **Count of** any column (e.g. Count of `id`) or add a measure that counts rows.
+4. Save the report.
+
+### Example: Score by question (bar chart)
+
+1. Add a **Clustered bar chart**.
+2. **Axis** — Drag `field_id` or `field_label`.
+3. **Values** — Drag `value_number` with **Average**.
+4. **Filters** — Filter **field_type** to `nps`, `csat`, or `rating` as needed.
+5. Save the report.
+
+Once Power BI has access to Hub’s database and the `feedback_records` table, your feedback data is ready for reporting with no extra integration work.
+
+### Quick reference: dimensions and metrics
+
+For the complete list of columns and field types, see the [Data Model](/core-concepts/data-model).
+
+| Use case                | Dimension / filter                    | Metric                    |
+|-------------------------|--------------------------------------|---------------------------|
+| NPS/CSAT over time      | `collected_at`; filter `field_type = nps` | AVG(value_number) or custom NPS |
+| Count by source         | `source_type`                        | COUNT(*)                  |
+| Score by question       | `field_id` or `field_label`          | AVG(value_number)         |
+| Categorical breakdown   | `value_text` (e.g. device, segment)  | COUNT(*)                  |
+| Multi-tenant            | Filter `tenant_id`                   | any                       |
+
+## References
+
+**Hub**
+
+- [Quick Start](/quickstart) — Run Hub and Postgres
+- [Data Model](/core-concepts/data-model) — Table schema, columns, and field types for `feedback_records`
+- [Connecting Hub to Superset](hub-superset.mdx) — Same data, with Apache Superset
+
+**Power BI**
+
+- [Power Query PostgreSQL connector](https://learn.microsoft.com/en-us/power-query/connectors/postgresql) — Official connector docs
+- [Get data in Power BI Desktop](https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-get-data)
+- [Create a report in Power BI Desktop](https://learn.microsoft.com/en-us/power-bi/create-reports/desktop-report-view)

--- a/docs/hub-superset.mdx
+++ b/docs/hub-superset.mdx
@@ -230,6 +230,7 @@ That’s it. Once Superset has access to Hub’s database, your feedback data is
 - [Quick Start](/quickstart) — Run Hub and Postgres
 - [Data Model](/core-concepts/data-model) — Table schema, columns, and field types for `feedback_records`
 - [Superset examples](superset-examples.md) — More SQL and chart ideas
+- [Connecting Hub to Power BI](hub-powerbi.mdx) — Same data, with Microsoft Power BI
 
 **Superset**
 


### PR DESCRIPTION
- Add `docs/hub-powerbi.mdx`: connect Hub’s Postgres to Power BI Desktop (Get Data → PostgreSQL → `feedback_records`), build reports (NPS over time, count by source, score by question), quick reference table, and note that Power BI Desktop is Windows-only with Superset as cross‑platform alternative.
- Add `hub-powerbi` to Quickstart in `docs/docs.json`.
- Cross-link Power BI and Superset docs in their References sections.

Addresses customer need for Hub integration with Microsoft Power BI alongside existing Superset guide.