### PR TITLE
refactor: rename google vertex provider to gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,18 +73,18 @@ WEBHOOK_MAX_COUNT=500
 # WEBHOOK_ENQUEUE_MAX_BACKOFF_MS=2000
 
 # Embeddings are optional. To enable, set both EMBEDDING_PROVIDER and EMBEDDING_MODEL; if either is unset, embeddings are disabled and no embedding jobs run.
-# Providers: openai, google (AI Studio), google-vertex.
-# EMBEDDING_PROVIDER_API_KEY is required for openai and google. For google-vertex, use Application Default Credentials (no API key); set EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION.
-# Vertex AI auth (google-vertex): Application Default Credentials (ADC) are used. When running outside GCP (e.g. EKS on AWS, Railway):
-#   Set GOOGLE_APPLICATION_CREDENTIALS to the path of a GCP service account key JSON file (e.g. mount the key in your pod and set the path). The same approach as your Slack chatbot on Railway.
-#   Create a service account in GCP with "Vertex AI User" (or required roles), download the key, and point GOOGLE_APPLICATION_CREDENTIALS at it.
+# Providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
+# EMBEDDING_PROVIDER_API_KEY is required for openai and google. For google-gemini, use Application Default Credentials (no API key); set EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION.
+# Google Gemini auth (google-gemini): Application Default Credentials (ADC) are used. When running outside Google Cloud (e.g. EKS on AWS, Railway):
+#   Set GOOGLE_APPLICATION_CREDENTIALS to the path of a Google Cloud service account key JSON file (e.g. mount the key in your pod and set the path).
+#   Create a service account in Google Cloud with the required model access permissions, download the key, and point GOOGLE_APPLICATION_CREDENTIALS at it.
 # Vector size is fixed (768) in code.
 # EMBEDDING_PROVIDER=openai
-# EMBEDDING_PROVIDER=google-vertex
-# EMBEDDING_PROVIDER_API_KEY=sk-...   (required for openai and google; not used for google-vertex)
-# EMBEDDING_GOOGLE_CLOUD_PROJECT=    (required for google-vertex; or use GOOGLE_CLOUD_PROJECT)
-# EMBEDDING_GOOGLE_CLOUD_LOCATION=   (required for google-vertex, e.g. europe-west3; or use GOOGLE_CLOUD_LOCATION)
-# GOOGLE_APPLICATION_CREDENTIALS=    (optional; for google-vertex when outside GCP: path to service account key JSON)
+# EMBEDDING_PROVIDER=google-gemini
+# EMBEDDING_PROVIDER_API_KEY=sk-...   (required for openai and google; not used for google-gemini)
+# EMBEDDING_GOOGLE_CLOUD_PROJECT=    (required for google-gemini; or use GOOGLE_CLOUD_PROJECT)
+# EMBEDDING_GOOGLE_CLOUD_LOCATION=   (required for google-gemini, e.g. europe-west3; or use GOOGLE_CLOUD_LOCATION)
+# GOOGLE_APPLICATION_CREDENTIALS=    (optional; for google-gemini when outside Google Cloud: path to service account key JSON)
 # EMBEDDING_MODEL=<model name>        (required to enable embeddings; no default)
 
 # River UI basic auth (optional, used when running River UI via docker compose)

--- a/.env.example
+++ b/.env.example
@@ -73,9 +73,9 @@ WEBHOOK_MAX_COUNT=500
 # WEBHOOK_ENQUEUE_MAX_BACKOFF_MS=2000
 
 # Embeddings are optional. To enable, set both EMBEDDING_PROVIDER and EMBEDDING_MODEL; if either is unset, embeddings are disabled and no embedding jobs run.
-# Providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
-# EMBEDDING_PROVIDER_API_KEY is required for openai and google. For google-gemini, use Application Default Credentials (no API key); set EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION.
-# Google Gemini auth (google-gemini): Application Default Credentials (ADC) are used. When running outside Google Cloud (e.g. EKS on AWS, Railway):
+# Providers: openai, google (Gemini Developer API / Google AI Studio), google-gemini (Gemini Enterprise Agent Platform API).
+# EMBEDDING_PROVIDER_API_KEY is required for openai and google. For google-gemini, use Google Cloud Application Default Credentials (no API key); set EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION.
+# Gemini Enterprise Agent Platform API auth (google-gemini): Google Cloud Application Default Credentials (ADC) are used. When running outside Google Cloud (e.g. EKS on AWS, Railway):
 #   Set GOOGLE_APPLICATION_CREDENTIALS to the path of a Google Cloud service account key JSON file (e.g. mount the key in your pod and set the path).
 #   Create a service account in Google Cloud with the required model access permissions, download the key, and point GOOGLE_APPLICATION_CREDENTIALS at it.
 # Vector size is fixed (768) in code.

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -133,7 +133,7 @@ secrets:
     DATABASE_URL: ""
     # REQUIRED
     API_KEY: ""
-    # Optional: required only when EMBEDDING_PROVIDER is openai or google
+    # Optional: required only when EMBEDDING_PROVIDER is openai or google (AI Studio)
     EMBEDDING_PROVIDER_API_KEY: ""
   externalSecrets:
     enabled: false

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -41,9 +41,9 @@ type App struct {
 }
 
 var (
-	errEmbeddingProviderAPIKeyRequired = errors.New("EMBEDDING_PROVIDER_API_KEY is required for this provider")
-	errEmbeddingVertexConfigRequired   = errors.New(
-		"google-vertex requires EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION")
+	errEmbeddingProviderAPIKeyRequired     = errors.New("EMBEDDING_PROVIDER_API_KEY is required for this provider")
+	errEmbeddingGoogleGeminiConfigRequired = errors.New(
+		"google-gemini requires EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION")
 )
 
 const riverQueueDepthInterval = 15 * time.Second
@@ -72,7 +72,7 @@ const searchQueryCacheSize = 1000
 
 // setupEmbeddingSearchHandler creates embedding client, worker, and search handler when embeddings are enabled.
 // Returns (handler, nil) or (nil, err). Caller should use errors.Is for service.ErrEmbeddingProviderAPIKey and
-// service.ErrEmbeddingVertexConfig to return app-level sentinel errors.
+// service.ErrEmbeddingGoogleGeminiConfig to return app-level sentinel errors.
 func setupEmbeddingSearchHandler(
 	ctx context.Context,
 	cfg *config.Config,
@@ -258,8 +258,8 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 				return nil, fmt.Errorf("%w: %s", errEmbeddingProviderAPIKeyRequired, embeddingProviderName)
 			}
 
