### PR TITLE
fix(helm): stop forcing TEI float16 dtype

### DIFF
--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -155,9 +155,7 @@ embeddings:
   # When empty, the chart renders TEI args from model, servedModelName, port,
   # revision, and persistence.mountPath. Set this to fully override args.
   args: []
-  extraArgs:
-    - --dtype
-    - float16
+  extraArgs: []
   env: {}
 
   port: 8080


### PR DESCRIPTION
## What does this PR do?

Removes the default `--dtype float16` extra arg from the Hub Helm chart's embeddings TEI deployment.

Staging showed TEI successfully serves `Alibaba-NLP/gte-multilingual-base` through the Candle backend, but the forced float16 override causes a misleading ORT startup error because ORT only supports float32 in this path. Leaving `extraArgs` empty lets TEI choose the compatible backend/defaults while preserving the ability to override args explicitly when needed.

## How should this be tested?

- `helm lint charts/hub --set secrets.stringData.DATABASE_URL=postgres://user:pass@db:5432/hub --set secrets.stringData.API_KEY=test-key --set embeddings.enabled=true`
- `helm template hub charts/hub --set secrets.stringData.DATABASE_URL=postgres://user:pass@db:5432/hub --set secrets.stringData.API_KEY=test-key --set embeddings.enabled=true`
- Verified rendered embeddings manifest no longer contains `--dtype`.
- `git diff --check`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [ ] Ran `make build` (not applicable: Helm-only chart change)
- [ ] Ran `make tests` (not applicable: Helm-only chart change)
- [ ] Ran `make fmt` and `make lint` (not applicable: Helm-only chart change)
- [x] Removed debug prints / temporary logging
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` (not applicable)

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (not applicable)
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR (not applicable)
- [ ] Updated docs in `docs/` if changes were necessary (not applicable)
