### PR TITLE
chore: upgrade Helm chart to Hub 0.2.0

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hub
 description: Formbricks Hub - Experience Management API
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - formbricks
   - hub
@@ -14,5 +14,5 @@ maintainers:
   - name: Formbricks
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial chart for Hub API service
+    - kind: changed
+      description: Upgrade to Hub 0.2.0

--- a/charts/hub/templates/deployment.yaml
+++ b/charts/hub/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "hub.fullname" . }}
   labels:
     {{- include "hub.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 10

--- a/charts/hub/templates/secret.yaml
+++ b/charts/hub/templates/secret.yaml
@@ -15,4 +15,7 @@ type: Opaque
 stringData:
   DATABASE_URL: {{ $dbUrl | quote }}
   API_KEY: {{ $apiKey | quote }}
+  {{- with .Values.secrets.stringData.EMBEDDING_PROVIDER_API_KEY }}
+  EMBEDDING_PROVIDER_API_KEY: {{ . | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -112,6 +112,17 @@ config:
     WEBHOOK_DELIVERY_MAX_ATTEMPTS: "3"
     WEBHOOK_MAX_FAN_OUT_PER_EVENT: "500"
     WEBHOOK_MAX_COUNT: "500"
+    WEBHOOK_HTTP_TIMEOUT_SECONDS: "15"
+    WEBHOOK_BLACKLIST: "localhost,127.0.0.1,::1,169.254.169.254"
+    WEBHOOK_ENQUEUE_MAX_RETRIES: "3"
+    WEBHOOK_ENQUEUE_INITIAL_BACKOFF_MS: "100"
+    WEBHOOK_ENQUEUE_MAX_BACKOFF_MS: "2000"
+    DATABASE_MAX_CONNS: "25"
+    DATABASE_MIN_CONNS: "0"
+    DATABASE_MAX_CONN_LIFETIME_SECONDS: "3600"
+    DATABASE_MAX_CONN_IDLE_TIME_SECONDS: "1800"
+    DATABASE_HEALTH_CHECK_PERIOD_SECONDS: "60"
+    DATABASE_CONNECT_TIMEOUT_SECONDS: "10"
 
 secrets:
   create: true
@@ -122,6 +133,8 @@ secrets:
     DATABASE_URL: ""
     # REQUIRED
     API_KEY: ""
+    # Optional: required only when EMBEDDING_PROVIDER is openai or google
+    EMBEDDING_PROVIDER_API_KEY: ""
   externalSecrets:
     enabled: false
     # Name of existing SecretStore resource for AWS Secrets Manager
@@ -134,6 +147,7 @@ secrets:
     keys:
       - DATABASE_URL
       - API_KEY
+      - EMBEDDING_PROVIDER_API_KEY
 
 extraEnv: []
 extraEnvFrom: []


### PR DESCRIPTION
## Summary
- Bump chart `appVersion` and `version` to `0.2.0` so the deployment pulls the `formbricks/hub:0.2.0` image
- Add all new 0.2.0 config keys to `values.yaml` with their defaults: webhook tuning (`WEBHOOK_HTTP_TIMEOUT_SECONDS`, `WEBHOOK_BLACKLIST`, `WEBHOOK_ENQUEUE_*`), DB connection pool (`DATABASE_MAX_CONNS`, etc.), and SSRF mitigation
- Support optional `EMBEDDING_PROVIDER_API_KEY` secret (conditionally included only when non-empty)
- Add ArgoCD `sync-wave: "2"` annotation on the Deployment so migrations (wave 1) complete before pod rollout

## Breaking change — staging database reset required

Hub 0.2.0 includes migration 003 which adds `submission_id VARCHAR(255) NOT NULL` without a default. This will fail on tables with existing rows. **Before deploying, drop and recreate the staging database:**

```sql
DROP SCHEMA public CASCADE;
CREATE SCHEMA public;
CREATE EXTENSION IF NOT EXISTS vector;
```

## Verification

```
helm lint charts/hub --set secrets.stringData.DATABASE_URL=... --set secrets.stringData.API_KEY=...
helm template test charts/hub --set secrets.stringData.DATABASE_URL=... --set secrets.stringData.API_KEY=...
```

Both pass cleanly. Tested with and without `EMBEDDING_PROVIDER_API_KEY`.
