### PR TITLE
feat: add submission_id for grouped submissions and idempotent ingestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ help:
 	@echo "  make clean            - Clean build artifacts"
 	@echo "  make schemathesis     - Run Schemathesis API tests (requires API server running)"
 
-# Run all tests (integration tests in tests/ directory)
+# Run all tests (integration tests in tests/ directory).
+# Loads .env if present so DATABASE_URL (e.g. port 5433) is used when Postgres runs on a non-default port.
 tests:
 	@echo "Running integration tests..."
-	go test ./tests/... -v
+	@(set -a && [ -f .env ] && . ./.env && set +a; go test ./tests/... -v)
 
 # Run unit tests (fast, no database required)
 test-unit:

--- a/internal/api/handlers/feedback_records_handler.go
+++ b/internal/api/handlers/feedback_records_handler.go
@@ -64,6 +64,12 @@ func (h *FeedbackRecordsHandler) Create(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
+		if errors.Is(err, huberrors.ErrConflict) {
+			response.RespondConflict(w, err.Error())
+
+			return
+		}
+
 		response.RespondInternalServerError(w, "An unexpected error occurred")
 
 		return

--- a/internal/api/response/response.go
+++ b/internal/api/response/response.go
@@ -56,6 +56,11 @@ func RespondNotFound(w http.ResponseWriter, detail string) {
 	RespondError(w, http.StatusNotFound, "Not Found", detail)
 }
 
+// RespondConflict writes a 409 Conflict error response.
+func RespondConflict(w http.ResponseWriter, detail string) {
+	RespondError(w, http.StatusConflict, "Conflict", detail)
+}
+
 // RespondInternalServerError writes a 500 Internal Server Error response.
 func RespondInternalServerError(w http.ResponseWriter, detail string) {
 	RespondError(w, http.StatusInternalServerError, "Internal Server Error", detail)

--- a/internal/huberrors/errors.go
+++ b/internal/huberrors/errors.go
@@ -106,3 +106,32 @@ func (e *LimitExceededError) Is(target error) bool {
 
 	return ok
 }
+
+// ErrConflict is the sentinel for conflict errors (e.g. duplicate tenant_id + submission_id + field_id).
+var ErrConflict = &ConflictError{}
+
+// ConflictError is a sentinel error for resource conflicts.
+type ConflictError struct {
+	Message string
+}
+
+// NewConflictError creates a ConflictError with a custom message.
+func NewConflictError(message string) *ConflictError {
+	return &ConflictError{Message: message}
+}
+
+// Error implements the error interface.
+func (e *ConflictError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	return "conflict"
+}
+
+// Is implements the error interface for error comparison.
+func (e *ConflictError) Is(target error) bool {
+	_, ok := target.(*ConflictError)
+
+	return ok
+}

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -102,6 +102,7 @@ type FeedbackRecord struct {
 	Language        *string         `json:"language,omitempty"`
 	UserIdentifier  *string         `json:"user_identifier,omitempty"`
 	TenantID        *string         `json:"tenant_id,omitempty"`
+	SubmissionID    *string         `json:"submission_id,omitempty"`
 }
 
 // CreateFeedbackRecordRequest represents the request to create a feedback record.
@@ -123,6 +124,7 @@ type CreateFeedbackRecordRequest struct {
 	Language        *string         `json:"language,omitempty"          validate:"omitempty,no_null_bytes,max=10"`
 	UserIdentifier  *string         `json:"user_identifier,omitempty"`
 	TenantID        *string         `json:"tenant_id,omitempty"         validate:"omitempty,no_null_bytes,max=255"`
+	SubmissionID    *string         `json:"submission_id,omitempty"     validate:"omitempty,no_null_bytes,min=1,max=255"`
 }
 
 // UpdateFeedbackRecordRequest represents the request to update a feedback record
@@ -174,6 +176,7 @@ func (r *UpdateFeedbackRecordRequest) ChangedFields() []string {
 // ListFeedbackRecordsFilters represents filters for listing feedback records.
 type ListFeedbackRecordsFilters struct {
 	TenantID       *string    `form:"tenant_id"       validate:"omitempty,no_null_bytes"`
+	SubmissionID   *string    `form:"submission_id"   validate:"omitempty,no_null_bytes"`
 	SourceType     *string    `form:"source_type"     validate:"omitempty,no_null_bytes"`
 	SourceID       *string    `form:"source_id"       validate:"omitempty,no_null_bytes"`
 	FieldID        *string    `form:"field_id"        validate:"omitempty,no_null_bytes"`

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -124,7 +124,7 @@ type CreateFeedbackRecordRequest struct {
 	Language        *string         `json:"language,omitempty"          validate:"omitempty,no_null_bytes,max=10"`
 	UserIdentifier  *string         `json:"user_identifier,omitempty"`
 	TenantID        *string         `json:"tenant_id,omitempty"         validate:"omitempty,no_null_bytes,max=255"`
-	SubmissionID    *string         `json:"submission_id,omitempty"     validate:"omitempty,no_null_bytes,min=1,max=255"`
+	SubmissionID    string          `json:"submission_id"               validate:"required,no_null_bytes,min=1,max=255"`
 }
 
 // UpdateFeedbackRecordRequest represents the request to update a feedback record

--- a/migrations/003_add_feedback_records_submission_id.sql
+++ b/migrations/003_add_feedback_records_submission_id.sql
@@ -1,20 +1,19 @@
 -- +goose up
 -- Add submission_id to feedback_records for grouping records belonging to one logical submission.
 -- Enables idempotent multi-field ingestion and simpler grouped reads (e.g. GET ?submission_id=...).
+-- Mandatory (NOT NULL): every record must belong to a submission; use e.g. field_id if single-field.
 
 ALTER TABLE feedback_records
-  ADD COLUMN submission_id VARCHAR(255);
+  ADD COLUMN submission_id VARCHAR(255) NOT NULL;
 
 -- Index for filtering by submission_id (and tenant-scoped list by submission)
 CREATE INDEX idx_feedback_records_submission_id ON feedback_records(submission_id);
 CREATE INDEX idx_feedback_records_tenant_submission_id ON feedback_records(tenant_id, submission_id);
 
 -- One value per field_id per submission per tenant (supports idempotent webhook retries).
--- Partial index: only enforce uniqueness when submission_id is set (backward compatible for NULL).
 -- NULLS NOT DISTINCT (PG 15+): treat NULL tenant_id as equal so duplicate (NULL, submission_id, field_id) conflicts.
 CREATE UNIQUE INDEX idx_feedback_records_tenant_submission_field
-  ON feedback_records(tenant_id, submission_id, field_id) NULLS NOT DISTINCT
-  WHERE submission_id IS NOT NULL;
+  ON feedback_records(tenant_id, submission_id, field_id) NULLS NOT DISTINCT;
 
 -- +goose down
 DROP INDEX IF EXISTS idx_feedback_records_tenant_submission_field;

--- a/migrations/003_add_feedback_records_submission_id.sql
+++ b/migrations/003_add_feedback_records_submission_id.sql
@@ -11,8 +11,9 @@ CREATE INDEX idx_feedback_records_tenant_submission_id ON feedback_records(tenan
 
 -- One value per field_id per submission per tenant (supports idempotent webhook retries).
 -- Partial index: only enforce uniqueness when submission_id is set (backward compatible for NULL).
+-- NULLS NOT DISTINCT (PG 15+): treat NULL tenant_id as equal so duplicate (NULL, submission_id, field_id) conflicts.
 CREATE UNIQUE INDEX idx_feedback_records_tenant_submission_field
-  ON feedback_records(tenant_id, submission_id, field_id)
+  ON feedback_records(tenant_id, submission_id, field_id) NULLS NOT DISTINCT
   WHERE submission_id IS NOT NULL;
 
 -- +goose down

--- a/migrations/003_add_feedback_records_submission_id.sql
+++ b/migrations/003_add_feedback_records_submission_id.sql
@@ -1,0 +1,22 @@
+-- +goose up
+-- Add submission_id to feedback_records for grouping records belonging to one logical submission.
+-- Enables idempotent multi-field ingestion and simpler grouped reads (e.g. GET ?submission_id=...).
+
+ALTER TABLE feedback_records
+  ADD COLUMN submission_id VARCHAR(255);
+
+-- Index for filtering by submission_id (and tenant-scoped list by submission)
+CREATE INDEX idx_feedback_records_submission_id ON feedback_records(submission_id);
+CREATE INDEX idx_feedback_records_tenant_submission_id ON feedback_records(tenant_id, submission_id);
+
+-- One value per field_id per submission per tenant (supports idempotent webhook retries).
+-- Partial index: only enforce uniqueness when submission_id is set (backward compatible for NULL).
+CREATE UNIQUE INDEX idx_feedback_records_tenant_submission_field
+  ON feedback_records(tenant_id, submission_id, field_id)
+  WHERE submission_id IS NOT NULL;
+
+-- +goose down
+DROP INDEX IF EXISTS idx_feedback_records_tenant_submission_field;
+DROP INDEX IF EXISTS idx_feedback_records_tenant_submission_id;
+DROP INDEX IF EXISTS idx_feedback_records_submission_id;
+ALTER TABLE feedback_records DROP COLUMN IF EXISTS submission_id;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1002,7 +1002,7 @@ components:
                     description: Type of feedback source
                 submission_id:
                     type: string
-                    description: Identifier for the logical submission this record belongs to (optional for legacy records).
+                    description: Identifier for the logical submission this record belongs to (required).
                     pattern: '^[^\x00]*$'
                 tenant_id:
                     type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -844,9 +844,9 @@ components:
                 submission_id:
                     type: string
                     description: |
-                        Identifier for the logical submission this record belongs to (tenant-scoped).
+                        Identifier for the logical submission this record belongs to (tenant-scoped). Required.
                         Enables grouping multi-field submissions and idempotent ingestion.
-                        Unique per (tenant_id, submission_id, field_id).
+                        Unique per (tenant_id, submission_id, field_id). If a record has no logical submission, use e.g. field_id.
                     examples:
                         - "550e8400-e29b-41d4-a716-446655440000"
                     minLength: 1
@@ -891,6 +891,7 @@ components:
                 - source_type
                 - field_id
                 - field_type
+                - submission_id
         ErrorDetail:
             type: object
             additionalProperties: false
@@ -1037,6 +1038,7 @@ components:
                 - source_type
                 - field_id
                 - field_type
+                - submission_id
         ListFeedbackRecordsOutputBody:
             type: object
             additionalProperties: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -52,6 +52,13 @@ paths:
                     type: string
                     description: Filter by tenant ID (for multi-tenant deployments). NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
+                - name: submission_id
+                  in: query
+                  description: Filter by submission ID to group records belonging to one logical submission. NULL bytes not allowed.
+                  schema:
+                    type: string
+                    description: Filter by submission ID (e.g. UUID from webhook idempotency). NULL bytes not allowed.
+                    pattern: '^[^\x00]*$'
                 - name: source_type
                   in: query
                   description: Filter by source type. NULL bytes not allowed.
@@ -323,6 +330,12 @@ paths:
                             parameters:
                                 id: '$response.body#/id'
                             description: Delete the created feedback record by ID
+                "409":
+                    description: Conflict – a feedback record with the same tenant_id, submission_id, and field_id already exists (idempotent create).
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
                 default:
                     description: Error
                     content:
@@ -828,6 +841,17 @@ components:
                     minLength: 1
                     maxLength: 255
                     pattern: '^[^\x00]*$'
+                submission_id:
+                    type: string
+                    description: |
+                        Identifier for the logical submission this record belongs to (tenant-scoped).
+                        Enables grouping multi-field submissions and idempotent ingestion.
+                        Unique per (tenant_id, submission_id, field_id).
+                    examples:
+                        - "550e8400-e29b-41d4-a716-446655440000"
+                    minLength: 1
+                    maxLength: 255
+                    pattern: '^[^\x00]*$'
                 tenant_id:
                     type: string
                     description: Tenant/organization identifier for multi-tenancy. NULL bytes not allowed.
@@ -975,6 +999,10 @@ components:
                 source_type:
                     type: string
                     description: Type of feedback source
+                submission_id:
+                    type: string
+                    description: Identifier for the logical submission this record belongs to (optional for legacy records).
+                    pattern: '^[^\x00]*$'
                 tenant_id:
                     type: string
                     description: Tenant/organization identifier. NULL bytes not allowed.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -134,10 +134,11 @@ func TestCreateFeedbackRecord(t *testing.T) {
 	// Test without authentication
 	t.Run("Unauthorized without API key", func(t *testing.T) {
 		reqBody := map[string]any{
-			"source_type": "formbricks",
-			"field_id":    "feedback",
-			"field_type":  "text",
-			"value_text":  "Great product!",
+			"source_type":   "formbricks",
+			"submission_id": "feedback",
+			"field_id":      "feedback",
+			"field_type":    "text",
+			"value_text":    "Great product!",
 		}
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
@@ -154,10 +155,11 @@ func TestCreateFeedbackRecord(t *testing.T) {
 	// Test with invalid API key
 	t.Run("Unauthorized with invalid API key", func(t *testing.T) {
 		reqBody := map[string]any{
-			"source_type": "formbricks",
-			"field_id":    "feedback",
-			"field_type":  "text",
-			"value_text":  "Great product!",
+			"source_type":   "formbricks",
+			"submission_id": "feedback",
+			"field_id":      "feedback",
+			"field_type":    "text",
+			"value_text":    "Great product!",
 		}
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
@@ -177,10 +179,11 @@ func TestCreateFeedbackRecord(t *testing.T) {
 	// Test with empty API key in header
 	t.Run("Unauthorized with empty API key", func(t *testing.T) {
 		reqBody := map[string]any{
-			"source_type": "formbricks",
-			"field_id":    "feedback",
-			"field_type":  "text",
-			"value_text":  "Great product!",
+			"source_type":   "formbricks",
+			"submission_id": "feedback",
+			"field_id":      "feedback",
+			"field_type":    "text",
+			"value_text":    "Great product!",
 		}
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
@@ -200,10 +203,11 @@ func TestCreateFeedbackRecord(t *testing.T) {
 	// Test with malformed Authorization header
 	t.Run("Unauthorized with malformed Authorization header", func(t *testing.T) {
 		reqBody := map[string]any{
-			"source_type": "formbricks",
-			"field_id":    "feedback",
-			"field_type":  "text",
-			"value_text":  "Great product!",
+			"source_type":   "formbricks",
+			"submission_id": "feedback",
+			"field_id":      "feedback",
+			"field_type":    "text",
+			"value_text":    "Great product!",
 		}
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
@@ -223,10 +227,11 @@ func TestCreateFeedbackRecord(t *testing.T) {
 	// Test with valid authentication
 	t.Run("Success with valid API key", func(t *testing.T) {
 		reqBody := map[string]any{
-			"source_type": "formbricks",
-			"field_id":    "feedback",
-			"field_type":  "text",
-			"value_text":  "Great product!",
+			"source_type":   "formbricks",
+			"submission_id": "feedback",
+			"field_id":      "feedback",
+			"field_type":    "text",
+			"value_text":    "Great product!",
 		}
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
@@ -296,10 +301,11 @@ func TestListFeedbackRecords(t *testing.T) {
 
 	// Create a test feedback record first
 	reqBody := map[string]any{
-		"source_type":  "formbricks",
-		"field_id":     "nps_score",
-		"field_type":   "number",
-		"value_number": 9,
+		"source_type":   "formbricks",
+		"submission_id": "nps_score",
+		"field_id":      "nps_score",
+		"field_type":    "number",
+		"value_number":  9,
 	}
 	body, err := json.Marshal(reqBody)
 	require.NoError(t, err)
@@ -487,10 +493,11 @@ func TestGetFeedbackRecord(t *testing.T) {
 
 	// Create a test feedback record
 	reqBody := map[string]any{
-		"source_type":  "formbricks",
-		"field_id":     "rating",
-		"field_type":   "number",
-		"value_number": 5,
+		"source_type":   "formbricks",
+		"submission_id": "rating",
+		"field_id":      "rating",
+		"field_type":    "number",
+		"value_number":  5,
 	}
 	body, err := json.Marshal(reqBody)
 	require.NoError(t, err)
@@ -570,10 +577,11 @@ func TestUpdateFeedbackRecord(t *testing.T) {
 
 	// Create a test feedback record
 	reqBody := map[string]any{
-		"source_type": "formbricks",
-		"field_id":    "comment",
-		"field_type":  "text",
-		"value_text":  "Initial comment",
+		"source_type":   "formbricks",
+		"submission_id": "comment",
+		"field_id":      "comment",
+		"field_type":    "text",
+		"value_text":    "Initial comment",
 	}
 	body, err := json.Marshal(reqBody)
 	require.NoError(t, err)
@@ -642,10 +650,11 @@ func TestDeleteFeedbackRecord(t *testing.T) {
 
 	// Create a test feedback record
 	reqBody := map[string]any{
-		"source_type": "formbricks",
-		"field_id":    "temp",
-		"field_type":  "text",
-		"value_text":  "To be deleted",
+		"source_type":   "formbricks",
+		"submission_id": "temp",
+		"field_id":      "temp",
+		"field_type":    "text",
+		"value_text":    "To be deleted",
 	}
 	body, err := json.Marshal(reqBody)
 	require.NoError(t, err)
@@ -701,6 +710,7 @@ func TestBulkDeleteFeedbackRecords(t *testing.T) {
 	createPayload := func(fieldID string, valueNum float64) map[string]any {
 		return map[string]any{
 			"source_type":     "formbricks",
+			"submission_id":   userID,
 			"user_identifier": userID,
 			"field_id":        fieldID,
 			"field_type":      "number",
@@ -864,6 +874,7 @@ func TestFeedbackRecordsRepository_BulkDelete(t *testing.T) {
 	// Create two records with same user_identifier
 	req1 := &models.CreateFeedbackRecordRequest{
 		SourceType:     sourceType,
+		SubmissionID:   userID,
 		FieldID:        "f1",
 		FieldType:      models.FieldTypeNumber,
 		ValueNumber:    ptrFloat64(1),
@@ -875,6 +886,7 @@ func TestFeedbackRecordsRepository_BulkDelete(t *testing.T) {
 
 	req2 := &models.CreateFeedbackRecordRequest{
 		SourceType:     sourceType,
+		SubmissionID:   userID,
 		FieldID:        "f2",
 		FieldType:      models.FieldTypeNumber,
 		ValueNumber:    ptrFloat64(2),


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follows these conventions -->

## What does this PR do?

Adds a `submission_id` field to `feedback_records` so that records belonging to one logical feedback submission can be grouped. This supports use cases like multi-field ingestion from a single event (e.g. Stripe cancellation: reason, comment, date) and simplifies:

- **Grouped reads**: `GET /v1/feedback-records?submission_id=...`
- **Idempotent webhook retries**: duplicate (tenant_id, submission_id, field_id) returns 409 Conflict
- **Partial-write reconciliation** and correlation across ingestion pipelines

**Changes:**
- **Migration** `003_add_feedback_records_submission_id.sql`: adds nullable `submission_id` (VARCHAR 255), indexes for filtering, and partial unique index on `(tenant_id, submission_id, field_id)` where `submission_id IS NOT NULL` (one value per field per submission; backward compatible for rows without submission_id).
- **Models**: `FeedbackRecord` and create/list request types include `submission_id`; list filters support `submission_id`.
- **Repository**: Create/Get/List/Update read/write `submission_id`; Create maps PostgreSQL unique violation (23505) to `huberrors.ConflictError`.
- **Handler**: Create responds with 409 Conflict and message when duplicate (tenant_id, submission_id, field_id).
- **OpenAPI**: Create body and list params document `submission_id`; FeedbackRecordData includes `submission_id`; 409 response documented for create.
- **Tests**: `TestFeedbackRecordsSubmissionID` (create with submission_id, list by submission_id), `TestFeedbackRecordsSubmissionIDUniqueConstraint` (duplicate create returns 409).

Existing integrations remain compatible: `submission_id` is optional on create; records without it are valid and the unique constraint does not apply to NULL.

<!-- For API behavior changes, include request/response examples or screenshots of Swagger UI to speed up reviews. -->

**Example – create with submission_id:**
```json
POST /v1/feedback-records
{
  "source_type": "formbricks",
  "submission_id": "550e8400-e29b-41d4-a716-446655440000",
  "tenant_id": "org-123",
  "field_id": "reason",
  "field_type": "text",
  "value_text": "cancelled"
}
```

**Example – list by submission_id:**
```
GET /v1/feedback-records?submission_id=550e8400-e29b-41d4-a716-446655440000&tenant_id=org-123
```

**Example – duplicate create (same tenant_id, submission_id, field_id):** returns `409 Conflict` with body describing the conflict.

## How should this be tested?

- **Unit tests**: `make test-unit` (passes).
- **Integration tests**: Start Postgres (`make docker-up`), then `make tests`. Covers create without/with submission_id, list by submission_id, and duplicate create → 409.
- **Build/lint**: `make build`, `make fmt`, `make lint` (all pass).
- **Migrations**: `make init-db` to apply migration; `make migrate-validate` to validate migration files.
- **Manual**: Create two records with same `tenant_id`, `submission_id`, and `field_id`; second request should return 409. List with `?submission_id=...` returns only records with that submission_id.

## Checklist

<!-- Please go through this checklist and tick off what you did. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests require Postgres; unit tests and build pass)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes

Solves https://github.com/formbricks/internal/issues/1424
