### PR TITLE
chore: streamline compose migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ API_KEY=your-secret-api-key-here
 # Postgres host port for docker-compose (optional). Default: 5432. Override only if 5432 is in use (e.g. POSTGRES_PORT=5433); keep DATABASE_URL in sync.
 # POSTGRES_PORT=5432
 
-# Hub image tag for docker-compose migration container (optional). Default: latest.
-# HUB_IMAGE_TAG=latest
+# Hub image tag for docker-compose migration container (optional). Default: 0.2.0.
+# Use a pinned release tag, not latest, so migration tooling is reproducible.
+# HUB_IMAGE_TAG=0.2.0
 
 # Database connection URL (optional). Port must match POSTGRES_PORT when you override it.
 # Default: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ API_KEY=your-secret-api-key-here
 # Postgres host port for docker-compose (optional). Default: 5432. Override only if 5432 is in use (e.g. POSTGRES_PORT=5433); keep DATABASE_URL in sync.
 # POSTGRES_PORT=5432
 
+# Hub image tag for docker-compose migration container (optional). Default: latest.
+# HUB_IMAGE_TAG=latest
+
 # Database connection URL (optional). Port must match POSTGRES_PORT when you override it.
 # Default: postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable
 # Format: postgres://username:password@host:port/database?sslmode=disable
@@ -94,7 +97,7 @@ WEBHOOK_MAX_COUNT=500
 # GOOGLE_APPLICATION_CREDENTIALS=    (optional; for google-gemini when outside Google Cloud: path to service account key JSON)
 # EMBEDDING_MODEL=<model name>        (required to enable embeddings; no default)
 
-# River UI basic auth (optional, used when running River UI via docker compose)
-# Defaults: admin / changeme if unset
+# Local River UI basic auth (optional, used by docker compose). Change these for your local setup as needed.
+# compose.yml defaults to admin / changeme if these are unset.
 RIVER_BASIC_AUTH_USER=admin
 RIVER_BASIC_AUTH_PASS=changeme

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ This repository contains the standalone Hub API and worker. The local
 `hub-migrate` container, and River UI. The migration container uses the packaged
 Hub image for `goose` and `river`, and bind-mounts this checkout's
 `migrations/` directory so the database schema matches the branch you are
-working on. Docker setup does not require migration tools on the host. It does
-not start `hub-api` or `hub-worker`; run those from this repository after the
-database is ready.
+working on. The image tag defaults to the current Hub release and should stay
+pinned if you override `HUB_IMAGE_TAG`. Docker setup does not require migration
+tools on the host. It does not start `hub-api` or `hub-worker`; run those from
+this repository after the database is ready.
 
 For a local Hub setup:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ If you want to evaluate Hub quickly, start with the docs:
 ### Local development in this repository
 
 This repository contains the standalone Hub API and worker. The local
-`compose.yml` starts dependency services only: PostgreSQL and River UI. It does
+`compose.yml` starts dependency services only: PostgreSQL, a one-shot
+`hub-migrate` container, and River UI. The migration container uses the packaged
+Hub image for `goose` and `river`, and bind-mounts this checkout's
+`migrations/` directory so the database schema matches the branch you are
+working on. Docker setup does not require migration tools on the host. It does
 not start `hub-api` or `hub-worker`; run those from this repository after the
 database is ready.
 
@@ -98,7 +102,15 @@ make run
 `make run` applies River queue migrations and starts both `hub-api` and
 `hub-worker` for local webhook delivery and embedding jobs. Use `make run-api`
 or `make run-worker` only when you intentionally want to run one process on its
-own. `make dev-setup` runs the Hub schema migrations through `make init-db`.
+own. `make dev-setup` also runs the local Hub schema migrations through
+`make init-db`, which is useful when you are changing migration files in this
+repository.
+
+The public Docker quickstart at [hub.formbricks.com/quickstart](https://hub.formbricks.com/quickstart/)
+is maintained outside this repository. Its Compose example should use the same
+one-shot migration service pattern, but rely on the published Hub image's bundled
+`/app/migrations` because quickstart users may not have this repository checked
+out.
 
 For the full Formbricks XM Suite UI, use the
 [`formbricks/formbricks`](https://github.com/formbricks/formbricks) repository

--- a/compose.yml
+++ b/compose.yml
@@ -24,7 +24,7 @@ services:
   # One-shot migration container for Docker-only setup. The Hub image supplies goose and river;
   # the bind mount keeps migrations aligned with this checkout.
   hub-migrate:
-    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-latest}
+    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.2.0}
     container_name: formbricks_hub_migrate
     restart: "no"
     entrypoint: ["sh", "-ec"]

--- a/compose.yml
+++ b/compose.yml
@@ -21,19 +21,46 @@ services:
       postgres
       -c shared_preload_libraries=vector
 
+  # One-shot migration container for Docker-only setup. The Hub image supplies goose and river;
+  # the bind mount keeps migrations aligned with this checkout.
+  hub-migrate:
+    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-latest}
+    container_name: formbricks_hub_migrate
+    restart: "no"
+    entrypoint: ["sh", "-ec"]
+    command:
+      - |
+        test -x /usr/local/bin/goose ||
+        { echo "Migration tool missing: /usr/local/bin/goose"; exit 1; }
+        test -x /usr/local/bin/river ||
+        { echo "Migration tool missing: /usr/local/bin/river"; exit 1; }
+        test -d /app/migrations ||
+        { echo "Migration directory missing: /app/migrations"; exit 1; }
+        /usr/local/bin/goose -dir /app/migrations postgres "$$DATABASE_URL" up
+        /usr/local/bin/river migrate-up --database-url "$$DATABASE_URL"
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/test_db?sslmode=disable
+    volumes:
+      - ./migrations:/app/migrations:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   # River UI - web dashboard for River job queue (webhook delivery jobs)
   riverui:
     image: ghcr.io/riverqueue/riverui:latest
     container_name: formbricks_riverui
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/test_db?sslmode=disable
-      RIVER_BASIC_AUTH_USER: ${RIVER_BASIC_AUTH_USER}
-      RIVER_BASIC_AUTH_PASS: ${RIVER_BASIC_AUTH_PASS}
+      RIVER_BASIC_AUTH_USER: ${RIVER_BASIC_AUTH_USER:-admin}
+      RIVER_BASIC_AUTH_PASS: ${RIVER_BASIC_AUTH_PASS:-changeme}
     ports:
       - '8081:8080'
     depends_on:
       postgres:
         condition: service_healthy
+      hub-migrate:
+        condition: service_completed_successfully
 
 volumes:
   postgres_data:

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,10 +6,9 @@ This directory contains integration tests for the Formbricks Hub API.
 
 Before running the tests, ensure:
 
-1. **PostgreSQL is running** (e.g. `make docker-up`). `make docker-up` starts dependency containers, currently PostgreSQL and River UI; it does not start the Hub API or worker. The tests use the connection string from `.env` (`DATABASE_URL`) when set; if empty, the default `postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable` is used. If you set `POSTGRES_PORT` in `.env`, keep `DATABASE_URL` in sync. If you see `password authentication failed for user "postgres"`, start the stack with `make docker-up` and run `make init-db`.
-2. **Database schema** has been initialized (`make init-db`).
-3. **River queue migrations** have been applied (`make river-migrate`) when testing worker-backed webhook delivery flows.
-4. **API_KEY** is set automatically by the tests; you do not need to set it.
+1. **PostgreSQL is running** (e.g. `make docker-up`). `make docker-up` starts dependency containers: PostgreSQL, the one-shot `hub-migrate` container, and River UI; it does not start the Hub API or worker. The tests use the connection string from `.env` (`DATABASE_URL`) when set; if empty, the default `postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable` is used. If you set `POSTGRES_PORT` in `.env`, keep `DATABASE_URL` in sync.
+2. **Database schema and River queue migrations** have been initialized. The default `make docker-up` path runs them through the packaged `hub-migrate` container, using this checkout's `migrations/` directory. If you are editing local migration files after the stack is already running, run `make init-db` and `make river-migrate` against your test database.
+3. **API_KEY** is set automatically by the tests; you do not need to set it.
 
 ## Running Tests
 


### PR DESCRIPTION
## What does this PR do?

Fixes:
- ENG-792: Resolve River Console warnings
- ENG-795: Add a migration init container to `compose.yml` for seamless quickstart setup
- ENG-794: Quickstart prerequisites missing Go as a requirement for database migration

This PR improves the local Docker Compose setup so the default path is quieter and easier to use:

- Adds a one-shot `hub-migrate` service that waits for Postgres, then runs Hub goose migrations and River queue migrations.
- Uses the published Hub image for `goose` and `river`, while bind-mounting this checkout’s `migrations/` directory so local development stays aligned with the current branch.
- Makes River UI wait for `hub-migrate` to complete successfully before starting.
- Adds Compose defaults for River UI basic auth env vars to avoid unset-variable warnings.
- Updates README/test docs to explain that Docker setup no longer requires host Go/goose/river for database initialization.

The public quickstart docs live outside this repo and should use the same one-shot migration pattern with the published image’s bundled `/app/migrations`.

## How should this be tested?

- `docker compose --env-file /dev/null config`
  - verifies Compose renders without River UI env warnings
  - verifies `hub-migrate` is present
  - verifies `hub-migrate` bind-mounts `./migrations:/app/migrations:ro`
  - verifies River UI depends on successful `hub-migrate` completion

- `goose -dir migrations validate`

- `go test ./cmd/api ./cmd/worker ./internal/config ./internal/workers`

Note: an isolated full Docker smoke test was attempted, but this machine already had a fixed-name `formbricks_postgres` container, which conflicts with this repo’s existing `container_name` convention.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [ ] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [x] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes