### PR TITLE
fix: add uuidv7() function definition to migration 001

### DIFF
--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -5,6 +5,21 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
+-- UUIDv7: time-ordered UUIDs (PG 16 and below; native in PG 17+).
+-- Requires pgcrypto for gen_random_bytes().
+CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $fn$
+DECLARE
+  unix_ts_ms bytea;
+  uuid_bytes bytea;
+BEGIN
+  unix_ts_ms = substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3);
+  uuid_bytes = unix_ts_ms || gen_random_bytes(10);
+  uuid_bytes = set_byte(uuid_bytes, 6, (b'0111' || get_byte(uuid_bytes, 6)::bit(4))::bit(8)::int);
+  uuid_bytes = set_byte(uuid_bytes, 8, (b'10' || get_byte(uuid_bytes, 8)::bit(6))::bit(8)::int);
+  RETURN encode(uuid_bytes, 'hex')::uuid;
+END
+$fn$ LANGUAGE plpgsql VOLATILE;
+
 -- Create ENUM types
 CREATE TYPE field_type_enum AS ENUM (
     'text', 'categorical', 'nps', 'csat', 'ces', 'rating', 'number', 'boolean', 'date'
@@ -72,3 +87,4 @@ CREATE INDEX idx_feedback_records_tenant_field_type ON feedback_records(tenant_i
 -- explicitly drop extensions elsewhere.
 DROP TABLE IF EXISTS feedback_records;
 DROP TYPE IF EXISTS field_type_enum;
+DROP FUNCTION IF EXISTS uuidv7();

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -5,9 +5,10 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
--- UUIDv7: time-ordered UUIDs (PG 16 and below; native in PG 17+).
+-- UUIDv7: time-ordered UUIDs (PG 16 and below; native in PG 18+).
 -- Requires pgcrypto for gen_random_bytes().
-CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $fn$
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $$
 DECLARE
   unix_ts_ms bytea;
   uuid_bytes bytea;
@@ -18,7 +19,8 @@ BEGIN
   uuid_bytes = set_byte(uuid_bytes, 8, (b'10' || get_byte(uuid_bytes, 8)::bit(6))::bit(8)::int);
   RETURN encode(uuid_bytes, 'hex')::uuid;
 END
-$fn$ LANGUAGE plpgsql VOLATILE;
+$$ LANGUAGE plpgsql VOLATILE;
+-- +goose StatementEnd
 
 -- Create ENUM types
 CREATE TYPE field_type_enum AS ENUM (


### PR DESCRIPTION
## Summary
- The `uuidv7()` function is used as a column default in migrations 001 (`feedback_records.id`) and 002 (`webhooks.id`) but was never defined in any migration — it was manually created on each database
- This breaks fresh deployments and schema resets (e.g. the 0.2.0 staging upgrade) because goose cannot create the tables
- Adds the standard PL/pgSQL UUIDv7 implementation right after the `pgcrypto` extension it depends on, and drops it in the down migration

## Test plan
- [ ] CI migration validation passes
- [ ] Fresh `goose up` against an empty database succeeds (all 6 migrations)

Made with [Cursor](https://cursor.com)