### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/api-contract-tests.yml
+++ b/.github/workflows/api-contract-tests.yml
@@ -48,15 +48,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -69,7 +69,7 @@ jobs:
         run: go mod download
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
 
       - name: Validate migrations
         run: make migrate-validate
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run River migrations
         run: |
-          go install github.com/riverqueue/river/cmd/river@v0.31.0
+          go install github.com/riverqueue/river/cmd/river@v0.35.0
           make river-migrate
 
       - name: Build application
@@ -108,37 +108,40 @@ jobs:
             exit 1
           fi
 
-      - name: Run API contract tests
-        uses: schemathesis/action@1f15936316e0742005bf69657b5909ac68f04cb3
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          schema: ./openapi.yaml
-          base-url: http://localhost:8080
-          # Pin version to avoid regressions from newer Schemathesis releases
-          version: "4.4.4"
-          # Only test schema conformance
-          checks: not_a_server_error,status_code_conformance,content_type_conformance,response_schema_conformance
-          # Only run examples phase for fast, deterministic CI testing.
-          # For deeper testing (stateful, fuzzing), run locally: make schemathesis
-          # Exclude search endpoints: CI does not configure embeddings, so they return 503 (treated as failure by not_a_server_error).
-          # Run locally with embeddings enabled to test these operations.
-          args: >-
-            --phases examples
-            -H "Authorization: Bearer test-api-key-for-ci"
-            --exclude-operation-id semantic-search-feedback-records
+          python-version: '3.13'
+
+      - name: Install Schemathesis
+        run: python -m pip install schemathesis==4.4.4
+
+      - name: Run API contract tests
+        env:
+          SCHEMATHESIS_BASE_URL: http://localhost:8080
+          SCHEMATHESIS_WAIT_FOR_SCHEMA: '2'
+        run: |
+          schemathesis run ./openapi.yaml \
+            --generation-database=:memory: \
+            --max-examples=100 \
+            --checks=not_a_server_error,status_code_conformance,content_type_conformance,response_schema_conformance \
+            --phases examples \
+            -H "Authorization: Bearer test-api-key-for-ci" \
+            --exclude-operation-id semantic-search-feedback-records \
             --exclude-operation-id similar-feedback-records
 
       - name: Run API contract tests (search endpoints)
-        uses: schemathesis/action@1f15936316e0742005bf69657b5909ac68f04cb3
-        with:
-          schema: ./openapi.yaml
-          base-url: http://localhost:8080
-          version: "4.4.4"
-          # Omit not_a_server_error: search endpoints return 503 when embeddings are disabled (documented behavior).
-          checks: status_code_conformance,content_type_conformance,response_schema_conformance
-          args: >-
-            --phases examples
-            -H "Authorization: Bearer test-api-key-for-ci"
-            --include-operation-id semantic-search-feedback-records
+        env:
+          SCHEMATHESIS_BASE_URL: http://localhost:8080
+          SCHEMATHESIS_WAIT_FOR_SCHEMA: '2'
+        run: |
+          schemathesis run ./openapi.yaml \
+            --generation-database=:memory: \
+            --max-examples=100 \
+            --checks=status_code_conformance,content_type_conformance,response_schema_conformance \
+            --phases examples \
+            -H "Authorization: Bearer test-api-key-for-ci" \
+            --include-operation-id semantic-search-feedback-records \
             --include-operation-id similar-feedback-records
 
       - name: Stop API server

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -59,12 +59,12 @@ jobs:
       TAGS: ${{ steps.tags.outputs.tags }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Resolve image version
         id: resolve_version
@@ -140,20 +140,20 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up Depot CLI
-        uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.2.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
           aws-region: ${{ env.ECR_REGION }}
 
       - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Build and push Docker image
         id: build
-        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
+        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,24 +25,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node (for Spectral)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Lint OpenAPI spec
         run: npx --yes @stoplight/spectral-cli@6 lint openapi.yaml
 
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -64,7 +64,7 @@ jobs:
       # Cache key includes Go version so tools are rebuilt when Go upgrades
       - name: Cache development tools
         id: cache-tools
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/go/bin/golangci-lint

--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -19,7 +19,7 @@ jobs:
       is_latest: ${{ steps.compare_tags.outputs.is_latest }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
@@ -126,7 +126,7 @@ jobs:
       - docker-build-ecr
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/migrations-validate.yml
+++ b/.github/workflows/migrations-validate.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
 
       - name: Validate migrations
         run: make migrate-validate

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -33,12 +33,12 @@ jobs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Extract release version from tag
         id: extract_version
@@ -72,13 +72,13 @@ jobs:
           echo "Using version: $TAG"
 
       - name: Set up Depot CLI
-        uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
+        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}

--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -4,6 +4,8 @@ env:
   OAS_PATH: ./openapi.yaml
   STAINLESS_ORG: formbricks
   STAINLESS_PROJECT: hub
+  # Stainless v1.13.2 still declares node20; force Node 24 now so CI catches incompatibilities early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 on:
   pull_request:
@@ -27,12 +29,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: Run preview builds
-        uses: stainless-api/upload-openapi-spec-action/preview@574dfd13ae0a31b75c78570b19811e0f03c66c64 # v1
+        uses: stainless-api/upload-openapi-spec-action/preview@0908d431428c675af1d590f1c6e49146cd5c4c2e # v1.13.2
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}
@@ -47,12 +49,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: Run merge build
-        uses: stainless-api/upload-openapi-spec-action/merge@574dfd13ae0a31b75c78570b19811e0f03c66c64 # v1
+        uses: stainless-api/upload-openapi-spec-action/merge@0908d431428c675af1d590f1c6e49146cd5c4c2e # v1.13.2
         with:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,15 +26,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -80,15 +80,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -101,7 +101,7 @@ jobs:
         run: go mod download
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
 
       - name: Validate migrations
         run: make migrate-validate
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run River migrations
         run: |
-          go install github.com/riverqueue/river/cmd/river@v0.31.0
+          go install github.com/riverqueue/river/cmd/river@v0.35.0
           make river-migrate
 
       - name: Run integration tests
@@ -143,15 +143,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
 
       - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -164,14 +164,14 @@ jobs:
         run: go mod download
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
 
       - name: Initialize database schema
         run: make init-db
 
       - name: Run River migrations
         run: |
-          go install github.com/riverqueue/river/cmd/river@v0.31.0
+          go install github.com/riverqueue/river/cmd/river@v0.35.0
           make river-migrate
 
       - name: Check coverage (excludes cmd/api)


### PR DESCRIPTION
## What does this PR do?

Updates GitHub Actions workflow dependencies ahead of GitHub’s Node 20 runner deprecation.

This PR:
- Upgrades official GitHub actions to Node 24-compatible releases (`checkout`, `setup-go`, `setup-node`, `setup-python`, `cache`).
- Updates third-party workflow actions where newer compatible versions are available (`harden-runner`, Depot, AWS, Docker login, cosign).
- Updates Stainless actions to `v1.13.2` and sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` because Stainless still declares `node20` upstream.
- Replaces `schemathesis/action` with explicit Python setup + pinned Schemathesis install to avoid Node 20 transitive action usage.
- Aligns CI tool pins for `goose` and `river` with the repo’s canonical versions.

Fixes #<!-- issue -->

## How should this be tested?

Validation performed:

- Parsed all workflow YAML:
  - `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml`
- Checked diff formatting:
  - `git diff --check`
- Verified stale pins are gone for:
  - Node 20 workflow runtime
  - old Stainless SHA
  - `goose@v3.27.0`
  - `river@v0.31.0`
  - old cosign installer SHA

CI should also run the updated workflows on this PR.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [ ] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes
