### PR TITLE
ci: coverage tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -64,5 +64,13 @@ if ! make lint; then
     exit 1
 fi
 
+# Fast unit tests (no DB); coverage is enforced in CI only
+echo "Running unit tests..."
+if ! make test-unit; then
+    echo ""
+    echo "❌ Unit tests failed. Fix the errors above before committing."
+    exit 1
+fi
+
 echo "✅ Pre-commit checks passed!"
 exit 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,14 +106,14 @@ jobs:
 
       - name: Run River migrations
         run: |
-          go install github.com/riverqueue/river/cmd/river@latest
+          go install github.com/riverqueue/river/cmd/river@v0.30.2
           make river-migrate
 
       - name: Run integration tests
         run: make tests
 
   coverage:
-    name: Coverage (≥16%)
+    name: Coverage
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -166,10 +166,10 @@ jobs:
 
       - name: Run River migrations
         run: |
-          go install github.com/riverqueue/river/cmd/river@latest
+          go install github.com/riverqueue/river/cmd/river@v0.30.2
           make river-migrate
 
-      - name: Check coverage (≥16%, excludes cmd/api)
+      - name: Check coverage (excludes cmd/api)
         run: make check-coverage
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
         run: make tests
 
   coverage:
-    name: Coverage (≥50%)
+    name: Coverage (≥16%)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -169,7 +169,7 @@ jobs:
           go install github.com/riverqueue/river/cmd/river@latest
           make river-migrate
 
-      - name: Check coverage (≥50%, excludes cmd/api)
+      - name: Check coverage (≥16%, excludes cmd/api)
         run: make check-coverage
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,10 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'Makefile'
       - 'migrations/**'
       - 'tests/**'
+      - '.githooks/**'
       - '.github/workflows/tests.yml'
 
 concurrency:
@@ -110,9 +112,69 @@ jobs:
       - name: Run integration tests
         run: make tests
 
+  coverage:
+    name: Coverage (≥50%)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
+      API_KEY: test-api-key-for-ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: '1.25.7'
+
+      - name: Cache Go modules
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.26.0
+
+      - name: Initialize database schema
+        run: make init-db
+
+      - name: Run River migrations
+        run: |
+          go install github.com/riverqueue/river/cmd/river@latest
+          make river-migrate
+
+      - name: Check coverage (≥50%, excludes cmd/api)
+        run: make check-coverage
+
   tests:
     name: All Tests
-    needs: [unit-tests, integration-tests]
+    needs: [unit-tests, integration-tests, coverage]
     runs-on: ubuntu-24.04
     if: always()
     steps:
@@ -124,6 +186,10 @@ jobs:
           fi
           if [ "${{ needs.integration-tests.result }}" != "success" ]; then
             echo "Integration tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.coverage.result }}" != "success" ]; then
+            echo "Coverage check failed"
             exit 1
           fi
           echo "✅ All tests passed!"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `make build`: build the API binary to `bin/api`.
 - `make tests`: run integration tests in `tests/`.
 - `make tests-coverage`: generate `coverage.html`.
-- `make check-coverage`: run all tests with coverage and fail if below 50% (excludes cmd/api: app.go, main.go).
+- `make check-coverage`: run all tests with coverage and fail if below 16% (excludes cmd/api: app.go, main.go).
 - `make init-db`: run goose migrations up using `DATABASE_URL`. `make migrate-status` and `make migrate-validate` for status and validation. New migrations go in `migrations/` with goose annotations (`-- +goose up` / `-- +goose down`). Name files with a sequential number and short description (e.g. `002_add_webhooks_table.sql`); goose orders by the numeric prefix. For webhook delivery, run `make river-migrate` after `init-db` to apply River job queue migrations.
 - `make fmt`: format code (runs `golangci-lint run --fix`; uses gofumpt/gci from config).
 - `make lint`: run `golangci-lint` (includes format checks; requires `make install-tools`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - `make build`: build the API binary to `bin/api`.
 - `make tests`: run integration tests in `tests/`.
 - `make tests-coverage`: generate `coverage.html`.
+- `make check-coverage`: run all tests with coverage and fail if below 50% (excludes cmd/api: app.go, main.go).
 - `make init-db`: run goose migrations up using `DATABASE_URL`. `make migrate-status` and `make migrate-validate` for status and validation. New migrations go in `migrations/` with goose annotations (`-- +goose up` / `-- +goose down`). Name files with a sequential number and short description (e.g. `002_add_webhooks_table.sql`); goose orders by the numeric prefix. For webhook delivery, run `make river-migrate` after `init-db` to apply River job queue migrations.
 - `make fmt`: format code (runs `golangci-lint run --fix`; uses gofumpt/gci from config).
 - `make lint`: run `golangci-lint` (includes format checks; requires `make install-tools`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `make build`: build the API binary to `bin/api`.
 - `make tests`: run integration tests in `tests/`.
 - `make tests-coverage`: generate `coverage.html`.
-- `make check-coverage`: run all tests with coverage and fail if below 16% (excludes cmd/api: app.go, main.go).
+- `make check-coverage`: run all tests with coverage and fail if below COVERAGE_THRESHOLD (excludes cmd/api: app.go, main.go).
 - `make init-db`: run goose migrations up using `DATABASE_URL`. `make migrate-status` and `make migrate-validate` for status and validation. New migrations go in `migrations/` with goose annotations (`-- +goose up` / `-- +goose down`). Name files with a sequential number and short description (e.g. `002_add_webhooks_table.sql`); goose orders by the numeric prefix. For webhook delivery, run `make river-migrate` after `init-db` to apply River job queue migrations.
 - `make fmt`: format code (runs `golangci-lint run --fix`; uses gofumpt/gci from config).
 - `make lint`: run `golangci-lint` (includes format checks; requires `make install-tools`).

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 	@echo "  make tests            - Run integration tests"
 	@echo "  make test-all         - Run all tests (unit + integration)"
 	@echo "  make tests-coverage   - Run tests with coverage report"
-	@echo "  make check-coverage   - Run tests and fail if coverage < 50% (excludes cmd/api)"
+	@echo "  make check-coverage   - Run tests and fail if coverage < 16% (excludes cmd/api)"
 	@echo "  make init-db          - Initialize database schema (run migrations with goose)"
 	@echo "  make migrate-status   - Show migration status"
 	@echo "  make migrate-validate - Validate migration files (no DB)"
@@ -58,7 +58,7 @@ tests-coverage:
 	@echo "Coverage report generated: coverage.html"
 
 # Minimum coverage threshold (percent). Fails if coverage falls below this.
-COVERAGE_THRESHOLD ?= 50
+COVERAGE_THRESHOLD ?= 16
 
 # Check coverage threshold (fail if below COVERAGE_THRESHOLD).
 # Excludes cmd/api (app.go, main.go) from coverage.

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 	@echo "  make tests            - Run integration tests"
 	@echo "  make test-all         - Run all tests (unit + integration)"
 	@echo "  make tests-coverage   - Run tests with coverage report"
-	@echo "  make check-coverage   - Run tests and fail if coverage < 16% (excludes cmd/api)"
+	@echo "  make check-coverage   - Run tests and fail if coverage below COVERAGE_THRESHOLD (excludes cmd/api)"
 	@echo "  make init-db          - Initialize database schema (run migrations with goose)"
 	@echo "  make migrate-status   - Show migration status"
 	@echo "  make migrate-validate - Validate migration files (no DB)"
@@ -50,10 +50,10 @@ test-all: test-unit tests
 	@echo "All tests passed!"
 
 # Run tests with coverage (unit + integration).
-# cmd/api (app.go, main.go) is excluded—coverage is for internal/ and tests/ only.
+# cmd/api (app.go, main.go) is excluded—coverage is for internal/, pkg/, and tests/.
 tests-coverage:
 	@echo "Running tests with coverage..."
-	go test ./internal/... ./tests/... -v -cover -coverprofile=coverage.out
+	go test ./internal/... ./pkg/... ./tests/... -v -cover -coverprofile=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
 
@@ -61,10 +61,10 @@ tests-coverage:
 COVERAGE_THRESHOLD ?= 16
 
 # Check coverage threshold (fail if below COVERAGE_THRESHOLD).
-# Excludes cmd/api (app.go, main.go) from coverage.
+# Excludes cmd/api (app.go, main.go) from coverage. Includes internal/, tests/, and pkg/.
 check-coverage:
 	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
-	@(set -a && [ -f .env ] && . ./.env && set +a; go test ./internal/... ./tests/... -coverprofile=coverage.out)
+	@(set -a && [ -f .env ] && . ./.env && set +a; go test ./internal/... ./pkg/... ./tests/... -coverprofile=coverage.out)
 	@COV=$$(go tool cover -func=coverage.out | tail -1 | awk '{gsub(/%/, ""); print $$3}') && \
 	if [ -z "$$COV" ] || ! awk -v c="$$COV" -v t="$(COVERAGE_THRESHOLD)" 'BEGIN { exit (c+0 >= t) ? 0 : 1 }'; then \
 		echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test help tests tests-coverage build build-backfill-embeddings run run-backfill-embeddings init-db clean docker-up docker-down docker-clean deps install-tools fmt lint lint-new dev-setup test-all test-unit schemathesis install-hooks migrate-status migrate-validate river-migrate
+.PHONY: all test help tests tests-coverage check-coverage build build-backfill-embeddings run run-backfill-embeddings init-db clean docker-up docker-down docker-clean deps install-tools fmt lint lint-new dev-setup test-all test-unit schemathesis install-hooks migrate-status migrate-validate river-migrate
 
 # Aliases for checkmake/lint expectations
 all: build
@@ -17,6 +17,7 @@ help:
 	@echo "  make tests            - Run integration tests"
 	@echo "  make test-all         - Run all tests (unit + integration)"
 	@echo "  make tests-coverage   - Run tests with coverage report"
+	@echo "  make check-coverage   - Run tests and fail if coverage < 50% (excludes cmd/api)"
 	@echo "  make init-db          - Initialize database schema (run migrations with goose)"
 	@echo "  make migrate-status   - Show migration status"
 	@echo "  make migrate-validate - Validate migration files (no DB)"
@@ -48,12 +49,30 @@ test-unit:
 test-all: test-unit tests
 	@echo "All tests passed!"
 
-# Run tests with coverage (unit + integration)
+# Run tests with coverage (unit + integration).
+# cmd/api (app.go, main.go) is excluded—coverage is for internal/ and tests/ only.
 tests-coverage:
 	@echo "Running tests with coverage..."
 	go test ./internal/... ./tests/... -v -cover -coverprofile=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
+
+# Minimum coverage threshold (percent). Fails if coverage falls below this.
+COVERAGE_THRESHOLD ?= 50
+
+# Check coverage threshold (fail if below COVERAGE_THRESHOLD).
+# Excludes cmd/api (app.go, main.go) from coverage.
+check-coverage:
+	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
+	@(set -a && [ -f .env ] && . ./.env && set +a; go test ./internal/... ./tests/... -coverprofile=coverage.out)
+	@COV=$$(go tool cover -func=coverage.out | tail -1 | awk '{gsub(/%/, ""); print $$3}') && \
+	if [ -z "$$COV" ] || ! awk -v c="$$COV" -v t="$(COVERAGE_THRESHOLD)" 'BEGIN { exit (c+0 >= t) ? 0 : 1 }'; then \
+		echo ""; \
+		echo "❌ Coverage $$COV% is below threshold $(COVERAGE_THRESHOLD)%"; \
+		go tool cover -func=coverage.out | tail -5; \
+		exit 1; \
+	fi && \
+	echo "✅ Coverage $$COV% meets threshold $(COVERAGE_THRESHOLD)%"
 
 # Build the API server
 build:


### PR DESCRIPTION
## What does this PR do?

Adds coverage enforcement in CI and adjusts pre-commit hooks to follow common production practices:

- **`make check-coverage`**: New target that runs all tests with coverage and fails if total coverage is below 16% (current value). Excludes `cmd/api` (app.go, main.go) from coverage. Threshold configurable via `COVERAGE_THRESHOLD`.
- **CI**: New `coverage` job in the Tests workflow that runs `make check-coverage` with Postgres. PRs must pass coverage to merge.
- **Pre-commit**: Runs unit tests (fast, no DB) instead of full coverage. Coverage is enforced in CI only so pre-commit stays fast and does not require Postgres.

## How should this be tested?

- `make build`
- `make test-unit` (pre-commit runs this; no DB needed)
- `make tests` (integration tests; requires Postgres and `DATABASE_URL`)
- `make check-coverage` (full coverage check; requires Postgres and `DATABASE_URL`)
- `make install-hooks` then commit to verify pre-commit (fmt, lint, unit tests)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [ ] Ran `make fmt` and `make lint`; no new warnings
- [ ] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes
