### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follows these conventions -->
+
+## What does this PR do?
+
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+Fixes #(issue)
+
+<!-- For API behavior changes, include request/response examples or screenshots of Swagger UI to speed up reviews. -->
+
+## How should this be tested?
+
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (e.g. DATABASE_URL, API_KEY). -->
+
+- Test A
+- Test B
+
+## Checklist
+
+<!-- Please go through this checklist and tick off what you did. -->
+
+### Required
+
+- [ ] Filled out the "How to test" section in this PR
+- [ ] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
+- [ ] Self-reviewed my own code
+- [ ] Commented on my code in hard-to-understand bits
+- [ ] Ran `make build`
+- [ ] Ran `make tests` (integration tests in `tests/`)
+- [ ] Ran `make fmt` and `make lint`; no new warnings
+- [ ] Removed debug prints / temporary logging
+- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
+- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`
+
+### Appreciated
+
+- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
+- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
+- [ ] Updated docs in `docs/` if changes were necessary
+- [ ] Ran `make tests-coverage` for meaningful logic changes


### PR DESCRIPTION
## What does this PR do?

Adds a default pull request template (`.github/pull_request_template.md`) so new PRs get a consistent description and checklist. The template is adapted from the formbricks repo and tailored to Hub:

- **Conventional Commits** reminder in the title
- **What does this PR do?** and **How should this be tested?** sections
- **Checklist** aligned with Hub: `make build`, `make tests`, `make fmt`/`make lint`, migrations, link to AGENTS.md
- **Appreciated** items: OpenAPI/contract tests, docs updates, coverage for logic changes

No issue linked (repo setup improvement).

## How should this be tested?

- Open a new PR from any branch and confirm GitHub pre-fills the body with the new template.
- Optionally run `make build`, `make fmt`, `make lint` to confirm the repo is clean (no code changes in this PR).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (N/A — single markdown file)
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging (N/A)
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` (N/A)

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (N/A)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR (N/A)
- [x] Updated docs in `docs/` if changes were necessary (N/A)
- [x] Ran `make tests-coverage` for meaningful logic changes (N/A)
