### PR TITLE
fix: make tenant filter optional for list records

### DIFF
--- a/internal/api/handlers/feedback_records_handler.go
+++ b/internal/api/handlers/feedback_records_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -117,6 +118,12 @@ func (h *FeedbackRecordsHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	// Decode and validate query parameters
 	if err := validation.ValidateAndDecodeQueryParams(r, filters); err != nil {
+		slog.WarnContext(r.Context(), "list feedback records request rejected",
+			"method", r.Method,
+			"endpoint", "/v1/feedback-records",
+			"status", http.StatusBadRequest,
+			"error", err,
+		)
 		validation.RespondValidationError(w, err)
 
 		return
@@ -125,11 +132,23 @@ func (h *FeedbackRecordsHandler) List(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.ListFeedbackRecords(r.Context(), filters)
 	if err != nil {
 		if errors.Is(err, cursor.ErrInvalidCursor) {
+			slog.WarnContext(r.Context(), "list feedback records request rejected",
+				"method", r.Method,
+				"endpoint", "/v1/feedback-records",
+				"status", http.StatusBadRequest,
+				"error", err,
+			)
 			response.RespondBadRequest(w, "Invalid cursor: omit for first page, or use the exact next_cursor value from the previous response")
 
 			return
 		}
 
+		slog.ErrorContext(r.Context(), "list feedback records failed",
+			"method", r.Method,
+			"endpoint", "/v1/feedback-records",
+			"status", http.StatusInternalServerError,
+			"error", err,
+		)
 		response.RespondInternalServerError(w, "An unexpected error occurred")
 
 		return

--- a/internal/api/handlers/feedback_records_handler_test.go
+++ b/internal/api/handlers/feedback_records_handler_test.go
@@ -16,6 +16,7 @@ import (
 
 // mockFeedbackRecordsService mocks FeedbackRecordsService for handler tests.
 type mockFeedbackRecordsService struct {
+	listFunc       func(ctx context.Context, filters *models.ListFeedbackRecordsFilters) (*models.ListFeedbackRecordsResponse, error)
 	bulkDeleteFunc func(ctx context.Context, userID string, tenantID *string) (int, error)
 }
 
@@ -30,9 +31,13 @@ func (m *mockFeedbackRecordsService) GetFeedbackRecord(context.Context, uuid.UUI
 }
 
 func (m *mockFeedbackRecordsService) ListFeedbackRecords(
-	context.Context, *models.ListFeedbackRecordsFilters,
+	ctx context.Context, filters *models.ListFeedbackRecordsFilters,
 ) (*models.ListFeedbackRecordsResponse, error) {
-	return nil, nil
+	if m.listFunc != nil {
+		return m.listFunc(ctx, filters)
+	}
+
+	return &models.ListFeedbackRecordsResponse{}, nil
 }
 
 func (m *mockFeedbackRecordsService) UpdateFeedbackRecord(
@@ -54,11 +59,39 @@ func (m *mockFeedbackRecordsService) BulkDeleteFeedbackRecords(ctx context.Conte
 }
 
 func TestFeedbackRecordsHandler_List(t *testing.T) {
-	t.Run("missing tenant_id returns 400", func(t *testing.T) {
-		mock := &mockFeedbackRecordsService{}
+	t.Run("missing tenant_id lists without tenant filter", func(t *testing.T) {
+		var capturedFilters *models.ListFeedbackRecordsFilters
+
+		mock := &mockFeedbackRecordsService{
+			listFunc: func(_ context.Context, filters *models.ListFeedbackRecordsFilters) (*models.ListFeedbackRecordsResponse, error) {
+				capturedFilters = filters
+
+				return &models.ListFeedbackRecordsResponse{}, nil
+			},
+		}
 		handler := NewFeedbackRecordsHandler(mock)
 
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://test/v1/feedback-records", http.NoBody)
+		rec := httptest.NewRecorder()
+
+		handler.List(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, capturedFilters)
+		assert.Nil(t, capturedFilters.TenantID)
+	})
+
+	t.Run("blank tenant_id returns 400", func(t *testing.T) {
+		mock := &mockFeedbackRecordsService{
+			listFunc: func(context.Context, *models.ListFeedbackRecordsFilters) (*models.ListFeedbackRecordsResponse, error) {
+				t.Fatal("service should not be called for invalid tenant_id")
+
+				return nil, nil
+			},
+		}
+		handler := NewFeedbackRecordsHandler(mock)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://test/v1/feedback-records?tenant_id=", http.NoBody)
 		rec := httptest.NewRecorder()
 
 		handler.List(rec, req)

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -175,7 +175,7 @@ func (r *UpdateFeedbackRecordRequest) ChangedFields() []string {
 
 // ListFeedbackRecordsFilters represents filters for listing feedback records.
 type ListFeedbackRecordsFilters struct {
-	TenantID     *string    `form:"tenant_id"      validate:"required,no_null_bytes,min=1"`
+	TenantID     *string    `form:"tenant_id"      validate:"omitempty,no_null_bytes,min=1,max=255"`
 	SubmissionID *string    `form:"submission_id"  validate:"omitempty,no_null_bytes"`
 	SourceType   *string    `form:"source_type"    validate:"omitempty,no_null_bytes"`
 	SourceID     *string    `form:"source_id"      validate:"omitempty,no_null_bytes"`

--- a/migrations/008_add_feedback_records_unscoped_list_index.sql
+++ b/migrations/008_add_feedback_records_unscoped_list_index.sql
@@ -1,0 +1,8 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Supports unscoped keyset pagination for GET /v1/feedback-records when tenant_id is omitted.
+CREATE INDEX CONCURRENTLY idx_feedback_records_collected_at_id
+  ON feedback_records (collected_at DESC, id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_feedback_records_collected_at_id;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,12 +54,13 @@ paths:
             parameters:
                 - name: tenant_id
                   in: query
-                  required: true
-                  description: Tenant ID (required for isolation). NULL bytes not allowed.
+                  required: false
+                  description: Optional tenant filter. Omit to list all feedback records visible to the API key. NULL bytes not allowed.
                   schema:
                     type: string
-                    description: Tenant ID (required for isolation). NULL bytes not allowed.
+                    description: Optional tenant filter. Omit to list all feedback records visible to the API key. NULL bytes not allowed.
                     minLength: 1
+                    maxLength: 255
                     pattern: '^[^\x00]*$'
                     example: "org-123"
                 - name: submission_id

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -345,9 +345,31 @@ func TestListFeedbackRecords(t *testing.T) {
 	// decodeData not needed for this create; we only need a record to list
 	require.NoError(t, createResp.Body.Close())
 
-	// Test missing tenant_id returns 400
-	t.Run("Missing tenant_id returns 400", func(t *testing.T) {
+	// Test missing tenant_id lists all records visible to the API key
+	t.Run("Missing tenant_id lists records", func(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/v1/feedback-records", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+testAPIKey)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	})
+
+	t.Run("Missing tenant_id with limit lists records", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/v1/feedback-records?limit=10", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+testAPIKey)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	})
+
+	t.Run("Blank tenant_id returns 400", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/v1/feedback-records?tenant_id=", http.NoBody)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey)
 


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-788

This PR makes `tenant_id` optional for `GET /v1/feedback-records`, matching the documented optional multi-tenancy field behavior. The root cause was the list query filter model still marking `TenantID` as `required`, so requests without `tenant_id` failed validation before reaching the repository, even though the repository already supports an omitted tenant filter.

It also updates the OpenAPI docs, adds structured logging around list endpoint failures, and adds a concurrent pagination index for unscoped list queries.

API behavior examples:

```bash
curl "http://localhost:8080/v1/feedback-records" \
  -H "Authorization: Bearer your_secure_api_key_here"
```

Expected response: `200 OK` with the paginated list body.

```bash
curl "http://localhost:8080/v1/feedback-records?limit=10" \
  -H "Authorization: Bearer your_secure_api_key_here"
```

Expected response: `200 OK` with the paginated list body.

```bash
curl "http://localhost:8080/v1/feedback-records?tenant_id=" \
  -H "Authorization: Bearer your_secure_api_key_here"
```

Expected response: `400 Bad Request`.

## How should this be tested?

- `go test ./internal/api/handlers`
- `go test ./tests/...`
- `go test ./...`
- `make build`
- `make tests`
- `make migrate-validate`
- `make fmt`
- `make lint`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes