### PR TITLE
fix: allow staging hub image tag

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      deploy_staging:
+        description: "Tag image for staging deployment"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       image_tag:
@@ -98,11 +103,18 @@ jobs:
           ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
           MAKE_LATEST: ${{ inputs.MAKE_LATEST }}
           DEPLOY_PRODUCTION: ${{ inputs.deploy_production }}
+          DEPLOY_STAGING: ${{ inputs.deploy_staging }}
         run: |
           set -euo pipefail
 
           # Start with base version tag
           TAGS="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+          # Manual staging deployment override (workflow_dispatch)
+          if [[ "${DEPLOY_STAGING}" == "true" ]]; then
+            TAGS="${TAGS}\n${ECR_REGISTRY}/${ECR_REPOSITORY}:staging"
+            echo "Adding staging tag (manual override)"
+          fi
 
           # Add production and latest tags for stable releases marked as latest
           if [[ "${MAKE_LATEST}" == "true" ]]; then


### PR DESCRIPTION
What changed:
- Adds a manual ECR workflow option to tag a Hub build as staging.
- Allows staging to be rebuilt from current main with both /app/hub-api and /app/hub-worker in the image.

Tested:
- git diff --check
- Dispatched Build & Push to AWS ECR with version_override=0.2.1-staging.20260507 and deploy_staging=true.
- Restarted hub-stage-worker and verified the rollout succeeded.

Notes:
- The previous live hub:staging image did not include /app/hub-worker, which caused hub-stage-worker to crash-loop.
