### PR TITLE
fix(helm): restore TEI float16 dtype

### DIFF
--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -155,7 +155,10 @@ embeddings:
   # When empty, the chart renders TEI args from model, servedModelName, port,
   # revision, and persistence.mountPath. Set this to fully override args.
   args: []
-  extraArgs: []
+  # Keeps the default GTE CPU runtime within the default memory budget.
+  extraArgs:
+    - --dtype
+    - float16
   env: {}
 
   port: 8080


### PR DESCRIPTION
## Summary
- restore the default TEI `--dtype float16` extra arg for the standalone Hub chart
- keeps the bundled `Alibaba-NLP/gte-multilingual-base` CPU deployment within the tested 8Gi memory profile
- keeps the standalone chart consistent with the Formbricks chart

## Verification
- `helm template hub charts/hub --set embeddings.enabled=true --set secrets.existingSecret=hub-secret --show-only templates/embeddings-deployment.yaml`
- `helm lint charts/hub --set embeddings.enabled=true --set secrets.existingSecret=hub-secret`