### PR TITLE
fix(api): improve feedback record validation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,26 +110,71 @@ run-backfill-embeddings:
 	@if [ ! -f .env ]; then echo "Error: .env file required. Copy .env.example to .env and configure."; exit 1; fi && \
 	(set -a && . ./.env && set +a && go run ./cmd/backfill-embeddings)
 
-# Run the full local app: apply River migrations, then run hub-worker in the background and hub-api in the foreground.
+define RUN_LOCAL_APP
+set -Eeuo pipefail
+worker_pid=""
+api_pid=""
+started_pid=""
+state_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/hub-run.XXXXXX")"
+event_pipe="$$state_dir/process-events"
+mkfifo "$$event_pipe"
+stop_process() {
+	pid="$${1:-}"
+	name="$$2"
+	if [ -z "$$pid" ] || ! kill -0 "$$pid" 2>/dev/null; then return; fi
+	echo "Stopping $$name..."
+	pkill -TERM -P "$$pid" 2>/dev/null || true
+	kill -TERM "$$pid" 2>/dev/null || true
+	wait "$$pid" 2>/dev/null || true
+}
+cleanup() {
+	status=$$?
+	trap - INT TERM EXIT
+	stop_process "$$api_pid" "hub-api"
+	stop_process "$$worker_pid" "hub-worker"
+	rm -rf "$$state_dir"
+	exit "$$status"
+}
+run_and_report() {
+	name="$$1"
+	shift
+	(set +e; "$$@"; status=$$?; printf '%s %s\n' "$$name" "$$status" >"$$event_pipe" || true; exit "$$status") &
+	started_pid=$$!
+}
+trap cleanup EXIT
+trap 'echo "Stopping hub-api and hub-worker..."; exit 130' INT
+trap 'echo "Stopping hub-api and hub-worker..."; exit 143' TERM
+echo "Starting hub-worker..."
+run_and_report hub-worker go run ./cmd/worker
+worker_pid="$$started_pid"
+echo "Starting hub-api..."
+run_and_report hub-api go run ./cmd/api
+api_pid="$$started_pid"
+read -r exited_process exit_status <"$$event_pipe"
+case "$$exited_process" in
+	hub-worker)
+		echo "hub-worker exited unexpectedly with status $$exit_status; stopping hub-api."
+		stop_process "$$api_pid" "hub-api"
+		if [ "$$exit_status" -eq 0 ]; then exit 1; fi
+		exit "$$exit_status"
+		;;
+	hub-api)
+		echo "hub-api exited with status $$exit_status; stopping hub-worker."
+		stop_process "$$worker_pid" "hub-worker"
+		exit "$$exit_status"
+		;;
+	*)
+		echo "Unknown process event from local runner: $$exited_process" >&2
+		exit 1
+		;;
+esac
+endef
+export RUN_LOCAL_APP
+
+# Run the full local app: apply River migrations, then supervise hub-worker and hub-api together.
 # Config: .env if present, else environment variables; env vars override .env. Copy .env.example to .env or set env vars.
 run: river-migrate
-	@echo "Starting hub-worker and hub-api..."
-	@set -e; \
-	go run ./cmd/worker & \
-	worker_pid=$$!; \
-	cleanup() { \
-		status=$$?; \
-		trap - INT TERM EXIT; \
-		if kill -0 "$$worker_pid" 2>/dev/null; then \
-			echo "Stopping hub-worker..."; \
-			kill "$$worker_pid" 2>/dev/null || true; \
-			wait "$$worker_pid" 2>/dev/null || true; \
-		fi; \
-		exit $$status; \
-	}; \
-	trap cleanup INT TERM EXIT; \
-	echo "Starting hub-api..."; \
-	go run ./cmd/api
+	@bash -c "$$RUN_LOCAL_APP"
 
 # Run the API server only (hub-api).
 run-api:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test help tests tests-coverage check-coverage build build-api build-worker build-backfill-embeddings run run-worker run-backfill-embeddings init-db clean docker-up docker-down docker-clean deps install-tools fmt lint lint-new lint-openapi dev-setup test-all test-unit schemathesis install-hooks migrate-status migrate-validate river-migrate
+.PHONY: all test help tests tests-coverage check-coverage build build-api build-worker build-backfill-embeddings run run-api run-worker run-backfill-embeddings init-db clean docker-up docker-down docker-clean deps install-tools fmt lint lint-new lint-openapi dev-setup test-all test-unit schemathesis install-hooks migrate-status migrate-validate river-migrate
 
 # Aliases for checkmake/lint expectations
 all: build
@@ -13,8 +13,9 @@ help:
 	@echo "  make build-api                - Build hub-api only (bin/hub-api)"
 	@echo "  make build-worker             - Build hub-worker only (bin/hub-worker)"
 	@echo "  make build-backfill-embeddings - Build the backfill-embeddings command"
-	@echo "  make run              - Run the API server (hub-api)"
-	@echo "  make run-worker       - Run the worker (hub-worker)"
+	@echo "  make run              - Run River migrations, then hub-api and hub-worker"
+	@echo "  make run-api          - Run the API server only (hub-api)"
+	@echo "  make run-worker       - Run the worker only (hub-worker)"
 	@echo "  make run-backfill-embeddings - Run the backfill-embeddings command (enqueues embedding jobs; loads .env)"
 	@echo "  make test-unit        - Run unit tests (fast, no database)"
 	@echo "  make tests            - Run integration tests"
@@ -109,13 +110,33 @@ run-backfill-embeddings:
 	@if [ ! -f .env ]; then echo "Error: .env file required. Copy .env.example to .env and configure."; exit 1; fi && \
 	(set -a && . ./.env && set +a && go run ./cmd/backfill-embeddings)
 
-# Run the API server (hub-api).
+# Run the full local app: apply River migrations, then run hub-worker in the background and hub-api in the foreground.
 # Config: .env if present, else environment variables; env vars override .env. Copy .env.example to .env or set env vars.
-run:
+run: river-migrate
+	@echo "Starting hub-worker and hub-api..."
+	@set -e; \
+	go run ./cmd/worker & \
+	worker_pid=$$!; \
+	cleanup() { \
+		status=$$?; \
+		trap - INT TERM EXIT; \
+		if kill -0 "$$worker_pid" 2>/dev/null; then \
+			echo "Stopping hub-worker..."; \
+			kill "$$worker_pid" 2>/dev/null || true; \
+			wait "$$worker_pid" 2>/dev/null || true; \
+		fi; \
+		exit $$status; \
+	}; \
+	trap cleanup INT TERM EXIT; \
+	echo "Starting hub-api..."; \
+	go run ./cmd/api
+
+# Run the API server only (hub-api).
+run-api:
 	@echo "Starting hub-api..."
 	go run ./cmd/api
 
-# Run the worker (hub-worker). Config: .env if present, else env vars (same as run). Requires DATABASE_URL; API_KEY not required.
+# Run the worker only (hub-worker). Config: .env if present, else env vars (same as run). Requires DATABASE_URL; API_KEY not required.
 run-worker:
 	@echo "Starting hub-worker..."
 	go run ./cmd/worker
@@ -258,7 +279,7 @@ install-hooks:
 dev-setup: docker-up deps install-tools init-db install-hooks
 	@echo "Development environment ready!"
 	@echo "Set API_KEY environment variable for authentication"
-	@echo "Run 'make run' to start the API server"
+	@echo "Run 'make run' to apply River migrations and start hub-api with hub-worker"
 
 # Run Schemathesis API tests (all phases for thorough local testing)
 # Phases: examples (schema examples), coverage (boundary values), stateful (API sequences), fuzzing (random)

--- a/README.md
+++ b/README.md
@@ -92,14 +92,13 @@ For a local Hub setup:
 ```bash
 cp .env.example .env
 make dev-setup
-make river-migrate
 make run
 ```
 
-Run `make run-worker` in a separate terminal when you need webhook delivery or
-embedding workers. `make dev-setup` runs the Hub schema migrations through
-`make init-db`; `make river-migrate` applies River queue migrations needed by
-worker-backed jobs.
+`make run` applies River queue migrations and starts both `hub-api` and
+`hub-worker` for local webhook delivery and embedding jobs. Use `make run-api`
+or `make run-worker` only when you intentionally want to run one process on its
+own. `make dev-setup` runs the Hub schema migrations through `make init-db`.
 
 For the full Formbricks XM Suite UI, use the
 [`formbricks/formbricks`](https://github.com/formbricks/formbricks) repository

--- a/internal/api/handlers/feedback_records_handler.go
+++ b/internal/api/handlers/feedback_records_handler.go
@@ -45,7 +45,7 @@ func (h *FeedbackRecordsHandler) Create(w http.ResponseWriter, r *http.Request) 
 	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(&req); err != nil {
-		response.RespondBadRequest(w, response.JSONDecodeErrorDetail(err))
+		response.RespondInvalidRequestBody(w, err)
 
 		return
 	}
@@ -160,7 +160,7 @@ func (h *FeedbackRecordsHandler) Update(w http.ResponseWriter, r *http.Request) 
 	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(&req); err != nil {
-		response.RespondBadRequest(w, response.JSONDecodeErrorDetail(err))
+		response.RespondInvalidRequestBody(w, err)
 
 		return
 	}

--- a/internal/api/handlers/feedback_records_handler_test.go
+++ b/internal/api/handlers/feedback_records_handler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/formbricks/hub/internal/api/response"
 	"github.com/formbricks/hub/internal/models"
 )
 
@@ -64,6 +66,42 @@ func TestFeedbackRecordsHandler_List(t *testing.T) {
 		handler.List(rec, req)
 
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+func TestFeedbackRecordsHandler_Create(t *testing.T) {
+	t.Run("invalid field_type returns field-level problem details", func(t *testing.T) {
+		mock := &mockFeedbackRecordsService{}
+		handler := NewFeedbackRecordsHandler(mock)
+
+		body := []byte(`{
+			"source_type": "survey",
+			"field_id": "q1",
+			"field_type": "textt",
+			"tenant_id": "tenant-123",
+			"submission_id": "submission-123"
+		}`)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://test/v1/feedback-records", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+
+		handler.Create(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Header().Get("Content-Type"), "application/problem+json")
+
+		var problem response.ProblemDetails
+
+		err := json.Unmarshal(rec.Body.Bytes(), &problem)
+		require.NoError(t, err)
+
+		assert.Equal(t, response.ProblemTypeValidationError, problem.Type)
+		assert.NotEqual(t, "about:blank", problem.Type)
+		assert.Equal(t, "Validation Error", problem.Title)
+		require.Len(t, problem.Errors, 1)
+		assert.Equal(t, "field_type", problem.Errors[0].Location)
+		assert.Equal(t, "textt", problem.Errors[0].Value)
+		assert.Contains(t, problem.Errors[0].Message, "text")
+		assert.Contains(t, problem.Errors[0].Message, "date")
 	})
 }
 

--- a/internal/api/response/response.go
+++ b/internal/api/response/response.go
@@ -19,6 +19,8 @@ const (
 	ProblemTypeBadRequest = "https://hub.formbricks.com/problems/bad-request"
 	// ProblemTypeValidationError identifies request validation problems.
 	ProblemTypeValidationError = "https://hub.formbricks.com/problems/validation-error"
+	// ProblemTypeClientError identifies unclassified client-side request problems.
+	ProblemTypeClientError = "https://hub.formbricks.com/problems/client-error"
 	// ProblemTypeUnauthorized identifies authentication problems.
 	ProblemTypeUnauthorized = "https://hub.formbricks.com/problems/unauthorized"
 	// ProblemTypeNotFound identifies missing resource problems.
@@ -27,6 +29,8 @@ const (
 	ProblemTypeConflict = "https://hub.formbricks.com/problems/conflict"
 	// ProblemTypeForbidden identifies authorization problems.
 	ProblemTypeForbidden = "https://hub.formbricks.com/problems/forbidden"
+	// ProblemTypeMethodNotAllowed identifies unsupported HTTP method problems.
+	ProblemTypeMethodNotAllowed = "https://hub.formbricks.com/problems/method-not-allowed"
 	// ProblemTypeServiceUnavailable identifies temporary dependency problems.
 	ProblemTypeServiceUnavailable = "https://hub.formbricks.com/problems/service-unavailable"
 	// ProblemTypeInternalServerError identifies unexpected server problems.
@@ -110,6 +114,8 @@ func problemTypeForStatus(statusCode int) string {
 		return ProblemTypeUnauthorized
 	case http.StatusForbidden:
 		return ProblemTypeForbidden
+	case http.StatusMethodNotAllowed:
+		return ProblemTypeMethodNotAllowed
 	case http.StatusNotFound:
 		return ProblemTypeNotFound
 	case http.StatusConflict:
@@ -119,6 +125,10 @@ func problemTypeForStatus(statusCode int) string {
 	case http.StatusInternalServerError:
 		return ProblemTypeInternalServerError
 	default:
+		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+			return ProblemTypeClientError
+		}
+
 		return ProblemTypeInternalServerError
 	}
 }

--- a/internal/api/response/response.go
+++ b/internal/api/response/response.go
@@ -10,6 +10,27 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
+
+	"github.com/formbricks/hub/internal/models"
+)
+
+const (
+	// ProblemTypeBadRequest identifies malformed request problems.
+	ProblemTypeBadRequest = "https://hub.formbricks.com/problems/bad-request"
+	// ProblemTypeValidationError identifies request validation problems.
+	ProblemTypeValidationError = "https://hub.formbricks.com/problems/validation-error"
+	// ProblemTypeUnauthorized identifies authentication problems.
+	ProblemTypeUnauthorized = "https://hub.formbricks.com/problems/unauthorized"
+	// ProblemTypeNotFound identifies missing resource problems.
+	ProblemTypeNotFound = "https://hub.formbricks.com/problems/not-found"
+	// ProblemTypeConflict identifies resource conflict problems.
+	ProblemTypeConflict = "https://hub.formbricks.com/problems/conflict"
+	// ProblemTypeForbidden identifies authorization problems.
+	ProblemTypeForbidden = "https://hub.formbricks.com/problems/forbidden"
+	// ProblemTypeServiceUnavailable identifies temporary dependency problems.
+	ProblemTypeServiceUnavailable = "https://hub.formbricks.com/problems/service-unavailable"
+	// ProblemTypeInternalServerError identifies unexpected server problems.
+	ProblemTypeInternalServerError = "https://hub.formbricks.com/problems/internal-server-error"
 )
 
 // ErrorDetail represents a single error detail in RFC 7807 Problem Details.
@@ -32,17 +53,73 @@ type ProblemDetails struct {
 // RespondError writes an RFC 7807 Problem Details error response.
 func RespondError(w http.ResponseWriter, statusCode int, title, detail string) {
 	problem := ProblemDetails{
-		Type:   "about:blank",
+		Type:   problemTypeForStatus(statusCode),
 		Title:  title,
 		Status: statusCode,
 		Detail: detail,
 	}
 
+	respondProblem(w, statusCode, problem)
+}
+
+// RespondInvalidRequestBody writes a 400 response for JSON request body decoding failures.
+func RespondInvalidRequestBody(w http.ResponseWriter, err error) {
+	problemType := jsonDecodeProblemType(err)
+
+	problem := ProblemDetails{
+		Type:   problemType,
+		Title:  jsonDecodeProblemTitle(problemType),
+		Status: http.StatusBadRequest,
+		Detail: JSONDecodeErrorDetail(err),
+		Errors: JSONDecodeErrorDetails(err),
+	}
+
+	respondProblem(w, http.StatusBadRequest, problem)
+}
+
+func jsonDecodeProblemType(err error) string {
+	if _, ok := invalidFieldTypeErrorDetail(err); ok {
+		return ProblemTypeValidationError
+	}
+
+	return ProblemTypeBadRequest
+}
+
+func jsonDecodeProblemTitle(problemType string) string {
+	if problemType == ProblemTypeValidationError {
+		return "Validation Error"
+	}
+
+	return "Bad Request"
+}
+
+func respondProblem(w http.ResponseWriter, statusCode int, problem ProblemDetails) {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(statusCode)
 
 	if err := json.NewEncoder(w).Encode(problem); err != nil {
 		slog.Error("Failed to encode error response", "error", err)
+	}
+}
+
+func problemTypeForStatus(statusCode int) string {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return ProblemTypeBadRequest
+	case http.StatusUnauthorized:
+		return ProblemTypeUnauthorized
+	case http.StatusForbidden:
+		return ProblemTypeForbidden
+	case http.StatusNotFound:
+		return ProblemTypeNotFound
+	case http.StatusConflict:
+		return ProblemTypeConflict
+	case http.StatusServiceUnavailable:
+		return ProblemTypeServiceUnavailable
+	case http.StatusInternalServerError:
+		return ProblemTypeInternalServerError
+	default:
+		return ProblemTypeInternalServerError
 	}
 }
 
@@ -57,6 +134,10 @@ func RespondBadRequest(w http.ResponseWriter, detail string) {
 func JSONDecodeErrorDetail(err error) string {
 	if err == nil {
 		return "Invalid request body"
+	}
+
+	if detail, ok := invalidFieldTypeErrorDetail(err); ok {
+		return detail.Message
 	}
 
 	var syntaxErr *json.SyntaxError
@@ -76,6 +157,32 @@ func JSONDecodeErrorDetail(err error) string {
 	}
 
 	return "Invalid request body"
+}
+
+// JSONDecodeErrorDetails returns field-level details for JSON request body decoding failures.
+func JSONDecodeErrorDetails(err error) []ErrorDetail {
+	if detail, ok := invalidFieldTypeErrorDetail(err); ok {
+		return []ErrorDetail{detail}
+	}
+
+	return nil
+}
+
+func invalidFieldTypeErrorDetail(err error) (ErrorDetail, bool) {
+	var invalidFieldType *models.InvalidFieldTypeError
+	if !errors.As(err, &invalidFieldType) {
+		return ErrorDetail{}, false
+	}
+
+	return ErrorDetail{
+		Location: "field_type",
+		Message: fmt.Sprintf(
+			"field_type has invalid value %q; must be one of: %s",
+			invalidFieldType.Value,
+			models.ValidFieldTypeValuesString(),
+		),
+		Value: invalidFieldType.Value,
+	}, true
 }
 
 // fieldNameForAPI converts a struct field path (e.g. "TenantID" or "X.Y") to API-style snake_case.

--- a/internal/api/response/response_test.go
+++ b/internal/api/response/response_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/models"
 )
 
 func TestJSONDecodeErrorDetail(t *testing.T) {
@@ -48,5 +50,25 @@ func TestJSONDecodeErrorDetail(t *testing.T) {
 		detail := JSONDecodeErrorDetail(err)
 		assert.Contains(t, detail, "unknown field")
 		assert.Contains(t, detail, "tenantId")
+	})
+
+	t.Run("invalid field type returns enum details", func(t *testing.T) {
+		var req struct {
+			FieldType models.FieldType `json:"field_type"`
+		}
+
+		err := json.Unmarshal([]byte(`{"field_type":"textt"}`), &req)
+		require.Error(t, err)
+
+		detail := JSONDecodeErrorDetail(err)
+		assert.Contains(t, detail, "field_type")
+		assert.Contains(t, detail, "text")
+		assert.Contains(t, detail, "date")
+
+		details := JSONDecodeErrorDetails(err)
+		require.Len(t, details, 1)
+		assert.Equal(t, "field_type", details[0].Location)
+		assert.Equal(t, "textt", details[0].Value)
+		assert.Contains(t, details[0].Message, "rating")
 	})
 }

--- a/internal/api/response/response_test.go
+++ b/internal/api/response/response_test.go
@@ -3,6 +3,8 @@ package response
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,47 @@ import (
 
 	"github.com/formbricks/hub/internal/models"
 )
+
+func TestRespondErrorProblemType(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantType   string
+	}{
+		{
+			name:       "method not allowed",
+			statusCode: http.StatusMethodNotAllowed,
+			wantType:   ProblemTypeMethodNotAllowed,
+		},
+		{
+			name:       "unlisted client error falls back to client error",
+			statusCode: http.StatusTooManyRequests,
+			wantType:   ProblemTypeClientError,
+		},
+		{
+			name:       "unlisted server error falls back to internal server error",
+			statusCode: http.StatusBadGateway,
+			wantType:   ProblemTypeInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+
+			RespondError(rec, tt.statusCode, http.StatusText(tt.statusCode), "test detail")
+
+			assert.Equal(t, tt.statusCode, rec.Code)
+
+			var problem ProblemDetails
+
+			err := json.Unmarshal(rec.Body.Bytes(), &problem)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, problem.Type)
+			assert.Equal(t, tt.statusCode, problem.Status)
+		})
+	}
+}
 
 func TestJSONDecodeErrorDetail(t *testing.T) {
 	t.Run("nil returns generic message", func(t *testing.T) {

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -109,10 +109,37 @@ func formatValidationErrors(err error) error {
 			messages = append(messages, formatFieldError(fieldError))
 		}
 
-		return fmt.Errorf("%w: %s", ErrValidationFailed, strings.Join(messages, "; "))
+		return requestValidationError{
+			message:          fmt.Sprintf("%s: %s", ErrValidationFailed, strings.Join(messages, "; ")),
+			validationErrors: validationErrors,
+		}
 	}
 
 	return err
+}
+
+type requestValidationError struct {
+	message          string
+	validationErrors validator.ValidationErrors
+}
+
+func (e requestValidationError) Error() string {
+	return e.message
+}
+
+func (e requestValidationError) Is(target error) bool {
+	return target == ErrValidationFailed
+}
+
+func (e requestValidationError) As(target any) bool {
+	validationErrors, ok := target.(*validator.ValidationErrors)
+	if !ok {
+		return false
+	}
+
+	*validationErrors = e.validationErrors
+
+	return true
 }
 
 // formatFieldError formats a single field validation error.

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -29,12 +29,26 @@ var (
 	decoder  *form.Decoder
 )
 
+const tagSplitParts = 2
+
 // ErrValidationFailed is returned when struct validation fails (err113).
 var ErrValidationFailed = errors.New("validation failed")
 
 func init() {
 	validate = validator.New()
 	decoder = form.NewDecoder()
+
+	validate.RegisterTagNameFunc(func(field reflect.StructField) string {
+		if name := tagName(field, "json"); name != "" {
+			return name
+		}
+
+		if name := tagName(field, "form"); name != "" {
+			return name
+		}
+
+		return field.Name
+	})
 
 	// Register custom validators
 	if err := validate.RegisterValidation("field_type", validateFieldType); err != nil {
@@ -120,7 +134,7 @@ func formatFieldError(fieldError validator.FieldError) string {
 	case "oneof":
 		return fmt.Sprintf("%s must be one of: %s", field, fieldError.Param())
 	case "field_type":
-		return field + " must be one of: text, categorical, nps, csat, ces, rating, number, boolean, date"
+		return field + " must be one of: " + models.ValidFieldTypeValuesString()
 	case "uuid":
 		return field + " must be a valid UUID"
 	case "rfc3339":
@@ -176,7 +190,7 @@ func RespondValidationError(w http.ResponseWriter, err error) {
 	details := GetValidationErrorDetails(err)
 
 	problem := response.ProblemDetails{
-		Type:   "about:blank",
+		Type:   response.ProblemTypeValidationError,
 		Title:  "Validation Error",
 		Status: http.StatusBadRequest,
 		Detail: err.Error(),
@@ -253,4 +267,13 @@ func validateNoNullBytes(fl validator.FieldLevel) bool {
 	value := field.String()
 
 	return !strings.Contains(value, "\x00")
+}
+
+func tagName(field reflect.StructField, key string) string {
+	name := strings.SplitN(field.Tag.Get(key), ",", tagSplitParts)[0]
+	if name == "-" {
+		return ""
+	}
+
+	return name
 }

--- a/internal/api/validation/validation_test.go
+++ b/internal/api/validation/validation_test.go
@@ -1,0 +1,64 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStructUsesAPITagNames(t *testing.T) {
+	t.Run("json tag", func(t *testing.T) {
+		var req struct {
+			FieldID string `json:"field_id" validate:"required"`
+		}
+
+		err := ValidateStruct(req)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrValidationFailed)
+		assert.Equal(t, "validation failed: field_id is required", err.Error())
+
+		details := GetValidationErrorDetails(err)
+		require.Len(t, details, 1)
+		assert.Equal(t, "field_id", details[0].Location)
+		assert.Equal(t, "field_id is required", details[0].Message)
+		assert.Empty(t, details[0].Value)
+	})
+
+	t.Run("form tag", func(t *testing.T) {
+		var filters struct {
+			TenantID *string `form:"tenant_id" validate:"required"`
+		}
+
+		err := ValidateStruct(filters)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrValidationFailed)
+		assert.Equal(t, "validation failed: tenant_id is required", err.Error())
+
+		details := GetValidationErrorDetails(err)
+		require.Len(t, details, 1)
+		assert.Equal(t, "tenant_id", details[0].Location)
+		assert.Equal(t, "tenant_id is required", details[0].Message)
+		assert.Nil(t, details[0].Value)
+	})
+}
+
+func TestValidateStructPreservesValidationDetails(t *testing.T) {
+	valueText := "contains\x00null"
+	req := struct {
+		ValueText *string `json:"value_text,omitempty" validate:"omitempty,no_null_bytes"`
+	}{
+		ValueText: &valueText,
+	}
+
+	err := ValidateStruct(req)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrValidationFailed)
+	assert.Equal(t, "validation failed: value_text must not contain NULL bytes", err.Error())
+
+	details := GetValidationErrorDetails(err)
+	require.Len(t, details, 1)
+	assert.Equal(t, "value_text", details[0].Location)
+	assert.Equal(t, "value_text must not contain NULL bytes", details[0].Message)
+	assert.Equal(t, valueText, details[0].Value)
+}

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,17 +30,66 @@ const (
 	FieldTypeDate        FieldType = "date"
 )
 
+var validFieldTypeValues = []FieldType{
+	FieldTypeText,
+	FieldTypeCategorical,
+	FieldTypeNPS,
+	FieldTypeCSAT,
+	FieldTypeCES,
+	FieldTypeRating,
+	FieldTypeNumber,
+	FieldTypeBoolean,
+	FieldTypeDate,
+}
+
+var validFieldTypeValueNames = func() []string {
+	values := make([]string, 0, len(validFieldTypeValues))
+	for _, fieldType := range validFieldTypeValues {
+		values = append(values, string(fieldType))
+	}
+
+	return values
+}()
+
+var validFieldTypeValuesString = strings.Join(validFieldTypeValueNames, ", ")
+
 // ValidFieldTypes contains all valid field type values (set membership).
-var ValidFieldTypes = map[FieldType]struct{}{
-	FieldTypeText:        {},
-	FieldTypeCategorical: {},
-	FieldTypeNPS:         {},
-	FieldTypeCSAT:        {},
-	FieldTypeCES:         {},
-	FieldTypeRating:      {},
-	FieldTypeNumber:      {},
-	FieldTypeBoolean:     {},
-	FieldTypeDate:        {},
+var ValidFieldTypes = func() map[FieldType]struct{} {
+	values := make(map[FieldType]struct{}, len(validFieldTypeValues))
+	for _, fieldType := range validFieldTypeValues {
+		values[fieldType] = struct{}{}
+	}
+
+	return values
+}()
+
+// InvalidFieldTypeError describes a rejected field_type enum value.
+type InvalidFieldTypeError struct {
+	Value string
+}
+
+// Error implements the error interface.
+func (e *InvalidFieldTypeError) Error() string {
+	if e == nil {
+		return ErrInvalidFieldType.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", ErrInvalidFieldType, e.Value)
+}
+
+// Unwrap allows errors.Is(err, ErrInvalidFieldType).
+func (e *InvalidFieldTypeError) Unwrap() error {
+	return ErrInvalidFieldType
+}
+
+// ValidFieldTypeValues returns valid field_type values in API documentation order.
+func ValidFieldTypeValues() []string {
+	return append([]string(nil), validFieldTypeValueNames...)
+}
+
+// ValidFieldTypeValuesString returns a comma-separated list of valid field_type values.
+func ValidFieldTypeValuesString() string {
+	return validFieldTypeValuesString
 }
 
 // IsValid returns true if the FieldType is valid.
@@ -57,7 +107,7 @@ func (ft *FieldType) IsValid() bool {
 func ParseFieldType(s string) (FieldType, error) {
 	ft := FieldType(s)
 	if _, valid := ValidFieldTypes[ft]; !valid {
-		return "", fmt.Errorf("%w: %s", ErrInvalidFieldType, s)
+		return "", &InvalidFieldTypeError{Value: s}
 	}
 
 	return ft, nil

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -204,8 +204,8 @@ paths:
                                 validation_error:
                                     summary: Validation error
                                     value:
-                                        type: "about:blank"
-                                        title: "Bad Request"
+                                        type: "https://hub.formbricks.com/problems/validation-error"
+                                        title: "Validation Error"
                                         status: 400
                                         detail: "Validation failed"
                                         instance: "https://hub.formbricks.com/v1/feedback-records"
@@ -365,6 +365,18 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+                            examples:
+                                invalid_field_type:
+                                    summary: Invalid field_type enum
+                                    value:
+                                        type: "https://hub.formbricks.com/problems/validation-error"
+                                        title: "Validation Error"
+                                        status: 400
+                                        detail: "field_type has invalid value \"textt\"; must be one of: text, categorical, nps, csat, ces, rating, number, boolean, date"
+                                        errors:
+                                            - location: "field_type"
+                                              message: "field_type has invalid value \"textt\"; must be one of: text, categorical, nps, csat, ces, rating, number, boolean, date"
+                                              value: "textt"
                 "409":
                     description: Conflict – a feedback record with the same tenant_id, submission_id, and field_id already exists (idempotent create).
                     content:
@@ -598,7 +610,7 @@ paths:
                                 not_found:
                                     summary: Record not found
                                     value:
-                                        type: "about:blank"
+                                        type: "https://hub.formbricks.com/problems/not-found"
                                         title: "Not Found"
                                         status: 404
                                         detail: "Feedback record with ID '018e1234-5678-9abc-def0-123456789abc' not found"
@@ -606,8 +618,8 @@ paths:
                                 validation_error:
                                     summary: Validation error
                                     value:
-                                        type: "about:blank"
-                                        title: "Bad Request"
+                                        type: "https://hub.formbricks.com/problems/validation-error"
+                                        title: "Validation Error"
                                         status: 400
                                         detail: "Invalid update request"
                                         instance: "https://hub.formbricks.com/v1/feedback-records/018e1234-5678-9abc-def0-123456789abc"
@@ -1287,9 +1299,8 @@ components:
                     type: string
                     description: A URI reference to human-readable documentation for the error.
                     format: uri
-                    default: about:blank
                     examples:
-                        - https://example.com/errors/example
+                        - https://hub.formbricks.com/problems/bad-request
         FeedbackRecordData:
             type: object
             additionalProperties: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -207,12 +207,11 @@ paths:
                                         type: "https://hub.formbricks.com/problems/validation-error"
                                         title: "Validation Error"
                                         status: 400
-                                        detail: "Validation failed"
+                                        detail: "validation failed: tenant_id is required"
                                         instance: "https://hub.formbricks.com/v1/feedback-records"
                                         errors:
-                                            - location: "body.field_id"
-                                              message: "Field is required"
-                                              value: null
+                                            - location: "tenant_id"
+                                              message: "tenant_id is required"
         post:
             tags:
                 - Feedback Records
@@ -621,12 +620,12 @@ paths:
                                         type: "https://hub.formbricks.com/problems/validation-error"
                                         title: "Validation Error"
                                         status: 400
-                                        detail: "Invalid update request"
+                                        detail: "validation failed: value_text must not contain NULL bytes"
                                         instance: "https://hub.formbricks.com/v1/feedback-records/018e1234-5678-9abc-def0-123456789abc"
                                         errors:
-                                            - location: "body.value_text"
-                                              message: "Text value cannot be empty"
-                                              value: ""
+                                            - location: "value_text"
+                                              message: "value_text must not contain NULL bytes"
+                                              value: 'contains\u0000null'
     /v1/feedback-records/search/semantic:
         post:
             tags:

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1295,7 +1295,7 @@ func TestWebhooksCreateRequiresTenantID(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, "Validation Error", problem.Title)
-	assert.Contains(t, problem.Detail, "TenantID is required")
+	assert.Contains(t, problem.Detail, "tenant_id is required")
 }
 
 // TestWebhooksInvalidSigningKey asserts that create and update reject invalid signing_key with 400.


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-791 and ENG-797.

This PR improves feedback record validation errors and local development startup:

- Returns detailed RFC 7807 problem responses for invalid `field_type` values in `POST /v1/feedback-records`
- Includes the failing field location, rejected value, and valid enum options
- Replaces `about:blank` problem types with stable Hub problem type URIs
- Updates OpenAPI examples to match runtime behavior
- Updates `make run` so local development runs River migrations and starts both `hub-api` and `hub-worker`
- Adds `make run-api` for API-only local runs
- Updates README local setup instructions

Example invalid `field_type` response:

```json
{
  "type": "https://hub.formbricks.com/problems/validation-error",
  "title": "Validation Error",
  "status": 400,
  "detail": "field_type has invalid value \"textt\"; must be one of: text, categorical, nps, csat, ces, rating, number, boolean, date",
  "errors": [
    {
      "location": "field_type",
      "message": "field_type has invalid value \"textt\"; must be one of: text, categorical, nps, csat, ces, rating, number, boolean, date",
      "value": "textt"
    }
  ]
}
```

## How should this be tested?

- `make lint`
- `go test ./internal/... ./pkg/...`
- `make -n run`
- Local smoke test against running API/worker:
  - `GET /health` returned `200`
  - Invalid `POST /v1/feedback-records` with `field_type: "textt"` returned `400` with detailed `validation-error`
  - Valid `POST /v1/feedback-records` with `field_type: "text"` returned `201`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [x] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes
