### PR TITLE
test: add staging hub server to openapi

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,6 +33,8 @@ servers:
         basePath:
             default: ""
             description: Optional reverse-proxy path prefix, for example /hub
+    - url: https://hub-internal.formbricks.com
+      description: Formbricks staging Hub server
     - url: http://localhost:8080
       description: Local development server
 tags:


### PR DESCRIPTION
## What does this PR do?

Changes OpenAPI server entries.

This is a focused validation change for ENG-759. Stainless Code Mode is currently receiving the correct `FORMBRICKS_HUB_BASE_URL`, but its sandbox rejects it. Stainless guidance suggests the sandbox may derive allowed outbound hosts from the OpenAPI `servers` array used during SDK/MCP generation, so this PR tests that hypothesis by making the staging Hub URL explicit in the uploaded spec.

## How should this be tested?

- `go test ./internal/api/handlers ./cmd/api -run 'OpenAPI|HTTPServerServesOpenAPI' -count=1`
- `npx --yes @stoplight/spectral-cli@6 lint openapi.yaml`
- After the Stainless preview build completes, run the generated/preview MCP package against staging:
  ```sh
  HUB_API_KEY=<staging-key> \
  FORMBRICKS_HUB_BASE_URL=<hub-urç> \
  npx -y @formbricks/hub-mcp@<preview-version>