-			if errors.Is(err, service.ErrEmbeddingVertexConfig) {
-				return nil, errEmbeddingVertexConfigRequired
+			if errors.Is(err, service.ErrEmbeddingGoogleGeminiConfig) {
+				return nil, errEmbeddingGoogleGeminiConfigRequired
 			}
 
 			return nil, fmt.Errorf("embedding config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,7 +248,7 @@ func applyDefaults(cfg *Config) {
 		cfg.Webhook.EnqueueMaxBackoffMs = 2000
 	}
 
-	// Google Vertex AI fallbacks: EMBEDDING_* can fall back to GOOGLE_CLOUD_*
+	// Google Cloud fallbacks: EMBEDDING_* can fall back to GOOGLE_CLOUD_*
 	if cfg.Embedding.GoogleCloudProject == "" {
 		cfg.Embedding.GoogleCloudProject = os.Getenv("GOOGLE_CLOUD_PROJECT")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,15 +138,15 @@ func TestLoad_WebhookDeliveryMaxAttempts(t *testing.T) {
 
 func TestLoad_EmbeddingGoogleCloudProject(t *testing.T) {
 	t.Setenv("API_KEY", "test-api-key")
-	t.Setenv("EMBEDDING_GOOGLE_CLOUD_PROJECT", "my-vertex-project")
+	t.Setenv("EMBEDDING_GOOGLE_CLOUD_PROJECT", "my-google-cloud-project")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if cfg.Embedding.GoogleCloudProject != "my-vertex-project" {
-		t.Errorf("Embedding.GoogleCloudProject = %q, want my-vertex-project", cfg.Embedding.GoogleCloudProject)
+	if cfg.Embedding.GoogleCloudProject != "my-google-cloud-project" {
+		t.Errorf("Embedding.GoogleCloudProject = %q, want my-google-cloud-project", cfg.Embedding.GoogleCloudProject)
 	}
 }
 

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -1,4 +1,4 @@
-// Package googleai provides a thin wrapper around the Google Gen AI SDK for embeddings (Gemini API).
+// Package googleai provides a thin wrapper around the Google Gen AI SDK for embeddings.
 package googleai
 
 import (

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -23,10 +23,10 @@ var (
 	ErrNoEmbeddingInResponse = errors.New("googleai: no embedding in response")
 	// ErrDimensionMismatch is returned when the response embedding length does not match configured dimensions.
 	ErrDimensionMismatch = errors.New("googleai: embedding dimension mismatch")
-	// ErrVertexProjectRequired is returned when NewVertexClient is called with empty project.
-	ErrVertexProjectRequired = errors.New("googleai vertex client: project is required")
-	// ErrVertexLocationRequired is returned when NewVertexClient is called with empty location.
-	ErrVertexLocationRequired = errors.New("googleai vertex client: location is required")
+	// ErrGoogleGeminiProjectRequired is returned when NewGoogleGeminiClient is called with empty project.
+	ErrGoogleGeminiProjectRequired = errors.New("googleai google-gemini client: project is required")
+	// ErrGoogleGeminiLocationRequired is returned when NewGoogleGeminiClient is called with empty location.
+	ErrGoogleGeminiLocationRequired = errors.New("googleai google-gemini client: location is required")
 )
 
 // Client calls the Gemini embeddings API via the Google Gen AI SDK.
@@ -82,16 +82,16 @@ func NewClient(ctx context.Context, apiKey string, opts ...ClientOption) (*Clien
 	return client, nil
 }
 
-// NewVertexClient creates a Vertex AI embeddings client using Application Default Credentials (ADC).
-// When running outside GCP (e.g. EKS, Railway), set GOOGLE_APPLICATION_CREDENTIALS to the path of a service account key JSON file.
-// project is the GCP project ID; location is the region (e.g. europe-west3, global).
-func NewVertexClient(ctx context.Context, project, location string, opts ...ClientOption) (*Client, error) {
+// NewGoogleGeminiClient creates a Google Cloud-hosted Gemini embeddings client using Application Default Credentials (ADC).
+// When running outside Google Cloud (e.g. EKS, Railway), set GOOGLE_APPLICATION_CREDENTIALS to the path of a service account key JSON file.
+// project is the Google Cloud project ID; location is the region (e.g. europe-west3, global).
+func NewGoogleGeminiClient(ctx context.Context, project, location string, opts ...ClientOption) (*Client, error) {
 	if strings.TrimSpace(project) == "" {
-		return nil, ErrVertexProjectRequired
+		return nil, ErrGoogleGeminiProjectRequired
 	}
 
 	if strings.TrimSpace(location) == "" {
-		return nil, ErrVertexLocationRequired
+		return nil, ErrGoogleGeminiLocationRequired
 	}
 
 	genaiClient, err := genai.NewClient(ctx, &genai.ClientConfig{
@@ -100,7 +100,7 @@ func NewVertexClient(ctx context.Context, project, location string, opts ...Clie
 		Backend:  genai.BackendVertexAI,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("googleai vertex client: %w", err)
+		return nil, fmt.Errorf("googleai google-gemini client: %w", err)
 	}
 
 	client := &Client{

--- a/internal/googleai/client_test.go
+++ b/internal/googleai/client_test.go
@@ -5,23 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestNewVertexClient_emptyProject_returnsError(t *testing.T) {
+func TestNewGoogleGeminiClient_emptyProject_returnsError(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := NewVertexClient(ctx, "", "europe-west3")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "vertex")
+	_, err := NewGoogleGeminiClient(ctx, "", "europe-west3")
+	assert.ErrorIs(t, err, ErrGoogleGeminiProjectRequired)
 }
 
-func TestNewVertexClient_emptyLocation_returnsError(t *testing.T) {
+func TestNewGoogleGeminiClient_emptyLocation_returnsError(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := NewVertexClient(ctx, "my-project", "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "vertex")
+	_, err := NewGoogleGeminiClient(ctx, "my-project", "")
+	assert.ErrorIs(t, err, ErrGoogleGeminiLocationRequired)
 }
 
 func TestClient_CreateEmbedding_emptyInput_returnsErrEmptyInput(t *testing.T) {

--- a/internal/service/embedding_client_factory.go
+++ b/internal/service/embedding_client_factory.go
@@ -14,7 +14,9 @@ import (
 const (
 	EmbeddingProviderOpenAI       = "openai"
 	EmbeddingProviderGoogle       = "google"
-	EmbeddingProviderGoogleVertex = "google-vertex"
+	EmbeddingProviderGoogleGemini = "google-gemini"
+
+	embeddingProviderGoogleVertexLegacy = "google-vertex"
 )
 
 var (
@@ -22,16 +24,17 @@ var (
 	ErrEmbeddingConfigInvalid = errors.New("embedding config invalid")
 	// ErrEmbeddingProviderAPIKey is returned when an API-key-based provider is configured without a key.
 	ErrEmbeddingProviderAPIKey = errors.New("EMBEDDING_PROVIDER_API_KEY is required for this provider")
-	// ErrEmbeddingVertexConfig is returned when google-vertex is configured without project or location.
-	ErrEmbeddingVertexConfig = errors.New("google-vertex requires EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION")
+	// ErrEmbeddingGoogleGeminiConfig is returned when google-gemini is configured without project or location.
+	ErrEmbeddingGoogleGeminiConfig = errors.New(
+		"google-gemini requires EMBEDDING_GOOGLE_CLOUD_PROJECT and EMBEDDING_GOOGLE_CLOUD_LOCATION")
 )
 
 // providerEntry describes capabilities and construction for one embedding provider (single source of truth).
 type providerEntry struct {
-	RequiresAPIKey       bool
-	RequiresVertexConfig bool
-	DocPrefix            string
-	Factory              func(context.Context, EmbeddingClientConfig) (EmbeddingClient, error)
+	RequiresAPIKey             bool
+	RequiresGoogleGeminiConfig bool
+	DocPrefix                  string
+	Factory                    func(context.Context, EmbeddingClientConfig) (EmbeddingClient, error)
 }
 
 // embeddingProviderRegistry is the single source of truth for provider capabilities and client creation.
@@ -46,10 +49,10 @@ var embeddingProviderRegistry = map[string]providerEntry{
 		DocPrefix:      "",
 		Factory:        googleEmbeddingFactory,
 	},
-	EmbeddingProviderGoogleVertex: {
-		RequiresVertexConfig: true,
-		DocPrefix:            "",
-		Factory:              googleVertexEmbeddingFactory,
+	EmbeddingProviderGoogleGemini: {
+		RequiresGoogleGeminiConfig: true,
+		DocPrefix:                  "",
+		Factory:                    googleGeminiEmbeddingFactory,
 	},
 }
 
@@ -72,13 +75,13 @@ func googleEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig) (Emb
 	return client, nil
 }
 
-func googleVertexEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig) (EmbeddingClient, error) {
-	client, err := googleai.NewVertexClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
+func googleGeminiEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig) (EmbeddingClient, error) {
+	client, err := googleai.NewGoogleGeminiClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
 		googleai.WithModel(cfg.Model),
 		googleai.WithNormalize(cfg.Normalize),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("create google-vertex embedding client: %w", err)
+		return nil, fmt.Errorf("create google-gemini embedding client: %w", err)
 	}
 
 	return client, nil
@@ -86,7 +89,12 @@ func googleVertexEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig
 
 // NormalizeEmbeddingProvider returns the canonical provider name (lowercase, trimmed).
 func NormalizeEmbeddingProvider(provider string) string {
-	return strings.ToLower(strings.TrimSpace(provider))
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == embeddingProviderGoogleVertexLegacy {
+		return EmbeddingProviderGoogleGemini
+	}
+
+	return provider
 }
 
 // EmbeddingClientConfig holds configuration for creating an embedding client.
@@ -99,7 +107,7 @@ type EmbeddingClientConfig struct {
 	GoogleCloudLocation string
 }
 
-// ValidateEmbeddingConfig checks provider support and provider-specific requirements (API key, vertex project/location).
+// ValidateEmbeddingConfig checks provider support and provider-specific requirements (API key, Google Gemini project/location).
 // Use before creating a client or at startup to fail fast with a clear error.
 func ValidateEmbeddingConfig(cfg EmbeddingClientConfig) error {
 	provider := NormalizeEmbeddingProvider(cfg.Provider)
@@ -113,8 +121,8 @@ func ValidateEmbeddingConfig(cfg EmbeddingClientConfig) error {
 		return fmt.Errorf("%w: %s", ErrEmbeddingProviderAPIKey, provider)
 	}
 
-	if entry.RequiresVertexConfig && (cfg.GoogleCloudProject == "" || cfg.GoogleCloudLocation == "") {
-		return ErrEmbeddingVertexConfig
+	if entry.RequiresGoogleGeminiConfig && (cfg.GoogleCloudProject == "" || cfg.GoogleCloudLocation == "") {
+		return ErrEmbeddingGoogleGeminiConfig
 	}
 
 	return nil
@@ -144,11 +152,11 @@ func ProviderRequiresAPIKey(provider string) bool {
 	return ok && entry.RequiresAPIKey
 }
 
-// ProviderRequiresVertexConfig returns true for providers that require project and location (from registry).
-func ProviderRequiresVertexConfig(provider string) bool {
+// ProviderRequiresGoogleGeminiConfig returns true for providers that require Google Cloud project and location.
+func ProviderRequiresGoogleGeminiConfig(provider string) bool {
 	entry, ok := embeddingProviderRegistry[NormalizeEmbeddingProvider(provider)]
 
-	return ok && entry.RequiresVertexConfig
+	return ok && entry.RequiresGoogleGeminiConfig
 }
 
 // SupportedEmbeddingProviders returns the set of supported provider names (from registry).

--- a/internal/service/embedding_client_factory.go
+++ b/internal/service/embedding_client_factory.go
@@ -107,7 +107,7 @@ type EmbeddingClientConfig struct {
 	GoogleCloudLocation string
 }
 
-// ValidateEmbeddingConfig checks provider support and provider-specific requirements (API key, Google Gemini project/location).
+// ValidateEmbeddingConfig checks provider support and provider-specific requirements (API key, Google Cloud project/location).
 // Use before creating a client or at startup to fail fast with a clear error.
 func ValidateEmbeddingConfig(cfg EmbeddingClientConfig) error {
 	provider := NormalizeEmbeddingProvider(cfg.Provider)

--- a/internal/service/embedding_client_factory_test.go
+++ b/internal/service/embedding_client_factory_test.go
@@ -58,29 +58,29 @@ func TestNewEmbeddingClient(t *testing.T) {
 			errIs:   ErrEmbeddingProviderAPIKey,
 		},
 		{
-			name: "google-vertex without project returns error",
+			name: "google-gemini without project returns error",
 			cfg: EmbeddingClientConfig{
-				Provider:            EmbeddingProviderGoogleVertex,
+				Provider:            EmbeddingProviderGoogleGemini,
 				Model:               "text-embedding-004",
 				GoogleCloudProject:  "",
 				GoogleCloudLocation: "europe-west3",
 			},
 			wantErr: true,
-			errIs:   ErrEmbeddingVertexConfig,
+			errIs:   ErrEmbeddingGoogleGeminiConfig,
 		},
 		{
-			name: "google-vertex without location returns error",
+			name: "google-gemini without location returns error",
 			cfg: EmbeddingClientConfig{
-				Provider:            EmbeddingProviderGoogleVertex,
+				Provider:            EmbeddingProviderGoogleGemini,
 				Model:               "text-embedding-004",
 				GoogleCloudProject:  "my-project",
 				GoogleCloudLocation: "",
 			},
 			wantErr: true,
-			errIs:   ErrEmbeddingVertexConfig,
+			errIs:   ErrEmbeddingGoogleGeminiConfig,
 		},
 		{
-			name: "google-vertex with mixed-case and whitespace provider name normalizes and validates",
+			name: "legacy google-vertex alias normalizes and validates",
 			cfg: EmbeddingClientConfig{
 				Provider:            " Google-Vertex ",
 				Model:               "text-embedding-004",
@@ -88,7 +88,7 @@ func TestNewEmbeddingClient(t *testing.T) {
 				GoogleCloudLocation: "",
 			},
 			wantErr: true,
-			errIs:   ErrEmbeddingVertexConfig,
+			errIs:   ErrEmbeddingGoogleGeminiConfig,
 		},
 		{
 			name: "unsupported provider returns error",
@@ -129,7 +129,7 @@ func TestProviderRequiresAPIKey(t *testing.T) {
 	}{
 		{EmbeddingProviderOpenAI, true},
 		{EmbeddingProviderGoogle, true},
-		{EmbeddingProviderGoogleVertex, false},
+		{EmbeddingProviderGoogleGemini, false},
 		{"unknown", false},
 		{"OPENAI", true},
 		{"Google", true},
@@ -143,21 +143,22 @@ func TestProviderRequiresAPIKey(t *testing.T) {
 	}
 }
 
-func TestProviderRequiresVertexConfig(t *testing.T) {
+func TestProviderRequiresGoogleGeminiConfig(t *testing.T) {
 	tests := []struct {
 		provider string
 		want     bool
 	}{
-		{EmbeddingProviderGoogleVertex, true},
+		{EmbeddingProviderGoogleGemini, true},
 		{EmbeddingProviderOpenAI, false},
 		{EmbeddingProviderGoogle, false},
 		{"unknown", false},
 		{"google-vertex", true},
+		{" Google-Gemini ", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {
-			got := ProviderRequiresVertexConfig(tt.provider)
+			got := ProviderRequiresGoogleGeminiConfig(tt.provider)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -168,7 +169,7 @@ func TestSupportedEmbeddingProviders(t *testing.T) {
 
 	assert.Contains(t, providers, EmbeddingProviderOpenAI)
 	assert.Contains(t, providers, EmbeddingProviderGoogle)
-	assert.Contains(t, providers, EmbeddingProviderGoogleVertex)
+	assert.Contains(t, providers, EmbeddingProviderGoogleGemini)
 	assert.Len(t, providers, 3)
 }
 
@@ -192,22 +193,22 @@ func TestValidateEmbeddingConfig(t *testing.T) {
 			true, ErrEmbeddingProviderAPIKey,
 		},
 		{
-			"vertex with project and location valid",
+			"google-gemini with project and location valid",
 			EmbeddingClientConfig{
-				Provider: EmbeddingProviderGoogleVertex, Model: "m",
+				Provider: EmbeddingProviderGoogleGemini, Model: "m",
 				GoogleCloudProject: "p", GoogleCloudLocation: "l",
 			},
 			false, nil,
 		},
 		{
-			"vertex without project invalid",
-			EmbeddingClientConfig{Provider: EmbeddingProviderGoogleVertex, Model: "m", GoogleCloudLocation: "l"},
-			true, ErrEmbeddingVertexConfig,
+			"google-gemini without project invalid",
+			EmbeddingClientConfig{Provider: EmbeddingProviderGoogleGemini, Model: "m", GoogleCloudLocation: "l"},
+			true, ErrEmbeddingGoogleGeminiConfig,
 		},
 		{
-			"vertex without location invalid",
-			EmbeddingClientConfig{Provider: EmbeddingProviderGoogleVertex, Model: "m", GoogleCloudProject: "p"},
-			true, ErrEmbeddingVertexConfig,
+			"google-gemini without location invalid",
+			EmbeddingClientConfig{Provider: EmbeddingProviderGoogleGemini, Model: "m", GoogleCloudProject: "p"},
+			true, ErrEmbeddingGoogleGeminiConfig,
 		},
 		{
 			"unsupported provider invalid",
@@ -236,12 +237,13 @@ func TestValidateEmbeddingConfig(t *testing.T) {
 func TestNormalizeEmbeddingProvider(t *testing.T) {
 	assert.Equal(t, "openai", NormalizeEmbeddingProvider("OpenAI"))
 	assert.Equal(t, "openai", NormalizeEmbeddingProvider("  openai  "))
-	assert.Equal(t, "google-vertex", NormalizeEmbeddingProvider(" Google-Vertex "))
+	assert.Equal(t, "google-gemini", NormalizeEmbeddingProvider(" Google-Gemini "))
+	assert.Equal(t, "google-gemini", NormalizeEmbeddingProvider(" Google-Vertex "))
 }
 
 func TestEmbeddingPrefixForProvider(t *testing.T) {
 	assert.Empty(t, EmbeddingPrefixForProvider(EmbeddingProviderOpenAI))
 	assert.Empty(t, EmbeddingPrefixForProvider(EmbeddingProviderGoogle))
-	assert.Empty(t, EmbeddingPrefixForProvider(EmbeddingProviderGoogleVertex))
+	assert.Empty(t, EmbeddingPrefixForProvider(EmbeddingProviderGoogleGemini))
 	assert.Empty(t, EmbeddingPrefixForProvider("unknown"))
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -622,7 +622,7 @@ paths:
             description: |
                 Embeds the search query and returns feedback record IDs with similarity scores (cosine, 0..1).
                 **Only available when embeddings are configured** (EMBEDDING_PROVIDER and EMBEDDING_MODEL set).
-                Supported providers: openai, google (AI Studio), google-vertex.
+                Supported providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
                 When embeddings are disabled, this endpoint returns 503 Service Unavailable.
                 Request body must include query and tenant_id (required for tenant isolation).
             operationId: semantic-search-feedback-records
@@ -694,7 +694,7 @@ paths:
             description: |
                 Returns feedback record IDs and similarity scores for records similar to the given one (by embedding).
                 **Only available when embeddings are configured** (EMBEDDING_PROVIDER and EMBEDDING_MODEL set).
-                Supported providers: openai, google (AI Studio), google-vertex.
+                Supported providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
                 When embeddings are disabled, this endpoint returns 503 Service Unavailable.
                 The source feedback record must belong to the given tenant_id (enforced).
             operationId: similar-feedback-records

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -622,7 +622,7 @@ paths:
             description: |
                 Embeds the search query and returns feedback record IDs with similarity scores (cosine, 0..1).
                 **Only available when embeddings are configured** (EMBEDDING_PROVIDER and EMBEDDING_MODEL set).
-                Supported providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
+                Supported providers: openai, google (Gemini Developer API / Google AI Studio), google-gemini (Gemini Enterprise Agent Platform API).
                 When embeddings are disabled, this endpoint returns 503 Service Unavailable.
                 Request body must include query and tenant_id (required for tenant isolation).
             operationId: semantic-search-feedback-records
@@ -694,7 +694,7 @@ paths:
             description: |
                 Returns feedback record IDs and similarity scores for records similar to the given one (by embedding).
                 **Only available when embeddings are configured** (EMBEDDING_PROVIDER and EMBEDDING_MODEL set).
-                Supported providers: openai, google (Gemini API / AI Studio), google-gemini (Gemini API on Google Cloud).
+                Supported providers: openai, google (Gemini Developer API / Google AI Studio), google-gemini (Gemini Enterprise Agent Platform API).
                 When embeddings are disabled, this endpoint returns 503 Service Unavailable.
                 The source feedback record must belong to the given tenant_id (enforced).
             operationId: similar-feedback-records


### PR DESCRIPTION
## What does this PR do?

Renames the Google Cloud-backed embeddings provider from the legacy `google-vertex` slug to `google-gemini` in Formbricks Hub.

This follows Google's current Gemini naming for the Cloud-backed Gemini API surface (`Gemini Enterprise Agent Platform API`) while keeping the Google Cloud/Vertex SDK configuration names that the official Google Gen AI SDK still requires.

The new canonical provider is `EMBEDDING_PROVIDER=google-gemini`. Existing `google-vertex` configurations continue to work through a legacy normalization alias, so current deployments do not break immediately while docs, OpenAPI, errors, and tests move to the new name.

Fixes [ENG-780](https://linear.app/formbricks/issue/ENG-780/rename-google-vertex-to-google-gemini-in-formbricks-hub).

<!-- For API behavior changes, include request/response examples or screenshots of Swagger UI to speed up reviews. -->

## How should this be tested?

- `go test ./cmd/... ./internal/... ./pkg/...`
- `golangci-lint run ./...`
- `make build`
- `git diff --check`

Note: `go test ./...` was also attempted, but the integration package requires a local Postgres database named `test_db` on `localhost:5432`; that database is not present in this environment.

## Checklist

<!-- Please go through this checklist and tick off what you did. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: N/A, no database schema changes

### Appreciated

- [x] If API changed: updated OpenAPI provider wording; no API behavior changes
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [x] Updated docs/examples where necessary (`.env.example`, OpenAPI provider text)
- [ ] Ran `make tests-coverage` for meaningful logic changes
