### PR TITLE
feat(helm): add worker and embeddings runtime

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hub
 description: Formbricks Hub - Experience Management API
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.2.0"
 keywords:
   - formbricks
@@ -14,5 +14,7 @@ maintainers:
   - name: Formbricks
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade to Hub 0.2.0
+    - kind: added
+      description: Add hub-worker deployment support
+    - kind: added
+      description: Add optional self-hosted embeddings runtime support

--- a/charts/hub/templates/NOTES.txt
+++ b/charts/hub/templates/NOTES.txt
@@ -20,7 +20,7 @@ Recommended production configuration
 - hub-worker: keep values.worker.enabled=true unless another deployment processes the same River queues.
 {{- if .Values.embeddings.enabled }}
 - embeddings: provide values.embeddings.huggingFace.token or values.embeddings.huggingFace.existingSecret
-  for gated models such as google/embeddinggemma-300m.
+  only when using private or gated models.
 {{- end }}
 
 Secret management options (choose one):

--- a/charts/hub/templates/NOTES.txt
+++ b/charts/hub/templates/NOTES.txt
@@ -1,6 +1,12 @@
 Thank you for installing {{ .Chart.Name }}.
 
 The Hub API service is now deploying.
+{{- if .Values.worker.enabled }}
+The Hub worker is also deploying for River webhook and embedding jobs.
+{{- end }}
+{{- if .Values.embeddings.enabled }}
+The self-hosted embeddings runtime is enabled and exposed only as an internal ClusterIP service.
+{{- end }}
 
 Required configuration
 ----------------------
@@ -11,6 +17,11 @@ Recommended production configuration
 ------------------------------------
 - PUBLIC_BASE_URL (ConfigMap/env): set this when Hub is exposed through ingress, TLS termination,
   or a reverse-proxy path prefix so /openapi.yaml and /openapi.json advertise the correct public URL.
+- hub-worker: keep values.worker.enabled=true unless another deployment processes the same River queues.
+{{- if .Values.embeddings.enabled }}
+- embeddings: provide values.embeddings.huggingFace.token or values.embeddings.huggingFace.existingSecret
+  for gated models such as google/embeddinggemma-300m.
+{{- end }}
 
 Secret management options (choose one):
 1) Chart-managed Secret:

--- a/charts/hub/templates/_helpers.tpl
+++ b/charts/hub/templates/_helpers.tpl
@@ -81,6 +81,115 @@ Secret name
 {{- end -}}
 
 {{/*
+Hub worker resource name and selectors. Worker pods must not match the API
+Service selector, because workers do not expose HTTP.
+*/}}
+{{- define "hub.workerName" -}}
+{{- printf "%s-worker" (include "hub.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hub.workerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "hub.workerName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Hub embeddings runtime resource name and selectors.
+*/}}
+{{- define "hub.embeddingsName" -}}
+{{- printf "%s-embeddings" (include "hub.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hub.embeddingsSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "hub.embeddingsName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Secret used by Hub and the embeddings runtime for the embeddings API key.
+*/}}
+{{- define "hub.embeddingsSecretName" -}}
+{{- default (printf "%s-secret" (include "hub.embeddingsName" .)) .Values.embeddings.auth.existingSecret -}}
+{{- end -}}
+
+{{/*
+Secret used by the embeddings runtime for Hugging Face access.
+*/}}
+{{- define "hub.embeddingsHuggingFaceSecretName" -}}
+{{- default (include "hub.embeddingsSecretName" .) .Values.embeddings.huggingFace.existingSecret -}}
+{{- end -}}
+
+{{/*
+Model name Hub sends to the OpenAI-compatible embeddings endpoint.
+*/}}
+{{- define "hub.embeddingsServedModelName" -}}
+{{- default .Values.embeddings.model .Values.embeddings.servedModelName -}}
+{{- end -}}
+
+{{/*
+OpenAI-compatible embeddings base URL used by Hub.
+*/}}
+{{- define "hub.embeddingsBaseURL" -}}
+{{- if .Values.embeddings.baseUrl -}}
+{{- .Values.embeddings.baseUrl -}}
+{{- else -}}
+{{- printf "http://%s:%v/v1" (include "hub.embeddingsName" .) (.Values.embeddings.service.port | default .Values.embeddings.port) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Embedding API key value for the generated embeddings secret.
+*/}}
+{{- define "hub.embeddingsApiKey" -}}
+{{- $secretName := include "hub.embeddingsSecretName" . }}
+{{- $secretKey := .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- if and $secret (index $secret.data $secretKey) }}
+    {{- index $secret.data $secretKey | b64dec -}}
+{{- else if .Values.embeddings.auth.apiKey }}
+    {{- .Values.embeddings.auth.apiKey -}}
+{{- else if .Values.secrets.stringData.EMBEDDING_PROVIDER_API_KEY }}
+    {{- .Values.secrets.stringData.EMBEDDING_PROVIDER_API_KEY -}}
+{{- else }}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Shared Hub embedding env. These values are managed from embeddings when the
+self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
+*/}}
+{{- define "hub.embeddingEnv" -}}
+{{- if .Values.embeddings.enabled }}
+- name: EMBEDDING_PROVIDER
+  value: "openai"
+- name: EMBEDDING_MODEL
+  value: {{ include "hub.embeddingsServedModelName" . | quote }}
+- name: EMBEDDING_BASE_URL
+  value: {{ include "hub.embeddingsBaseURL" . | quote }}
+- name: EMBEDDING_PROVIDER_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "hub.embeddingsSecretName" . }}
+      key: {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}
+- name: EMBEDDING_MAX_CONCURRENT
+  value: {{ .Values.embeddings.maxConcurrent | quote }}
+- name: EMBEDDING_NORMALIZE
+  value: {{ .Values.embeddings.normalize | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns true when an env var is managed by embeddings and should not be rendered from extraEnv.
+*/}}
+{{- define "hub.embeddingEnvManaged" -}}
+{{- $key := .key -}}
+{{- if has $key (list "EMBEDDING_PROVIDER" "EMBEDDING_MODEL" "EMBEDDING_BASE_URL" "EMBEDDING_PROVIDER_API_KEY" "EMBEDDING_MAX_CONCURRENT" "EMBEDDING_NORMALIZE") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the image reference
 */}}
 {{- define "hub.image" -}}

--- a/charts/hub/templates/deployment.yaml
+++ b/charts/hub/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -26,6 +28,9 @@ spec:
         {{- end }}
       annotations:
         {{- include "hub.checksumAnnotations" . | nindent 8 }}
+        {{- if .Values.embeddings.enabled }}
+        checksum/embeddings-secret: {{ include (print $.Template.BasePath "/embeddings-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -60,9 +65,15 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- if gt (len .Values.extraEnv) 0 }}
+          {{- if or .Values.embeddings.enabled (gt (len .Values.extraEnv) 0) }}
           env:
-            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- include "hub.embeddingEnv" . | nindent 12 }}
+            {{- range .Values.extraEnv }}
+            {{- $name := .name | default "" }}
+            {{- if not (and $.Values.embeddings.enabled (include "hub.embeddingEnvManaged" (dict "key" $name))) }}
+            {{- toYaml (list .) | nindent 12 }}
+            {{- end }}
+            {{- end }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
           startupProbe:

--- a/charts/hub/templates/embeddings-deployment.yaml
+++ b/charts/hub/templates/embeddings-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.embeddings.enabled -}}
 {{- $embeddingsReplicas := int (.Values.embeddings.replicaCount | default 1) -}}
 {{- $embeddingsMaxReplicas := int (.Values.embeddings.autoscaling.maxReplicas | default 1) -}}
-{{- if and .Values.embeddings.persistence.enabled (not (has "ReadWriteMany" .Values.embeddings.persistence.accessModes)) (or (gt $embeddingsReplicas 1) (and .Values.embeddings.autoscaling.enabled (gt $embeddingsMaxReplicas 1))) }}
+{{- if and .Values.embeddings.persistence.enabled (not .Values.embeddings.persistence.existingClaim) (not (has "ReadWriteMany" .Values.embeddings.persistence.accessModes)) (or (gt $embeddingsReplicas 1) (and .Values.embeddings.autoscaling.enabled (gt $embeddingsMaxReplicas 1))) }}
   {{- fail "embeddings persistence with multiple replicas requires persistence.accessModes to include ReadWriteMany, or set embeddings.persistence.enabled=false/use a ReadWriteMany existingClaim" }}
 {{- end }}
 {{- if and .Values.embeddings.auth.existingSecret .Values.embeddings.huggingFace.token (not .Values.embeddings.huggingFace.existingSecret) }}
@@ -24,11 +24,16 @@ spec:
   selector:
     matchLabels:
       {{- include "hub.embeddingsSelectorLabels" . | nindent 6 }}
+  {{- if and .Values.embeddings.persistence.enabled (not (has "ReadWriteMany" .Values.embeddings.persistence.accessModes)) }}
+  strategy:
+    type: Recreate
+  {{- else }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  {{- end }}
   template:
     metadata:
       labels:
@@ -94,14 +99,14 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hub.embeddingsSecretName" . }}
-                  key: {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}
+                  key: {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" | quote }}
             {{- end }}
             {{- if or .Values.embeddings.huggingFace.existingSecret .Values.embeddings.huggingFace.token }}
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hub.embeddingsHuggingFaceSecretName" . }}
-                  key: {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" }}
+                  key: {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" | quote }}
             {{- end }}
             {{- range $key, $value := .Values.embeddings.env }}
             {{- if not (or (and $.Values.embeddings.auth.enabled (eq $key "API_KEY")) (and (or $.Values.embeddings.huggingFace.existingSecret $.Values.embeddings.huggingFace.token) (eq $key "HF_TOKEN"))) }}

--- a/charts/hub/templates/embeddings-deployment.yaml
+++ b/charts/hub/templates/embeddings-deployment.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.embeddings.enabled -}}
+{{- $embeddingsReplicas := int (.Values.embeddings.replicaCount | default 1) -}}
+{{- $embeddingsMaxReplicas := int (.Values.embeddings.autoscaling.maxReplicas | default 1) -}}
+{{- if and .Values.embeddings.persistence.enabled (not (has "ReadWriteMany" .Values.embeddings.persistence.accessModes)) (or (gt $embeddingsReplicas 1) (and .Values.embeddings.autoscaling.enabled (gt $embeddingsMaxReplicas 1))) }}
+  {{- fail "embeddings persistence with multiple replicas requires persistence.accessModes to include ReadWriteMany, or set embeddings.persistence.enabled=false/use a ReadWriteMany existingClaim" }}
+{{- end }}
+{{- if and .Values.embeddings.auth.existingSecret .Values.embeddings.huggingFace.token (not .Values.embeddings.huggingFace.existingSecret) }}
+  {{- fail "embeddings.huggingFace.token cannot be stored when embeddings.auth.existingSecret is set; put HF_TOKEN in the existing auth secret or set embeddings.huggingFace.existingSecret" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hub.embeddingsName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  {{- if not .Values.embeddings.autoscaling.enabled }}
+  replicas: {{ .Values.embeddings.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      {{- include "hub.embeddingsSelectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "hub.embeddingsSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: embeddings
+        {{- with .Values.embeddings.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/embeddings-secret: {{ include (print $.Template.BasePath "/embeddings-secret.yaml") . | sha256sum }}
+        {{- with .Values.embeddings.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.embeddings.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: hub-embeddings
+          image: "{{ .Values.embeddings.image.repository }}:{{ .Values.embeddings.image.tag }}"
+          imagePullPolicy: {{ .Values.embeddings.image.pullPolicy }}
+          {{- with .Values.embeddings.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.embeddings.args }}
+          args:
+            {{- toYaml .Values.embeddings.args | nindent 12 }}
+          {{- else }}
+          args:
+            - --model-id
+            - {{ .Values.embeddings.model | quote }}
+            - --port
+            - {{ .Values.embeddings.port | quote }}
+            - --huggingface-hub-cache
+            - {{ .Values.embeddings.persistence.mountPath | quote }}
+            - --served-model-name
+            - {{ include "hub.embeddingsServedModelName" . | quote }}
+            {{- with .Values.embeddings.revision }}
+            - --revision
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.embeddings.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.embeddings.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.embeddings.prometheusPort }}
+              protocol: TCP
+          {{- if or .Values.embeddings.auth.enabled .Values.embeddings.huggingFace.existingSecret .Values.embeddings.huggingFace.token (gt (len .Values.embeddings.env) 0) }}
+          env:
+            {{- if .Values.embeddings.auth.enabled }}
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hub.embeddingsSecretName" . }}
+                  key: {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}
+            {{- end }}
+            {{- if or .Values.embeddings.huggingFace.existingSecret .Values.embeddings.huggingFace.token }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hub.embeddingsHuggingFaceSecretName" . }}
+                  key: {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" }}
+            {{- end }}
+            {{- range $key, $value := .Values.embeddings.env }}
+            {{- if not (or (and $.Values.embeddings.auth.enabled (eq $key "API_KEY")) (and (or $.Values.embeddings.huggingFace.existingSecret $.Values.embeddings.huggingFace.token) (eq $key "HF_TOKEN"))) }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.embeddings.probes.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.embeddings.probes.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.embeddings.probes.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.embeddings.resources | nindent 12 }}
+          {{- with .Values.embeddings.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.embeddings.persistence.enabled }}
+          volumeMounts:
+            - name: model-cache
+              mountPath: {{ .Values.embeddings.persistence.mountPath }}
+          {{- end }}
+      {{- with .Values.embeddings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.embeddings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.embeddings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.embeddings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.embeddings.persistence.enabled }}
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: {{ default (include "hub.embeddingsName" .) .Values.embeddings.persistence.existingClaim }}
+      {{- end }}
+{{- end }}

--- a/charts/hub/templates/embeddings-pvc.yaml
+++ b/charts/hub/templates/embeddings-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.embeddings.enabled .Values.embeddings.persistence.enabled (not .Values.embeddings.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hub.embeddingsName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  accessModes:
+    {{- toYaml .Values.embeddings.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.embeddings.persistence.size }}
+  {{- with .Values.embeddings.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/hub/templates/embeddings-secret.yaml
+++ b/charts/hub/templates/embeddings-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.embeddings.enabled (not .Values.embeddings.auth.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hub.embeddingsSecretName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+type: Opaque
+data:
+  {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}: {{ include "hub.embeddingsApiKey" . | b64enc }}
+  {{- if and (not .Values.embeddings.huggingFace.existingSecret) .Values.embeddings.huggingFace.token }}
+  {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" }}: {{ .Values.embeddings.huggingFace.token | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/hub/templates/embeddings-secret.yaml
+++ b/charts/hub/templates/embeddings-secret.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/component: embeddings
 type: Opaque
 data:
-  {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}: {{ include "hub.embeddingsApiKey" . | b64enc }}
+  {{ .Values.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" | quote }}: {{ include "hub.embeddingsApiKey" . | b64enc }}
   {{- if and (not .Values.embeddings.huggingFace.existingSecret) .Values.embeddings.huggingFace.token }}
-  {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" }}: {{ .Values.embeddings.huggingFace.token | b64enc }}
+  {{ .Values.embeddings.huggingFace.tokenKey | default "HF_TOKEN" | quote }}: {{ .Values.embeddings.huggingFace.token | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/hub/templates/embeddings-service.yaml
+++ b/charts/hub/templates/embeddings-service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.embeddings.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hub.embeddingsName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+    {{- with .Values.embeddings.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.embeddings.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.embeddings.service.type }}
+  selector:
+    {{- include "hub.embeddingsSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.embeddings.service.port }}
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.embeddings.prometheusPort }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/charts/hub/templates/hpa.yaml
+++ b/charts/hub/templates/hpa.yaml
@@ -27,4 +27,80 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hub.workerName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hub.workerName" . }}
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.worker.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.embeddings.enabled .Values.embeddings.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hub.embeddingsName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hub.embeddingsName" . }}
+  minReplicas: {{ .Values.embeddings.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.embeddings.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.embeddings.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.embeddings.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.embeddings.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.embeddings.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/hub/templates/pdb.yaml
+++ b/charts/hub/templates/pdb.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.pdb.enabled -}}
+{{- $hasMinAvailable := not (kindIs "invalid" .Values.pdb.minAvailable) -}}
+{{- $hasMaxUnavailable := not (kindIs "invalid" .Values.pdb.maxUnavailable) -}}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+  {{- fail "pdb.minAvailable and pdb.maxUnavailable are mutually exclusive; set only one" }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+  {{- fail "pdb.enabled is true but neither pdb.minAvailable nor pdb.maxUnavailable is set; set exactly one" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -6,8 +14,69 @@ metadata:
   labels:
     {{- include "hub.labels" . | nindent 4 }}
 spec:
+  {{- if $hasMinAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "hub.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- if and .Values.worker.enabled .Values.worker.pdb.enabled }}
+{{- $hasMinAvailable := not (kindIs "invalid" .Values.worker.pdb.minAvailable) -}}
+{{- $hasMaxUnavailable := not (kindIs "invalid" .Values.worker.pdb.maxUnavailable) -}}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+  {{- fail "worker.pdb.minAvailable and worker.pdb.maxUnavailable are mutually exclusive; set only one" }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+  {{- fail "worker.pdb.enabled is true but neither worker.pdb.minAvailable nor worker.pdb.maxUnavailable is set; set exactly one" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hub.workerName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ .Values.worker.pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.worker.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "hub.workerSelectorLabels" . | nindent 6 }}
+{{- end }}
+{{- if and .Values.embeddings.enabled .Values.embeddings.pdb.enabled }}
+{{- $hasMinAvailable := not (kindIs "invalid" .Values.embeddings.pdb.minAvailable) -}}
+{{- $hasMaxUnavailable := not (kindIs "invalid" .Values.embeddings.pdb.maxUnavailable) -}}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+  {{- fail "embeddings.pdb.minAvailable and embeddings.pdb.maxUnavailable are mutually exclusive; set only one" }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+  {{- fail "embeddings.pdb.enabled is true but neither embeddings.pdb.minAvailable nor embeddings.pdb.maxUnavailable is set; set exactly one" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hub.embeddingsName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ .Values.embeddings.pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.embeddings.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "hub.embeddingsSelectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/hub/templates/worker-deployment.yaml
+++ b/charts/hub/templates/worker-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.worker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hub.workerName" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  {{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      {{- include "hub.workerSelectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "hub.workerSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.worker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- include "hub.checksumAnnotations" . | nindent 8 }}
+        {{- if .Values.embeddings.enabled }}
+        checksum/embeddings-secret: {{ include (print $.Template.BasePath "/embeddings-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.worker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "hub.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds | default .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml (.Values.worker.podSecurityContext | default .Values.podSecurityContext) | nindent 8 }}
+      {{- if .Values.worker.waitForApi.enabled }}
+      initContainers:
+        - name: wait-for-hub-api
+          image: {{ include "hub.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml (.Values.worker.securityContext | default .Values.securityContext) | nindent 12 }}
+          command:
+            - sh
+            - -c
+            - |
+              until wget --no-verbose --tries=1 --spider http://{{ include "hub.fullname" . }}:{{ .Values.service.port }}/health; do
+                echo "Waiting for Hub API health check..."
+                sleep 5
+              done
+      {{- end }}
+      containers:
+        - name: hub-worker
+          image: {{ include "hub.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/hub-worker
+          {{- if or (and .Values.config.create (not .Values.config.existingConfigMap)) .Values.config.existingConfigMap (and .Values.secrets.create (not .Values.secrets.existingSecret) (not .Values.secrets.externalSecrets.enabled)) .Values.secrets.existingSecret .Values.secrets.externalSecrets.enabled .Values.extraEnvFrom .Values.worker.extraEnvFrom }}
+          envFrom:
+            {{- if or (and .Values.config.create (not .Values.config.existingConfigMap)) .Values.config.existingConfigMap }}
+            - configMapRef:
+                name: {{ include "hub.configMapName" . }}
+            {{- end }}
+            {{- if or (and .Values.secrets.create (not .Values.secrets.existingSecret) (not .Values.secrets.externalSecrets.enabled)) .Values.secrets.existingSecret .Values.secrets.externalSecrets.enabled }}
+            - secretRef:
+                name: {{ include "hub.secretName" . }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.worker.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or .Values.embeddings.enabled (gt (len .Values.extraEnv) 0) (gt (len .Values.worker.extraEnv) 0) }}
+          env:
+            {{- include "hub.embeddingEnv" . | nindent 12 }}
+            {{- range .Values.extraEnv }}
+            {{- $name := .name | default "" }}
+            {{- if not (and $.Values.embeddings.enabled (include "hub.embeddingEnvManaged" (dict "key" $name))) }}
+            {{- toYaml (list .) | nindent 12 }}
+            {{- end }}
+            {{- end }}
+            {{- range .Values.worker.extraEnv }}
+            {{- $name := .name | default "" }}
+            {{- if not (and $.Values.embeddings.enabled (include "hub.embeddingEnvManaged" (dict "key" $name))) }}
+            {{- toYaml (list .) | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml (.Values.worker.securityContext | default .Values.securityContext) | nindent 12 }}
+      {{- with (.Values.worker.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.worker.topologySpreadConstraints | default .Values.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/hub/templates/worker-deployment.yaml
+++ b/charts/hub/templates/worker-deployment.yaml
@@ -57,7 +57,14 @@ spec:
             - sh
             - -c
             - |
+              attempts=0
+              max_attempts={{ .Values.worker.waitForApi.maxAttempts | default 120 }}
               until wget --no-verbose --tries=1 --spider http://{{ include "hub.fullname" . }}:{{ .Values.service.port }}/health; do
+                attempts=$((attempts+1))
+                if [ "$attempts" -ge "$max_attempts" ]; then
+                  echo "Hub API health check timed out after $((max_attempts * 5)) seconds"
+                  exit 1
+                fi
                 echo "Waiting for Hub API health check..."
                 sleep 5
               done

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -80,6 +80,8 @@ worker:
   waitForApi:
     # Avoid starting workers before the API service is healthy during installs/upgrades.
     enabled: true
+    # 120 attempts * 5 seconds = 10 minutes.
+    maxAttempts: 120
 
   podAnnotations: {}
   podLabels: {}

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -133,7 +133,7 @@ embeddings:
   # Optional self-hosted OpenAI-compatible embeddings runtime for Hub.
   enabled: false
   runtime: tei
-  model: google/embeddinggemma-300m
+  model: Alibaba-NLP/gte-multilingual-base
   revision: ""
   # Defaults to `model` when empty. Used by TEI OpenAI-compatible responses
   # and as Hub's EMBEDDING_MODEL.
@@ -153,7 +153,9 @@ embeddings:
   # When empty, the chart renders TEI args from model, servedModelName, port,
   # revision, and persistence.mountPath. Set this to fully override args.
   args: []
-  extraArgs: []
+  extraArgs:
+    - --dtype
+    - float16
   env: {}
 
   port: 8080
@@ -175,8 +177,7 @@ embeddings:
     apiKey: ""
 
   huggingFace:
-    # Required for gated models such as google/embeddinggemma-300m unless the
-    # model is pre-cached or a different ungated model is configured.
+    # Required only for private/gated models unless the model is pre-cached.
     existingSecret: ""
     tokenKey: HF_TOKEN
     token: ""

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -64,10 +64,194 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: null
+  behavior: {}
 
 pdb:
   enabled: true
   minAvailable: 1
+  # maxUnavailable: 1
+
+worker:
+  # Hub async jobs (webhook dispatch, embeddings) run in hub-worker. Keep this
+  # enabled unless another deployment processes the same River queues.
+  enabled: true
+  replicaCount: 1
+
+  waitForApi:
+    # Avoid starting workers before the API service is healthy during installs/upgrades.
+    enabled: true
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+
+  extraEnv: []
+  extraEnvFrom: []
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 120
+      scaleUp:
+        stabilizationWindowSeconds: 60
+        policies:
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+
+  # Disabled by default because the default worker replica count is 1.
+  pdb:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  terminationGracePeriodSeconds: null
+
+embeddings:
+  # Optional self-hosted OpenAI-compatible embeddings runtime for Hub.
+  enabled: false
+  runtime: tei
+  model: google/embeddinggemma-300m
+  revision: ""
+  # Defaults to `model` when empty. Used by TEI OpenAI-compatible responses
+  # and as Hub's EMBEDDING_MODEL.
+  servedModelName: ""
+  # Defaults to http://<release>-hub-embeddings:<service.port>/v1 when empty.
+  baseUrl: ""
+  maxConcurrent: "5"
+  normalize: "false"
+  replicaCount: 1
+
+  image:
+    repository: "ghcr.io/huggingface/text-embeddings-inference"
+    tag: "cpu-1.9"
+    pullPolicy: IfNotPresent
+
+  command: []
+  # When empty, the chart renders TEI args from model, servedModelName, port,
+  # revision, and persistence.mountPath. Set this to fully override args.
+  args: []
+  extraArgs: []
+  env: {}
+
+  port: 8080
+  prometheusPort: 9000
+
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+    additionalLabels: {}
+
+  auth:
+    # TEI can enforce bearer-token auth with API_KEY. Hub always receives the
+    # same key as EMBEDDING_PROVIDER_API_KEY because the OpenAI-compatible Hub
+    # provider requires an API key.
+    enabled: true
+    existingSecret: ""
+    secretKey: EMBEDDING_PROVIDER_API_KEY
+    apiKey: ""
+
+  huggingFace:
+    # Required for gated models such as google/embeddinggemma-300m unless the
+    # model is pre-cached or a different ungated model is configured.
+    existingSecret: ""
+    tokenKey: HF_TOKEN
+    token: ""
+
+  persistence:
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    mountPath: /data
+
+  resources:
+    requests:
+      cpu: "4"
+      memory: 8Gi
+    limits:
+      memory: 8Gi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 600
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 300
+      scaleUp:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 120
+
+  # Disabled by default because the default embeddings replica count is 1.
+  pdb:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
+
+  probes:
+    startupProbe:
+      failureThreshold: 60
+      periodSeconds: 10
+      tcpSocket:
+        port: http
+    readinessProbe:
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 5
+      tcpSocket:
+        port: http
+    livenessProbe:
+      failureThreshold: 6
+      periodSeconds: 20
+      timeoutSeconds: 5
+      tcpSocket:
+        port: http
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  # Keep empty by default because upstream model-serving images may define
+  # their own user and need write access to the model cache path.
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
## What does this PR do?

Adds Helm support for running the full standalone Hub deployment shape: Hub API, Hub worker, and an optional self-hosted embeddings runtime.

Related: ENG-849

- Deploys `hub-worker` by default so River webhook and embedding jobs are processed by the chart unless explicitly disabled.
- Adds opt-in `embeddings` support for an internal Hugging Face Text Embeddings Inference service using `Alibaba-NLP/gte-multilingual-base`.
- Adds embeddings service, generated/existing secret support, optional Hugging Face token support, PVC cache handling, and managed Hub env wiring through the OpenAI-compatible endpoint.
- Adds separate HPA and PDB support for Hub API, Hub worker, and the embeddings runtime.
- Adds validations for unsafe multi-replica embeddings with RWO persistence, conflicting PDB settings, and incompatible HF token/existing-secret configuration.
- Adds embeddings-secret rollout checksums for API, worker, and embeddings pods.
- Keeps the change in one PR because the templates, values, validations, and chart version change need to be reviewed together for a usable Helm deployment shape.

## How should this be tested?

- `helm lint charts/hub --set secrets.stringData.DATABASE_URL=postgres://user:pass@db:5432/hub --set secrets.stringData.API_KEY=test-key`
- `helm lint charts/hub --set secrets.stringData.DATABASE_URL=postgres://user:pass@db:5432/hub --set secrets.stringData.API_KEY=test-key --set embeddings.enabled=true`
- `helm template` default, embeddings-enabled, HPA-enabled, PDB-enabled, external-secret, RWX, and worker-disabled variants
- Negative render checks for multi-replica embeddings with RWO persistence, conflicting PDB settings, and invalid HF token/existing-secret configuration
- Positive render check for multi-replica embeddings with `embeddings.persistence.existingClaim`
- `git diff --check`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits where useful
- [ ] Ran `make build` (not applicable: Helm-only chart change)
- [ ] Ran `make tests` (not applicable: Helm-only chart change)
- [ ] Ran `make fmt` and `make lint`; no new warnings (not applicable: Helm-only chart change)
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch before opening this PR
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` (not applicable)

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow) (not applicable)
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR (not applicable)
- [ ] Updated docs in `docs/` if changes were necessary (not applicable)
- [ ] Ran `make tests-coverage` for meaningful logic changes (not applicable)