### PR TITLE
feat(openapi): add Formbricks Cloud servers

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,6 +35,10 @@ servers:
             description: Optional reverse-proxy path prefix, for example /hub
     - url: https://hub-internal.formbricks.com
       description: Formbricks staging Hub server
+    - url: https://app.formbricks.com
+      description: Formbricks Cloud
+    - url: https://staging.app.formbricks.com
+      description: Formbricks Cloud (staging)
     - url: http://localhost:8080
       description: Local development server
 tags:


### PR DESCRIPTION
## Summary

- Adds `https://app.formbricks.com` and `https://staging.app.formbricks.com` as named server entries in `openapi.yaml`
- Enables generated Hub API clients and MCP servers to target Formbricks Cloud instances out of the box

## Test plan

- [ ] Verify the OpenAPI spec is valid (`make lint-openapi`)
- [ ] Confirm the new server entries appear in generated SDK/MCP client server lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)