### PR TITLE
feat: support UUIDv7 on Postgres 16 and 17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,76 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
+  compatibility-tests:
+    name: Compatibility Tests (${{ matrix.postgres_image }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres_image: [pg16, pg17]
+
+    services:
+      postgres:
+        image: pgvector/pgvector:${{ matrix.postgres_image }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
+      API_KEY: test-api-key-for-ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: '1.26.2'
+
+      - name: Cache Go modules
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+
+      - name: Validate migrations
+        run: make migrate-validate
+
+      - name: Initialize database schema
+        run: make init-db
+
+      - name: Run River migrations
+        run: |
+          go install github.com/riverqueue/river/cmd/river@v0.31.0
+          make river-migrate
+
+      - name: Run integration tests
+        run: make tests
+
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (pg18)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -174,7 +242,7 @@ jobs:
 
   tests:
     name: All Tests
-    needs: [unit-tests, integration-tests, coverage]
+    needs: [unit-tests, compatibility-tests, integration-tests, coverage]
     runs-on: ubuntu-24.04
     if: always()
     steps:
@@ -186,6 +254,10 @@ jobs:
           fi
           if [ "${{ needs.integration-tests.result }}" != "success" ]; then
             echo "Integration tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.compatibility-tests.result }}" != "success" ]; then
+            echo "Compatibility tests failed"
             exit 1
           fi
           if [ "${{ needs.coverage.result }}" != "success" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,82 +49,19 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
-  compatibility-tests:
-    name: Compatibility Tests (${{ matrix.postgres_image }})
+  integration-tests:
+    name: Integration Tests (${{ matrix.postgres_image }})
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        postgres_image: [pg16, pg17]
+        postgres_image: [pg16, pg17, pg18]
 
     services:
       postgres:
         image: pgvector/pgvector:${{ matrix.postgres_image }}
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_db
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
-      API_KEY: test-api-key-for-ci
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
-        with:
-          go-version: '1.26.2'
-
-      - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
-
-      - name: Validate migrations
-        run: make migrate-validate
-
-      - name: Initialize database schema
-        run: make init-db
-
-      - name: Run River migrations
-        run: |
-          go install github.com/riverqueue/river/cmd/river@v0.31.0
-          make river-migrate
-
-      - name: Run integration tests
-        run: make tests
-
-  integration-tests:
-    name: Integration Tests (pg18)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-
-    services:
-      postgres:
-        image: pgvector/pgvector:pg18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -242,7 +179,7 @@ jobs:
 
   tests:
     name: All Tests
-    needs: [unit-tests, compatibility-tests, integration-tests, coverage]
+    needs: [unit-tests, integration-tests, coverage]
     runs-on: ubuntu-24.04
     if: always()
     steps:
@@ -254,10 +191,6 @@ jobs:
           fi
           if [ "${{ needs.integration-tests.result }}" != "success" ]; then
             echo "Integration tests failed"
-            exit 1
-          fi
-          if [ "${{ needs.compatibility-tests.result }}" != "success" ]; then
-            echo "Compatibility tests failed"
             exit 1
           fi
           if [ "${{ needs.coverage.result }}" != "success" ]; then

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   # PostgreSQL database with pgvector extension for Hub
   postgres:
-    image: pgvector/pgvector:${POSTGRES_IMAGE_TAG:-pg17}
+    image: pgvector/pgvector:${POSTGRES_IMAGE_TAG:-pg18}
     container_name: formbricks_postgres
     environment:
       POSTGRES_USER: postgres

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   # PostgreSQL database with pgvector extension for Hub
   postgres:
-    image: pgvector/pgvector:pg18
+    image: pgvector/pgvector:${POSTGRES_IMAGE_TAG:-pg17}
     container_name: formbricks_postgres
     environment:
       POSTGRES_USER: postgres

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -5,6 +5,28 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
+-- PostgreSQL 18+ provides a native uuidv7() in pg_catalog.
+-- Older versions do not, so create a schema-local fallback for bootstrap compatibility.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.uuidv7() RETURNS uuid
+AS $$
+  SELECT encode(
+    set_bit(
+      set_bit(
+        overlay(
+          uuid_send(gen_random_uuid())
+          PLACING substring(int8send((extract(epoch from clock_timestamp()) * 1000)::bigint) FROM 3)
+          FROM 1 FOR 6
+        ),
+        52, 1
+      ),
+      53, 1
+    ),
+    'hex'
+  )::uuid;
+$$ LANGUAGE sql VOLATILE PARALLEL SAFE;
+-- +goose StatementEnd
+
 -- Create ENUM types
 CREATE TYPE field_type_enum AS ENUM (
     'text', 'categorical', 'nps', 'csat', 'ces', 'rating', 'number', 'boolean', 'date'
@@ -72,3 +94,4 @@ CREATE INDEX idx_feedback_records_tenant_field_type ON feedback_records(tenant_i
 -- explicitly drop extensions elsewhere.
 DROP TABLE IF EXISTS feedback_records;
 DROP TYPE IF EXISTS field_type_enum;
+DROP FUNCTION IF EXISTS public.uuidv7();

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -8,23 +8,39 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 -- PostgreSQL 18+ provides a native uuidv7() in pg_catalog.
 -- Older versions do not, so create a schema-local fallback for bootstrap compatibility.
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION public.uuidv7() RETURNS uuid
-AS $$
-  SELECT encode(
-    set_bit(
-      set_bit(
-        overlay(
-          uuid_send(gen_random_uuid())
-          PLACING substring(int8send((extract(epoch from clock_timestamp()) * 1000)::bigint) FROM 3)
-          FROM 1 FOR 6
-        ),
-        52, 1
-      ),
-      53, 1
-    ),
-    'hex'
-  )::uuid;
-$$ LANGUAGE sql VOLATILE PARALLEL SAFE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'uuidv7'
+      AND p.pronargs = 0
+      AND n.nspname IN ('pg_catalog', 'public')
+  ) THEN
+    EXECUTE $fn$
+      CREATE FUNCTION public.uuidv7() RETURNS uuid
+      AS $body$
+        SELECT encode(
+          set_bit(
+            set_bit(
+              overlay(
+                uuid_send(gen_random_uuid())
+                PLACING substring(int8send((extract(epoch from clock_timestamp()) * 1000)::bigint) FROM 3)
+                FROM 1 FOR 6
+              ),
+              52, 1
+            ),
+            53, 1
+          ),
+          'hex'
+        )::uuid;
+      $body$ LANGUAGE sql VOLATILE PARALLEL SAFE
+    $fn$;
+
+    COMMENT ON FUNCTION public.uuidv7() IS 'formbricks hub bootstrap fallback';
+  END IF;
+END $$;
 -- +goose StatementEnd
 
 -- Create ENUM types
@@ -94,4 +110,23 @@ CREATE INDEX idx_feedback_records_tenant_field_type ON feedback_records(tenant_i
 -- explicitly drop extensions elsewhere.
 DROP TABLE IF EXISTS feedback_records;
 DROP TYPE IF EXISTS field_type_enum;
-DROP FUNCTION IF EXISTS public.uuidv7();
+-- +goose StatementBegin
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_description d
+      ON d.objoid = p.oid
+     AND d.classoid = 'pg_proc'::regclass
+     AND d.objsubid = 0
+    WHERE p.proname = 'uuidv7'
+      AND p.pronargs = 0
+      AND n.nspname = 'public'
+      AND d.description = 'formbricks hub bootstrap fallback'
+  ) THEN
+    DROP FUNCTION public.uuidv7();
+  END IF;
+END $$;
+-- +goose StatementEnd

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -36,6 +36,7 @@ const (
 	testWebhookURLV2 = "https://192.0.2.1/webhook-v2"
 )
 
+// requireUUIDv7 asserts that an ID uses UUID version 7 with the RFC4122 variant.
 func requireUUIDv7(t *testing.T, id uuid.UUID) {
 	t.Helper()
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -30,6 +30,16 @@ import (
 // defaultTestDatabaseURL is the default Postgres URL used by compose (postgres/postgres/test_db).
 // Used when DATABASE_URL is not set (e.g. CI uses job env; local can rely on .env).
 const defaultTestDatabaseURL = "postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable"
+const testWebhookURL = "https://93.184.216.34/webhook"
+const testWebhookURLV2 = "https://93.184.216.34/webhook-v2"
+
+func requireUUIDv7(t *testing.T, id uuid.UUID) {
+	t.Helper()
+
+	require.NotEqual(t, uuid.Nil, id)
+	require.Equal(t, uuid.Version(7), id.Version())
+	require.Equal(t, uuid.RFC4122, id.Variant())
+}
 
 // setupTestServer creates a test HTTP server with all routes configured.
 // Database URL comes from env (DATABASE_URL) when set; otherwise config.Load() uses its default.
@@ -275,7 +285,7 @@ func TestCreateFeedbackRecord(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 
-		assert.NotEmpty(t, result.ID)
+		requireUUIDv7(t, result.ID)
 		assert.Equal(t, "formbricks", result.SourceType)
 		assert.Equal(t, "feedback", result.FieldID)
 		assert.Equal(t, models.FieldTypeText, result.FieldType)
@@ -1096,7 +1106,7 @@ func TestWebhooksCRUD(t *testing.T) {
 
 	// Create webhook (no signing key = auto-generated)
 	createBody := map[string]any{
-		"url":         "https://example.com/webhook",
+		"url":         testWebhookURL,
 		"event_types": []string{"feedback_record.created", "feedback_record.updated"},
 	}
 	body, err := json.Marshal(createBody)
@@ -1115,8 +1125,8 @@ func TestWebhooksCRUD(t *testing.T) {
 	err = decodeData(createResp, &created)
 	require.NoError(t, err)
 	require.NoError(t, createResp.Body.Close())
-	assert.NotEmpty(t, created.ID.String())
-	assert.Equal(t, "https://example.com/webhook", created.URL)
+	requireUUIDv7(t, created.ID)
+	assert.Equal(t, testWebhookURL, created.URL)
 	assert.NotEmpty(t, created.SigningKey)
 	assert.True(t, created.Enabled)
 	assert.Len(t, created.EventTypes, 2)
@@ -1186,7 +1196,7 @@ func TestWebhooksCRUD(t *testing.T) {
 
 	// Update webhook (including tenant_id)
 	updateBody := map[string]any{
-		"url":       "https://example.com/webhook-v2",
+		"url":       testWebhookURLV2,
 		"enabled":   false,
 		"tenant_id": "org-123",
 	}
@@ -1207,7 +1217,7 @@ func TestWebhooksCRUD(t *testing.T) {
 	err = decodeData(updateResp, &updated)
 	require.NoError(t, err)
 	require.NoError(t, updateResp.Body.Close())
-	assert.Equal(t, "https://example.com/webhook-v2", updated.URL)
+	assert.Equal(t, testWebhookURLV2, updated.URL)
 	assert.False(t, updated.Enabled)
 	require.NotNil(t, updated.TenantID)
 	assert.Equal(t, "org-123", *updated.TenantID)
@@ -1263,7 +1273,7 @@ func TestWebhooksInvalidSigningKey(t *testing.T) {
 
 	// Create with invalid signing_key
 	createBody := map[string]any{
-		"url":         "https://example.com/webhook",
+		"url":         testWebhookURL,
 		"signing_key": "not-valid",
 		"event_types": []string{"feedback_record.created"},
 	}
@@ -1291,7 +1301,7 @@ func TestWebhooksInvalidSigningKey(t *testing.T) {
 
 	// Create a valid webhook first for update test
 	validBody := map[string]any{
-		"url":         "https://example.com/webhook",
+		"url":         testWebhookURL,
 		"event_types": []string{"feedback_record.created"},
 	}
 	validJSON, err := json.Marshal(validBody)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -30,8 +30,11 @@ import (
 // defaultTestDatabaseURL is the default Postgres URL used by compose (postgres/postgres/test_db).
 // Used when DATABASE_URL is not set (e.g. CI uses job env; local can rely on .env).
 const defaultTestDatabaseURL = "postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable"
-const testWebhookURL = "https://93.184.216.34/webhook"
-const testWebhookURLV2 = "https://93.184.216.34/webhook-v2"
+
+const (
+	testWebhookURL   = "https://192.0.2.1/webhook"
+	testWebhookURLV2 = "https://192.0.2.1/webhook-v2"
+)
 
 func requireUUIDv7(t *testing.T, id uuid.UUID) {
 	t.Helper()


### PR DESCRIPTION
## Summary
This change makes Hub bootstrap cleanly on PostgreSQL 16 and 17 while preserving native UUIDv7 behavior on PostgreSQL 18.

## What changed
- add a SQL `public.uuidv7()` fallback in `001_initial_schema.sql` so fresh installs on PG16/17 can create tables that use `DEFAULT uuidv7()`
- keep the default expression unchanged so PG18 continues to resolve to `pg_catalog.uuidv7()`
- switch the local compose default to `pg17`
- add PG16/PG17 compatibility jobs to CI while keeping the existing PG18 integration and coverage flow
- assert UUIDv7 shape in integration tests and replace `example.com` webhook URLs with public IP literal URLs so compatibility checks do not depend on external DNS

## Why this approach
Hub currently relies on database-side UUID generation for persisted record and webhook IDs, so the failure mode is migration-time schema creation rather than Go runtime behavior.

I kept the fix in the bootstrap migration instead of moving ID generation into application code because:
- it preserves the existing insert paths and public API behavior
- it avoids widening the change surface into repositories and services
- it lets older Postgres versions bootstrap without extra operator steps or external extensions
- it keeps PG18 on the native implementation automatically

I also added explicit compatibility jobs rather than only changing local compose defaults, because without CI coverage this would regress easily and the original failure would remain invisible until integration into older XM Suite installations.

## Root cause
`feedback_records.id` and `webhooks.id` use `DEFAULT uuidv7()`, but PostgreSQL 16 and 17 do not provide that built-in function. The schema only worked because local and CI environments were pinned to PG18.

## Validation
- `PATH=/Users/bhagya/work/bin:$PATH make migrate-validate`
- `go test ./internal/...`
- fresh bootstrap + River migrations + targeted integration tests on `pgvector/pgvector:pg16`
- fresh bootstrap + River migrations + full `./tests/...` suite on `pgvector/pgvector:pg17`
- fresh bootstrap + River migrations + targeted integration tests on `pgvector/pgvector:pg18`

Closes ENG-755.
