### PR TITLE
feat: add taxonomy run APIs

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -321,8 +321,31 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	tenantDataService := service.NewTenantDataService(tenantDataRepo)
 	tenantDataHandler := handlers.NewTenantDataHandler(tenantDataService)
 
+	taxonomyRepo := repository.NewTaxonomyRepository(db)
+	var taxonomyStarter service.TaxonomyRunStarter
+	if cfg.Taxonomy.ServiceURL != "" || cfg.Taxonomy.ServiceToken != "" {
+		taxonomyClient, err := service.NewTaxonomyClient(service.TaxonomyClientConfig{
+			ServiceURL:   cfg.Taxonomy.ServiceURL,
+			ServiceToken: cfg.Taxonomy.ServiceToken,
+		}, nil)
+		if err != nil {
+			cleanupNewAppStartupFailure(context.Background(), messageManager, riverClient, tracerProvider, meterProvider)
+
+			return nil, fmt.Errorf("create taxonomy client: %w", err)
+		}
+
+		taxonomyStarter = taxonomyClient
+	}
+
+	taxonomyService := service.NewTaxonomyService(service.NewTaxonomyServiceParams{
+		Repo:                  taxonomyRepo,
+		Starter:               taxonomyStarter,
+		EmbeddingModel:        embeddingModelForDB,
+		MinimumEmbeddingCount: cfg.Taxonomy.MinimumEmbeddedRecords,
+	})
+	taxonomyHandler := handlers.NewTaxonomyHandler(taxonomyService)
 	feedbackRecordsHandler := handlers.NewFeedbackRecordsHandler(feedbackRecordsService)
-	taxonomyInternalHandler := handlers.NewTaxonomyInternalHandler()
+	taxonomyInternalHandler := handlers.NewTaxonomyInternalHandler(taxonomyService)
 	healthHandler := handlers.NewHealthHandler()
 
 	openapiHandler, err := handlers.NewOpenAPIHandler(handlers.ResolveOpenAPISpecPath(), cfg.Server.PublicBaseURL)
@@ -334,7 +357,7 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 
 	server := newHTTPServer(
 		cfg, healthHandler, openapiHandler, feedbackRecordsHandler, webhooksHandler, tenantDataHandler, searchHandler,
-		taxonomyInternalHandler,
+		taxonomyHandler, taxonomyInternalHandler,
 		meterProvider, tracerProvider,
 	)
 
@@ -361,6 +384,7 @@ func newHTTPServer(
 	webhooks *handlers.WebhooksHandler,
 	tenantData *handlers.TenantDataHandler,
 	search *handlers.SearchHandler,
+	taxonomy *handlers.TaxonomyHandler,
 	taxonomyInternal *handlers.TaxonomyInternalHandler,
 	meterProvider *sdkmetric.MeterProvider,
 	tracerProvider *sdktrace.TracerProvider,
@@ -389,6 +413,16 @@ func newHTTPServer(
 	protected.HandleFunc("POST /v1/feedback-records/search/semantic", search.SemanticSearch)
 	protected.HandleFunc("GET /v1/feedback-records/{id}/similar", search.SimilarFeedback)
 
+	protected.HandleFunc("GET /v1/taxonomy/fields", taxonomy.ListFields)
+	protected.HandleFunc("POST /v1/taxonomy/runs", taxonomy.CreateRun)
+	protected.HandleFunc("GET /v1/taxonomy/runs", taxonomy.ListRuns)
+	protected.HandleFunc("GET /v1/taxonomy/runs/active/tree", taxonomy.GetActiveTree)
+	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}", taxonomy.GetRun)
+	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/tree", taxonomy.GetTree)
+	protected.HandleFunc("PATCH /v1/taxonomy/nodes/{node_id}", taxonomy.RenameNode)
+	protected.HandleFunc("DELETE /v1/taxonomy/nodes/{node_id}", taxonomy.RemoveNode)
+	protected.HandleFunc("GET /v1/taxonomy/nodes/{node_id}/records", taxonomy.ListNodeRecords)
+
 	protectedWithAuth := middleware.Auth(cfg.Server.HubAPIKey)(protected)
 
 	mux := http.NewServeMux()
@@ -397,6 +431,9 @@ func newHTTPServer(
 	if cfg.Taxonomy.HubInternalAPIToken != "" {
 		internalTaxonomy := http.NewServeMux()
 		internalTaxonomy.HandleFunc("GET /internal/v1/taxonomy/auth-check", taxonomyInternal.AuthCheck)
+		internalTaxonomy.HandleFunc("GET /internal/v1/taxonomy/runs/{run_id}/input", taxonomyInternal.GetRunInput)
+		internalTaxonomy.HandleFunc("PUT /internal/v1/taxonomy/runs/{run_id}/result", taxonomyInternal.CompleteRun)
+		internalTaxonomy.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/failed", taxonomyInternal.FailRun)
 		internalTaxonomyWithAuth := middleware.Auth(cfg.Taxonomy.HubInternalAPIToken)(internalTaxonomy)
 		mux.Handle("/internal/v1/taxonomy/", internalTaxonomyWithAuth)
 	}

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -322,7 +322,9 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	tenantDataHandler := handlers.NewTenantDataHandler(tenantDataService)
 
 	taxonomyRepo := repository.NewTaxonomyRepository(db)
+
 	var taxonomyStarter service.TaxonomyRunStarter
+
 	if cfg.Taxonomy.ServiceURL != "" || cfg.Taxonomy.ServiceToken != "" {
 		taxonomyClient, err := service.NewTaxonomyClient(service.TaxonomyClientConfig{
 			ServiceURL:   cfg.Taxonomy.ServiceURL,

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -375,6 +375,7 @@ func newTestHTTPServerWithConfig(t *testing.T, publicBaseURL string, taxonomy co
 		handlers.NewWebhooksHandler(nil),
 		handlers.NewTenantDataHandler(nil),
 		handlers.NewSearchHandler(nil),
+		handlers.NewTaxonomyHandler(nil),
 		handlers.NewTaxonomyInternalHandler(),
 		nil,
 		nil,

--- a/internal/api/handlers/taxonomy_handler.go
+++ b/internal/api/handlers/taxonomy_handler.go
@@ -20,9 +20,9 @@ type TaxonomyService interface {
 	ListFieldOptions(ctx context.Context, tenantID string) (*models.TaxonomyFieldsResponse, error)
 	StartManualRun(ctx context.Context, req models.CreateTaxonomyRunRequest) (*models.CreateTaxonomyRunResponse, error)
 	ListRuns(ctx context.Context, filters models.ListTaxonomyRunsFilters) (*models.ListTaxonomyRunsResponse, error)
-	GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	GetRun(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyRun, error)
 	GetActiveTree(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyTreeResponse, error)
-	GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error)
+	GetTree(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyTreeResponse, error)
 	RenameNode(ctx context.Context, nodeID uuid.UUID, req models.RenameTaxonomyNodeRequest) (*models.TaxonomyNode, error)
 	RemoveNode(ctx context.Context, nodeID uuid.UUID, filters models.RemoveTaxonomyNodeFilters) (*models.TaxonomyNode, error)
 	ListNodeRecords(
@@ -124,7 +124,7 @@ func (h *TaxonomyHandler) GetRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.GetRun(r.Context(), runID)
+	result, err := h.service.GetRun(r.Context(), runID, r.URL.Query().Get("tenant_id"))
 	if err != nil {
 		respondTaxonomyError(w, r, err)
 
@@ -158,7 +158,7 @@ func (h *TaxonomyHandler) GetTree(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.GetTree(r.Context(), runID)
+	result, err := h.service.GetTree(r.Context(), runID, r.URL.Query().Get("tenant_id"))
 	if err != nil {
 		respondTaxonomyError(w, r, err)
 

--- a/internal/api/handlers/taxonomy_handler.go
+++ b/internal/api/handlers/taxonomy_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -14,6 +15,7 @@ import (
 	"github.com/formbricks/hub/internal/service"
 )
 
+// TaxonomyService is the application service used by taxonomy HTTP handlers.
 type TaxonomyService interface {
 	ListFieldOptions(ctx context.Context, tenantID string) (*models.TaxonomyFieldsResponse, error)
 	StartManualRun(ctx context.Context, req models.CreateTaxonomyRunRequest) (*models.CreateTaxonomyRunResponse, error)
@@ -30,14 +32,17 @@ type TaxonomyService interface {
 	) (*models.TaxonomyNodeRecordsResponse, error)
 }
 
+// TaxonomyHandler hosts public taxonomy API endpoints.
 type TaxonomyHandler struct {
 	service TaxonomyService
 }
 
+// NewTaxonomyHandler creates a public taxonomy handler.
 func NewTaxonomyHandler(service TaxonomyService) *TaxonomyHandler {
 	return &TaxonomyHandler{service: service}
 }
 
+// ListFields returns taxonomy-capable feedback fields.
 func (h *TaxonomyHandler) ListFields(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
@@ -46,6 +51,7 @@ func (h *TaxonomyHandler) ListFields(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tenantID := r.URL.Query().Get("tenant_id")
+
 	result, err := h.service.ListFieldOptions(r.Context(), tenantID)
 	if err != nil {
 		respondTaxonomyError(w, r, err)
@@ -56,6 +62,7 @@ func (h *TaxonomyHandler) ListFields(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// CreateRun starts a manual taxonomy generation run.
 func (h *TaxonomyHandler) CreateRun(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
@@ -85,6 +92,7 @@ func (h *TaxonomyHandler) CreateRun(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, status, result)
 }
 
+// ListRuns returns taxonomy run history.
 func (h *TaxonomyHandler) ListRuns(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
@@ -109,6 +117,7 @@ func (h *TaxonomyHandler) ListRuns(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// GetRun returns a taxonomy run by ID.
 func (h *TaxonomyHandler) GetRun(w http.ResponseWriter, r *http.Request) {
 	runID, ok := parseUUIDPathValue(w, r, "run_id")
 	if !ok {
@@ -125,6 +134,7 @@ func (h *TaxonomyHandler) GetRun(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// GetActiveTree returns the active taxonomy tree for a field scope.
 func (h *TaxonomyHandler) GetActiveTree(w http.ResponseWriter, r *http.Request) {
 	scope, ok := taxonomyScopeFromQuery(w, r)
 	if !ok {
@@ -141,6 +151,7 @@ func (h *TaxonomyHandler) GetActiveTree(w http.ResponseWriter, r *http.Request) 
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// GetTree returns a taxonomy tree for a run.
 func (h *TaxonomyHandler) GetTree(w http.ResponseWriter, r *http.Request) {
 	runID, ok := parseUUIDPathValue(w, r, "run_id")
 	if !ok {
@@ -157,6 +168,7 @@ func (h *TaxonomyHandler) GetTree(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// RenameNode renames a taxonomy node.
 func (h *TaxonomyHandler) RenameNode(w http.ResponseWriter, r *http.Request) {
 	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
 	if !ok {
@@ -180,6 +192,7 @@ func (h *TaxonomyHandler) RenameNode(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// RemoveNode soft-removes a taxonomy node.
 func (h *TaxonomyHandler) RemoveNode(w http.ResponseWriter, r *http.Request) {
 	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
 	if !ok {
@@ -203,6 +216,7 @@ func (h *TaxonomyHandler) RemoveNode(w http.ResponseWriter, r *http.Request) {
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// ListNodeRecords returns feedback records assigned to a taxonomy node.
 func (h *TaxonomyHandler) ListNodeRecords(w http.ResponseWriter, r *http.Request) {
 	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
 	if !ok {
@@ -229,11 +243,16 @@ func (h *TaxonomyHandler) ListNodeRecords(w http.ResponseWriter, r *http.Request
 func decodeAndValidateJSON(r *http.Request, dst any) error {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
+
 	if err := decoder.Decode(dst); err != nil {
-		return response.NewRequestJSONDecodeError(err)
+		return fmt.Errorf("decode request JSON: %w", response.NewRequestJSONDecodeError(err))
 	}
 
-	return validation.ValidateStruct(dst)
+	if err := validation.ValidateStruct(dst); err != nil {
+		return fmt.Errorf("validate request body: %w", err)
+	}
+
+	return nil
 }
 
 func parseUUIDPathValue(w http.ResponseWriter, r *http.Request, name string) (uuid.UUID, bool) {

--- a/internal/api/handlers/taxonomy_handler.go
+++ b/internal/api/handlers/taxonomy_handler.go
@@ -1,0 +1,287 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/formbricks/hub/internal/api/response"
+	"github.com/formbricks/hub/internal/api/validation"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/service"
+)
+
+type TaxonomyService interface {
+	ListFieldOptions(ctx context.Context, tenantID string) (*models.TaxonomyFieldsResponse, error)
+	StartManualRun(ctx context.Context, req models.CreateTaxonomyRunRequest) (*models.CreateTaxonomyRunResponse, error)
+	ListRuns(ctx context.Context, filters models.ListTaxonomyRunsFilters) (*models.ListTaxonomyRunsResponse, error)
+	GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	GetActiveTree(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyTreeResponse, error)
+	GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error)
+	RenameNode(ctx context.Context, nodeID uuid.UUID, req models.RenameTaxonomyNodeRequest) (*models.TaxonomyNode, error)
+	RemoveNode(ctx context.Context, nodeID uuid.UUID, filters models.RemoveTaxonomyNodeFilters) (*models.TaxonomyNode, error)
+	ListNodeRecords(
+		ctx context.Context,
+		nodeID uuid.UUID,
+		filters models.TaxonomyNodeRecordsFilters,
+	) (*models.TaxonomyNodeRecordsResponse, error)
+}
+
+type TaxonomyHandler struct {
+	service TaxonomyService
+}
+
+func NewTaxonomyHandler(service TaxonomyService) *TaxonomyHandler {
+	return &TaxonomyHandler{service: service}
+}
+
+func (h *TaxonomyHandler) ListFields(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
+
+		return
+	}
+
+	tenantID := r.URL.Query().Get("tenant_id")
+	result, err := h.service.ListFieldOptions(r.Context(), tenantID)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) CreateRun(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
+
+		return
+	}
+
+	var req models.CreateTaxonomyRunRequest
+	if err := decodeAndValidateJSON(r, &req); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.StartManualRun(r.Context(), req)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	status := http.StatusAccepted
+	if result.InProgress {
+		status = http.StatusOK
+	}
+
+	response.RespondJSON(w, status, result)
+}
+
+func (h *TaxonomyHandler) ListRuns(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy is not available.")
+
+		return
+	}
+
+	filters := models.ListTaxonomyRunsFilters{}
+	if err := validation.ValidateAndDecodeQueryParams(r, &filters); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.ListRuns(r.Context(), filters)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) GetRun(w http.ResponseWriter, r *http.Request) {
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	result, err := h.service.GetRun(r.Context(), runID)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) GetActiveTree(w http.ResponseWriter, r *http.Request) {
+	scope, ok := taxonomyScopeFromQuery(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.service.GetActiveTree(r.Context(), scope)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) GetTree(w http.ResponseWriter, r *http.Request) {
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	result, err := h.service.GetTree(r.Context(), runID)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) RenameNode(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
+	if !ok {
+		return
+	}
+
+	var req models.RenameTaxonomyNodeRequest
+	if err := decodeAndValidateJSON(r, &req); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.RenameNode(r.Context(), nodeID, req)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) RemoveNode(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
+	if !ok {
+		return
+	}
+
+	filters := models.RemoveTaxonomyNodeFilters{}
+	if err := validation.ValidateAndDecodeQueryParams(r, &filters); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.RemoveNode(r.Context(), nodeID, filters)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyHandler) ListNodeRecords(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseUUIDPathValue(w, r, "node_id")
+	if !ok {
+		return
+	}
+
+	filters := models.TaxonomyNodeRecordsFilters{}
+	if err := validation.ValidateAndDecodeQueryParams(r, &filters); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.ListNodeRecords(r.Context(), nodeID, filters)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func decodeAndValidateJSON(r *http.Request, dst any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return response.NewRequestJSONDecodeError(err)
+	}
+
+	return validation.ValidateStruct(dst)
+}
+
+func parseUUIDPathValue(w http.ResponseWriter, r *http.Request, name string) (uuid.UUID, bool) {
+	raw := r.PathValue(name)
+	if raw == "" {
+		response.RespondInvalidParams(w, r, response.InvalidParam{Name: name, Reason: "is required"})
+
+		return uuid.Nil, false
+	}
+
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		response.RespondInvalidParams(w, r, response.InvalidParam{Name: name, Reason: "must be a valid UUID"})
+
+		return uuid.Nil, false
+	}
+
+	return id, true
+}
+
+func taxonomyScopeFromQuery(w http.ResponseWriter, r *http.Request) (models.TaxonomyScope, bool) {
+	scope := models.TaxonomyScope{
+		TenantID:   r.URL.Query().Get("tenant_id"),
+		SourceType: r.URL.Query().Get("source_type"),
+		SourceID:   r.URL.Query().Get("source_id"),
+		FieldID:    r.URL.Query().Get("field_id"),
+	}
+	if err := validation.ValidateStruct(scope); err != nil {
+		response.RespondError(w, r, err)
+
+		return models.TaxonomyScope{}, false
+	}
+
+	return scope, true
+}
+
+func respondTaxonomyError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, service.ErrTaxonomyEmbeddingsNotConfigured) {
+		response.RespondServiceUnavailable(w, r, "Taxonomy requires Hub embeddings to be configured.")
+
+		return
+	}
+
+	if errors.Is(err, service.ErrTaxonomyServiceNotConfigured) || errors.Is(err, service.ErrTaxonomyServiceStartFailed) {
+		response.RespondServiceUnavailable(w, r, "Taxonomy service is not available.")
+
+		return
+	}
+
+	response.RespondError(w, r, err)
+}

--- a/internal/api/handlers/taxonomy_internal_handler.go
+++ b/internal/api/handlers/taxonomy_internal_handler.go
@@ -1,17 +1,34 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/google/uuid"
+
 	"github.com/formbricks/hub/internal/api/response"
+	"github.com/formbricks/hub/internal/models"
 )
 
+type TaxonomyInternalService interface {
+	GetRunInput(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRunInputResponse, error)
+	CompleteRun(ctx context.Context, runID uuid.UUID, req models.TaxonomyRunResultRequest) (*models.TaxonomyRun, error)
+	FailRun(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error)
+}
+
 // TaxonomyInternalHandler hosts internal taxonomy service endpoints.
-type TaxonomyInternalHandler struct{}
+type TaxonomyInternalHandler struct {
+	service TaxonomyInternalService
+}
 
 // NewTaxonomyInternalHandler creates a taxonomy internal handler.
-func NewTaxonomyInternalHandler() *TaxonomyInternalHandler {
-	return &TaxonomyInternalHandler{}
+func NewTaxonomyInternalHandler(services ...TaxonomyInternalService) *TaxonomyInternalHandler {
+	var service TaxonomyInternalService
+	if len(services) > 0 {
+		service = services[0]
+	}
+
+	return &TaxonomyInternalHandler{service: service}
 }
 
 // AuthCheck returns success after middleware.Auth enforces the internal Hub API token.
@@ -20,4 +37,84 @@ func (h *TaxonomyInternalHandler) AuthCheck(w http.ResponseWriter, _ *http.Reque
 		"status":  "ok",
 		"service": "hub-taxonomy-internal",
 	})
+}
+
+func (h *TaxonomyInternalHandler) GetRunInput(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
+
+		return
+	}
+
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	result, err := h.service.GetRunInput(r.Context(), runID)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyInternalHandler) CompleteRun(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
+
+		return
+	}
+
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	var req models.TaxonomyRunResultRequest
+	if err := decodeAndValidateJSON(r, &req); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.CompleteRun(r.Context(), runID, req)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *TaxonomyInternalHandler) FailRun(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
+
+		return
+	}
+
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	var req models.TaxonomyRunFailedRequest
+	if err := decodeAndValidateJSON(r, &req); err != nil {
+		response.RespondError(w, r, err)
+
+		return
+	}
+
+	result, err := h.service.FailRun(r.Context(), runID, req.Error)
+	if err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, result)
 }

--- a/internal/api/handlers/taxonomy_internal_handler.go
+++ b/internal/api/handlers/taxonomy_internal_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formbricks/hub/internal/models"
 )
 
+// TaxonomyInternalService is the application service used by internal taxonomy endpoints.
 type TaxonomyInternalService interface {
 	GetRunInput(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRunInputResponse, error)
 	CompleteRun(ctx context.Context, runID uuid.UUID, req models.TaxonomyRunResultRequest) (*models.TaxonomyRun, error)
@@ -39,6 +40,7 @@ func (h *TaxonomyInternalHandler) AuthCheck(w http.ResponseWriter, _ *http.Reque
 	})
 }
 
+// GetRunInput returns run-scoped input for the taxonomy service.
 func (h *TaxonomyInternalHandler) GetRunInput(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
@@ -61,6 +63,7 @@ func (h *TaxonomyInternalHandler) GetRunInput(w http.ResponseWriter, r *http.Req
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// CompleteRun stores successful taxonomy output from the taxonomy service.
 func (h *TaxonomyInternalHandler) CompleteRun(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
@@ -90,6 +93,7 @@ func (h *TaxonomyInternalHandler) CompleteRun(w http.ResponseWriter, r *http.Req
 	response.RespondJSON(w, http.StatusOK, result)
 }
 
+// FailRun records a failed taxonomy run from the taxonomy service.
 func (h *TaxonomyInternalHandler) FailRun(w http.ResponseWriter, r *http.Request) {
 	if h.service == nil {
 		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")

--- a/internal/api/handlers/taxonomy_internal_handler.go
+++ b/internal/api/handlers/taxonomy_internal_handler.go
@@ -14,7 +14,12 @@ import (
 type TaxonomyInternalService interface {
 	GetRunInput(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRunInputResponse, error)
 	CompleteRun(ctx context.Context, runID uuid.UUID, req models.TaxonomyRunResultRequest) (*models.TaxonomyRun, error)
-	FailRun(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error)
+	FailRun(
+		ctx context.Context,
+		runID uuid.UUID,
+		message string,
+		errorCode models.TaxonomyRunFailureCode,
+	) (*models.TaxonomyRun, error)
 }
 
 // TaxonomyInternalHandler hosts internal taxonomy service endpoints.
@@ -113,7 +118,7 @@ func (h *TaxonomyInternalHandler) FailRun(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	result, err := h.service.FailRun(r.Context(), runID, req.Error)
+	result, err := h.service.FailRun(r.Context(), runID, req.Error, req.ErrorCode)
 	if err != nil {
 		respondTaxonomyError(w, r, err)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,9 +128,10 @@ type EmbeddingConfig struct {
 
 // TaxonomyConfig holds Hub-to-taxonomy service settings.
 type TaxonomyConfig struct {
-	ServiceURL          string `env:"TAXONOMY_SERVICE_URL"`
-	ServiceToken        string `env:"TAXONOMY_SERVICE_TOKEN"`
-	HubInternalAPIToken string `env:"HUB_INTERNAL_API_TOKEN"`
+	ServiceURL             string `env:"TAXONOMY_SERVICE_URL"`
+	ServiceToken           string `env:"TAXONOMY_SERVICE_TOKEN"`
+	HubInternalAPIToken    string `env:"HUB_INTERNAL_API_TOKEN"`
+	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
 }
 
 // ObservabilityConfig holds OpenTelemetry settings.
@@ -277,6 +278,10 @@ func applyDefaults(cfg *Config) {
 
 	if cfg.Embedding.MaxAttempts <= 0 {
 		cfg.Embedding.MaxAttempts = 3
+	}
+
+	if cfg.Taxonomy.MinimumEmbeddedRecords <= 0 {
+		cfg.Taxonomy.MinimumEmbeddedRecords = 20
 	}
 }
 

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -7,8 +7,10 @@ import (
 	"github.com/google/uuid"
 )
 
+// TaxonomyRunStatus is the lifecycle state for a taxonomy generation run.
 type TaxonomyRunStatus string
 
+// Taxonomy run statuses.
 const (
 	TaxonomyRunStatusPending   TaxonomyRunStatus = "pending"
 	TaxonomyRunStatusRunning   TaxonomyRunStatus = "running"
@@ -17,14 +19,17 @@ const (
 	TaxonomyRunStatusCanceled  TaxonomyRunStatus = "canceled"
 )
 
+// TaxonomyNodeType describes a taxonomy node's position in the tree.
 type TaxonomyNodeType string
 
+// Taxonomy node types.
 const (
 	TaxonomyNodeTypeRoot   TaxonomyNodeType = "root"
 	TaxonomyNodeTypeBranch TaxonomyNodeType = "branch"
 	TaxonomyNodeTypeLeaf   TaxonomyNodeType = "leaf"
 )
 
+// TaxonomyScope identifies the feedback field that a taxonomy run covers.
 type TaxonomyScope struct {
 	TenantID   string `json:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
 	SourceType string `json:"source_type" validate:"required,no_null_bytes,min=1,max=255"`
@@ -32,6 +37,7 @@ type TaxonomyScope struct {
 	FieldID    string `json:"field_id"    validate:"required,no_null_bytes,min=1,max=255"`
 }
 
+// TaxonomyFieldOption describes a feedback field that can be used for taxonomy generation.
 type TaxonomyFieldOption struct {
 	TenantID       string `json:"tenant_id"`
 	SourceType     string `json:"source_type"`
@@ -43,10 +49,12 @@ type TaxonomyFieldOption struct {
 	EmbeddingCount int    `json:"embedding_count"`
 }
 
+// TaxonomyFieldsResponse contains taxonomy-capable field options.
 type TaxonomyFieldsResponse struct {
 	Data []TaxonomyFieldOption `json:"data"`
 }
 
+// TaxonomyRun is a persisted taxonomy generation run.
 type TaxonomyRun struct {
 	ID             uuid.UUID         `json:"id"`
 	TenantID       string            `json:"tenant_id"`
@@ -68,17 +76,21 @@ type TaxonomyRun struct {
 	UpdatedAt      time.Time         `json:"updated_at"`
 }
 
+// CreateTaxonomyRunRequest starts a manual taxonomy generation run.
 type CreateTaxonomyRunRequest struct {
 	TaxonomyScope
+
 	FieldLabel *string `json:"field_label,omitempty" validate:"omitempty,no_null_bytes"`
 	ActorID    *string `json:"actor_id,omitempty"    validate:"omitempty,no_null_bytes,min=1,max=255"`
 }
 
+// CreateTaxonomyRunResponse returns the created or already-running taxonomy run.
 type CreateTaxonomyRunResponse struct {
 	Run        TaxonomyRun `json:"run"`
 	InProgress bool        `json:"in_progress"`
 }
 
+// ListTaxonomyRunsFilters scopes taxonomy run history queries.
 type ListTaxonomyRunsFilters struct {
 	TenantID   string `form:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
 	SourceType string `form:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
@@ -87,10 +99,12 @@ type ListTaxonomyRunsFilters struct {
 	Limit      int    `form:"limit"       validate:"omitempty,min=1,max=100"`
 }
 
+// ListTaxonomyRunsResponse contains taxonomy run history.
 type ListTaxonomyRunsResponse struct {
 	Data []TaxonomyRun `json:"data"`
 }
 
+// TaxonomyCluster is a generated feedback cluster for a taxonomy run.
 type TaxonomyCluster struct {
 	ID         uuid.UUID       `json:"id"`
 	RunID      uuid.UUID       `json:"run_id"`
@@ -105,6 +119,7 @@ type TaxonomyCluster struct {
 	UpdatedAt  time.Time       `json:"updated_at"`
 }
 
+// TaxonomyNode is a generated or edited node in a taxonomy tree.
 type TaxonomyNode struct {
 	ID            uuid.UUID        `json:"id"`
 	RunID         uuid.UUID        `json:"run_id"`
@@ -124,11 +139,13 @@ type TaxonomyNode struct {
 	Children      []TaxonomyNode   `json:"children,omitempty"`
 }
 
+// TaxonomyTreeResponse returns a run and its taxonomy tree.
 type TaxonomyTreeResponse struct {
 	Run  TaxonomyRun   `json:"run"`
 	Root *TaxonomyNode `json:"root"`
 }
 
+// TaxonomyRunInputRecord is a feedback record and embedding used by the taxonomy service.
 type TaxonomyRunInputRecord struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id"`
 	FieldLabel       string    `json:"field_label,omitempty"`
@@ -136,11 +153,13 @@ type TaxonomyRunInputRecord struct {
 	Embedding        []float32 `json:"embedding"`
 }
 
+// TaxonomyRunInputResponse contains run-scoped input for the taxonomy service.
 type TaxonomyRunInputResponse struct {
 	Run     TaxonomyRun              `json:"run"`
 	Records []TaxonomyRunInputRecord `json:"records"`
 }
 
+// TaxonomyResultCluster is a generated cluster returned by the taxonomy service.
 type TaxonomyResultCluster struct {
 	ClusterKey int             `json:"cluster_key"`
 	Label      *string         `json:"label,omitempty"`
@@ -151,6 +170,7 @@ type TaxonomyResultCluster struct {
 	Metrics    json.RawMessage `json:"metrics,omitempty"`
 }
 
+// TaxonomyResultMembership maps a feedback record to a generated cluster.
 type TaxonomyResultMembership struct {
 	ClusterKey       int             `json:"cluster_key"`
 	FeedbackRecordID uuid.UUID       `json:"feedback_record_id"`
@@ -159,45 +179,52 @@ type TaxonomyResultMembership struct {
 	Metadata         json.RawMessage `json:"metadata,omitempty"`
 }
 
+// TaxonomyResultNode is a generated taxonomy tree node returned by the taxonomy service.
 type TaxonomyResultNode struct {
-	NodeKey     string           `json:"node_key"    validate:"required,no_null_bytes,min=1,max=255"`
-	ParentKey   *string          `json:"parent_key,omitempty" validate:"omitempty,no_null_bytes,min=1,max=255"`
+	NodeKey     string           `json:"node_key"              validate:"required,no_null_bytes,min=1,max=255"`
+	ParentKey   *string          `json:"parent_key,omitempty"  validate:"omitempty,no_null_bytes,min=1,max=255"`
 	ClusterKey  *int             `json:"cluster_key,omitempty"`
-	NodeType    TaxonomyNodeType `json:"node_type"   validate:"required,oneof=root branch leaf"`
-	Label       string           `json:"label"       validate:"required,no_null_bytes,min=1"`
+	NodeType    TaxonomyNodeType `json:"node_type"             validate:"required,oneof=root branch leaf"`
+	Label       string           `json:"label"                 validate:"required,no_null_bytes,min=1"`
 	Description *string          `json:"description,omitempty" validate:"omitempty,no_null_bytes"`
-	Level       int              `json:"level"       validate:"min=0"`
+	Level       int              `json:"level"                 validate:"min=0"`
 	SortOrder   int              `json:"sort_order"`
 	Metadata    json.RawMessage  `json:"metadata,omitempty"`
 }
 
+// TaxonomyRunResultRequest persists generated taxonomy artifacts.
 type TaxonomyRunResultRequest struct {
 	Metrics     json.RawMessage            `json:"metrics,omitempty"`
-	Clusters    []TaxonomyResultCluster    `json:"clusters"    validate:"required,dive"`
-	Memberships []TaxonomyResultMembership `json:"memberships" validate:"required,dive"`
-	Nodes       []TaxonomyResultNode       `json:"nodes"       validate:"required,dive"`
+	Clusters    []TaxonomyResultCluster    `json:"clusters"          validate:"required,dive"`
+	Memberships []TaxonomyResultMembership `json:"memberships"       validate:"required,dive"`
+	Nodes       []TaxonomyResultNode       `json:"nodes"             validate:"required,dive"`
 }
 
+// TaxonomyRunFailedRequest records a taxonomy run failure.
 type TaxonomyRunFailedRequest struct {
 	Error string `json:"error" validate:"required,no_null_bytes,min=1,max=2000"`
 }
 
+// RenameTaxonomyNodeRequest renames a generated taxonomy node.
 type RenameTaxonomyNodeRequest struct {
 	TenantID string `json:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
 	ActorID  string `json:"actor_id"  validate:"required,no_null_bytes,min=1,max=255"`
 	Label    string `json:"label"     validate:"required,no_null_bytes,min=1"`
 }
 
+// TaxonomyNodeRecordsFilters scopes taxonomy node feedback record drilldown.
 type TaxonomyNodeRecordsFilters struct {
 	TenantID string `form:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
 	Limit    int    `form:"limit"     validate:"omitempty,min=1,max=100"`
 }
 
+// RemoveTaxonomyNodeFilters scopes a taxonomy node soft-remove request.
 type RemoveTaxonomyNodeFilters struct {
 	TenantID string `form:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
 	ActorID  string `form:"actor_id"  validate:"required,no_null_bytes,min=1,max=255"`
 }
 
+// TaxonomyNodeRecordsResponse contains feedback records for a taxonomy node.
 type TaxonomyNodeRecordsResponse struct {
 	Data  []FeedbackRecord `json:"data"`
 	Limit int              `json:"limit"`

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -1,0 +1,204 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type TaxonomyRunStatus string
+
+const (
+	TaxonomyRunStatusPending   TaxonomyRunStatus = "pending"
+	TaxonomyRunStatusRunning   TaxonomyRunStatus = "running"
+	TaxonomyRunStatusSucceeded TaxonomyRunStatus = "succeeded"
+	TaxonomyRunStatusFailed    TaxonomyRunStatus = "failed"
+	TaxonomyRunStatusCanceled  TaxonomyRunStatus = "canceled"
+)
+
+type TaxonomyNodeType string
+
+const (
+	TaxonomyNodeTypeRoot   TaxonomyNodeType = "root"
+	TaxonomyNodeTypeBranch TaxonomyNodeType = "branch"
+	TaxonomyNodeTypeLeaf   TaxonomyNodeType = "leaf"
+)
+
+type TaxonomyScope struct {
+	TenantID   string `json:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
+	SourceType string `json:"source_type" validate:"required,no_null_bytes,min=1,max=255"`
+	SourceID   string `json:"source_id"   validate:"required,no_null_bytes,min=1,max=255"`
+	FieldID    string `json:"field_id"    validate:"required,no_null_bytes,min=1,max=255"`
+}
+
+type TaxonomyFieldOption struct {
+	TenantID       string `json:"tenant_id"`
+	SourceType     string `json:"source_type"`
+	SourceID       string `json:"source_id"`
+	SourceName     string `json:"source_name,omitempty"`
+	FieldID        string `json:"field_id"`
+	FieldLabel     string `json:"field_label,omitempty"`
+	RecordCount    int    `json:"record_count"`
+	EmbeddingCount int    `json:"embedding_count"`
+}
+
+type TaxonomyFieldsResponse struct {
+	Data []TaxonomyFieldOption `json:"data"`
+}
+
+type TaxonomyRun struct {
+	ID             uuid.UUID         `json:"id"`
+	TenantID       string            `json:"tenant_id"`
+	SourceType     string            `json:"source_type"`
+	SourceID       string            `json:"source_id"`
+	FieldID        string            `json:"field_id"`
+	FieldLabel     *string           `json:"field_label,omitempty"`
+	Status         TaxonomyRunStatus `json:"status"`
+	Params         json.RawMessage   `json:"params,omitempty"`
+	Metrics        json.RawMessage   `json:"metrics,omitempty"`
+	RecordCount    int               `json:"record_count"`
+	EmbeddingCount int               `json:"embedding_count"`
+	ClusterCount   int               `json:"cluster_count"`
+	NodeCount      int               `json:"node_count"`
+	Error          *string           `json:"error,omitempty"`
+	StartedAt      *time.Time        `json:"started_at,omitempty"`
+	FinishedAt     *time.Time        `json:"finished_at,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+}
+
+type CreateTaxonomyRunRequest struct {
+	TaxonomyScope
+	FieldLabel *string `json:"field_label,omitempty" validate:"omitempty,no_null_bytes"`
+	ActorID    *string `json:"actor_id,omitempty"    validate:"omitempty,no_null_bytes,min=1,max=255"`
+}
+
+type CreateTaxonomyRunResponse struct {
+	Run        TaxonomyRun `json:"run"`
+	InProgress bool        `json:"in_progress"`
+}
+
+type ListTaxonomyRunsFilters struct {
+	TenantID   string `form:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
+	SourceType string `form:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
+	SourceID   string `form:"source_id"   validate:"omitempty,no_null_bytes,min=1,max=255"`
+	FieldID    string `form:"field_id"    validate:"omitempty,no_null_bytes,min=1,max=255"`
+	Limit      int    `form:"limit"       validate:"omitempty,min=1,max=100"`
+}
+
+type ListTaxonomyRunsResponse struct {
+	Data []TaxonomyRun `json:"data"`
+}
+
+type TaxonomyCluster struct {
+	ID         uuid.UUID       `json:"id"`
+	RunID      uuid.UUID       `json:"run_id"`
+	ClusterKey int             `json:"cluster_key"`
+	Label      *string         `json:"label,omitempty"`
+	LLMLabel   *string         `json:"llm_label,omitempty"`
+	Keywords   json.RawMessage `json:"keywords,omitempty"`
+	Size       int             `json:"size"`
+	IsOutlier  bool            `json:"is_outlier"`
+	Metrics    json.RawMessage `json:"metrics,omitempty"`
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+type TaxonomyNode struct {
+	ID            uuid.UUID        `json:"id"`
+	RunID         uuid.UUID        `json:"run_id"`
+	ParentID      *uuid.UUID       `json:"parent_id,omitempty"`
+	ClusterID     *uuid.UUID       `json:"cluster_id,omitempty"`
+	NodeType      TaxonomyNodeType `json:"node_type"`
+	Label         string           `json:"label"`
+	OriginalLabel *string          `json:"original_label,omitempty"`
+	Description   *string          `json:"description,omitempty"`
+	Level         int              `json:"level"`
+	SortOrder     int              `json:"sort_order"`
+	Metadata      json.RawMessage  `json:"metadata,omitempty"`
+	RemovedAt     *time.Time       `json:"removed_at,omitempty"`
+	RemovedBy     *string          `json:"removed_by,omitempty"`
+	CreatedAt     time.Time        `json:"created_at"`
+	UpdatedAt     time.Time        `json:"updated_at"`
+	Children      []TaxonomyNode   `json:"children,omitempty"`
+}
+
+type TaxonomyTreeResponse struct {
+	Run  TaxonomyRun   `json:"run"`
+	Root *TaxonomyNode `json:"root"`
+}
+
+type TaxonomyRunInputRecord struct {
+	FeedbackRecordID uuid.UUID `json:"feedback_record_id"`
+	FieldLabel       string    `json:"field_label,omitempty"`
+	ValueText        string    `json:"value_text"`
+	Embedding        []float32 `json:"embedding"`
+}
+
+type TaxonomyRunInputResponse struct {
+	Run     TaxonomyRun              `json:"run"`
+	Records []TaxonomyRunInputRecord `json:"records"`
+}
+
+type TaxonomyResultCluster struct {
+	ClusterKey int             `json:"cluster_key"`
+	Label      *string         `json:"label,omitempty"`
+	LLMLabel   *string         `json:"llm_label,omitempty"`
+	Keywords   json.RawMessage `json:"keywords,omitempty"`
+	Size       int             `json:"size"`
+	IsOutlier  bool            `json:"is_outlier"`
+	Metrics    json.RawMessage `json:"metrics,omitempty"`
+}
+
+type TaxonomyResultMembership struct {
+	ClusterKey       int             `json:"cluster_key"`
+	FeedbackRecordID uuid.UUID       `json:"feedback_record_id"`
+	Confidence       *float64        `json:"confidence,omitempty"`
+	Distance         *float64        `json:"distance,omitempty"`
+	Metadata         json.RawMessage `json:"metadata,omitempty"`
+}
+
+type TaxonomyResultNode struct {
+	NodeKey     string           `json:"node_key"    validate:"required,no_null_bytes,min=1,max=255"`
+	ParentKey   *string          `json:"parent_key,omitempty" validate:"omitempty,no_null_bytes,min=1,max=255"`
+	ClusterKey  *int             `json:"cluster_key,omitempty"`
+	NodeType    TaxonomyNodeType `json:"node_type"   validate:"required,oneof=root branch leaf"`
+	Label       string           `json:"label"       validate:"required,no_null_bytes,min=1"`
+	Description *string          `json:"description,omitempty" validate:"omitempty,no_null_bytes"`
+	Level       int              `json:"level"       validate:"min=0"`
+	SortOrder   int              `json:"sort_order"`
+	Metadata    json.RawMessage  `json:"metadata,omitempty"`
+}
+
+type TaxonomyRunResultRequest struct {
+	Metrics     json.RawMessage            `json:"metrics,omitempty"`
+	Clusters    []TaxonomyResultCluster    `json:"clusters"    validate:"required,dive"`
+	Memberships []TaxonomyResultMembership `json:"memberships" validate:"required,dive"`
+	Nodes       []TaxonomyResultNode       `json:"nodes"       validate:"required,dive"`
+}
+
+type TaxonomyRunFailedRequest struct {
+	Error string `json:"error" validate:"required,no_null_bytes,min=1,max=2000"`
+}
+
+type RenameTaxonomyNodeRequest struct {
+	TenantID string `json:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
+	ActorID  string `json:"actor_id"  validate:"required,no_null_bytes,min=1,max=255"`
+	Label    string `json:"label"     validate:"required,no_null_bytes,min=1"`
+}
+
+type TaxonomyNodeRecordsFilters struct {
+	TenantID string `form:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
+	Limit    int    `form:"limit"     validate:"omitempty,min=1,max=100"`
+}
+
+type RemoveTaxonomyNodeFilters struct {
+	TenantID string `form:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
+	ActorID  string `form:"actor_id"  validate:"required,no_null_bytes,min=1,max=255"`
+}
+
+type TaxonomyNodeRecordsResponse struct {
+	Data  []FeedbackRecord `json:"data"`
+	Limit int              `json:"limit"`
+}

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -7,7 +7,19 @@ import (
 	"github.com/google/uuid"
 )
 
-// TaxonomyRunStatus is the lifecycle state for a taxonomy generation run.
+// TaxonomyRunStatus is the persisted lifecycle state for a taxonomy generation run.
+//
+// Lifecycle contract:
+//   - pending: Hub accepted the manual request and persisted a run.
+//   - running: Hub handed the run to the taxonomy service.
+//   - succeeded: the taxonomy service persisted artifacts and Hub activated the run.
+//   - failed: the run ended with a sanitized error and optional failure code.
+//   - canceled: reserved for future user/operator cancellation.
+//
+// Allowed transitions are pending -> running|failed|canceled and
+// running -> succeeded|failed|canceled. Terminal states must not be overwritten.
+// Insufficient input and service availability are represented as failure/error
+// codes, not as additional persisted statuses.
 type TaxonomyRunStatus string
 
 // Taxonomy run statuses.
@@ -17,6 +29,18 @@ const (
 	TaxonomyRunStatusSucceeded TaxonomyRunStatus = "succeeded"
 	TaxonomyRunStatusFailed    TaxonomyRunStatus = "failed"
 	TaxonomyRunStatusCanceled  TaxonomyRunStatus = "canceled"
+)
+
+// TaxonomyRunFailureCode is a machine-readable reason for a failed taxonomy run or prerequisite error.
+type TaxonomyRunFailureCode string
+
+// Taxonomy run failure codes.
+const (
+	TaxonomyRunFailureCodeInsufficientData   TaxonomyRunFailureCode = "insufficient_data"
+	TaxonomyRunFailureCodeServiceUnavailable TaxonomyRunFailureCode = "service_unavailable"
+	TaxonomyRunFailureCodeGenerationFailed   TaxonomyRunFailureCode = "generation_failed"
+	TaxonomyRunFailureCodeInvalidOutput      TaxonomyRunFailureCode = "invalid_output"
+	TaxonomyRunFailureCodeInternalError      TaxonomyRunFailureCode = "internal_error"
 )
 
 // TaxonomyNodeType describes a taxonomy node's position in the tree.
@@ -56,24 +80,25 @@ type TaxonomyFieldsResponse struct {
 
 // TaxonomyRun is a persisted taxonomy generation run.
 type TaxonomyRun struct {
-	ID             uuid.UUID         `json:"id"`
-	TenantID       string            `json:"tenant_id"`
-	SourceType     string            `json:"source_type"`
-	SourceID       string            `json:"source_id"`
-	FieldID        string            `json:"field_id"`
-	FieldLabel     *string           `json:"field_label,omitempty"`
-	Status         TaxonomyRunStatus `json:"status"`
-	Params         json.RawMessage   `json:"params,omitempty"`
-	Metrics        json.RawMessage   `json:"metrics,omitempty"`
-	RecordCount    int               `json:"record_count"`
-	EmbeddingCount int               `json:"embedding_count"`
-	ClusterCount   int               `json:"cluster_count"`
-	NodeCount      int               `json:"node_count"`
-	Error          *string           `json:"error,omitempty"`
-	StartedAt      *time.Time        `json:"started_at,omitempty"`
-	FinishedAt     *time.Time        `json:"finished_at,omitempty"`
-	CreatedAt      time.Time         `json:"created_at"`
-	UpdatedAt      time.Time         `json:"updated_at"`
+	ID             uuid.UUID               `json:"id"`
+	TenantID       string                  `json:"tenant_id"`
+	SourceType     string                  `json:"source_type"`
+	SourceID       string                  `json:"source_id"`
+	FieldID        string                  `json:"field_id"`
+	FieldLabel     *string                 `json:"field_label,omitempty"`
+	Status         TaxonomyRunStatus       `json:"status"`
+	Params         json.RawMessage         `json:"params,omitempty"`
+	Metrics        json.RawMessage         `json:"metrics,omitempty"`
+	RecordCount    int                     `json:"record_count"`
+	EmbeddingCount int                     `json:"embedding_count"`
+	ClusterCount   int                     `json:"cluster_count"`
+	NodeCount      int                     `json:"node_count"`
+	Error          *string                 `json:"error,omitempty"`
+	ErrorCode      *TaxonomyRunFailureCode `json:"error_code,omitempty"`
+	StartedAt      *time.Time              `json:"started_at,omitempty"`
+	FinishedAt     *time.Time              `json:"finished_at,omitempty"`
+	CreatedAt      time.Time               `json:"created_at"`
+	UpdatedAt      time.Time               `json:"updated_at"`
 }
 
 // CreateTaxonomyRunRequest starts a manual taxonomy generation run.
@@ -202,7 +227,8 @@ type TaxonomyRunResultRequest struct {
 
 // TaxonomyRunFailedRequest records a taxonomy run failure.
 type TaxonomyRunFailedRequest struct {
-	Error string `json:"error" validate:"required,no_null_bytes,min=1,max=2000"`
+	Error     string                 `json:"error"                validate:"required,no_null_bytes,min=1,max=2000"`
+	ErrorCode TaxonomyRunFailureCode `json:"error_code,omitempty" validate:"omitempty,oneof=insufficient_data service_unavailable generation_failed invalid_output internal_error"` //nolint:lll // Validator oneof values are space-delimited.
 }
 
 // RenameTaxonomyNodeRequest renames a generated taxonomy node.

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -27,22 +27,27 @@ var (
 	defaultJSONArr = json.RawMessage(`[]`)
 )
 
+// TaxonomyRepository stores taxonomy runs, artifacts, and edit events.
 type TaxonomyRepository struct {
 	db *pgxpool.Pool
 }
 
+// CreateTaxonomyRunParams contains the data needed to create a taxonomy run.
 type CreateTaxonomyRunParams struct {
 	models.TaxonomyScope
+
 	FieldLabel     *string
 	Params         json.RawMessage
 	RecordCount    int
 	EmbeddingCount int
 }
 
+// NewTaxonomyRepository creates a taxonomy repository.
 func NewTaxonomyRepository(db *pgxpool.Pool) *TaxonomyRepository {
 	return &TaxonomyRepository{db: db}
 }
 
+// ListFieldOptions returns taxonomy-capable feedback fields for a tenant.
 func (r *TaxonomyRepository) ListFieldOptions(
 	ctx context.Context,
 	tenantID string,
@@ -75,6 +80,7 @@ func (r *TaxonomyRepository) ListFieldOptions(
 	defer rows.Close()
 
 	out := make([]models.TaxonomyFieldOption, 0)
+
 	for rows.Next() {
 		var option models.TaxonomyFieldOption
 		if err := rows.Scan(
@@ -100,6 +106,7 @@ func (r *TaxonomyRepository) ListFieldOptions(
 	return out, nil
 }
 
+// CountScopeInput counts text records and embeddings for a taxonomy scope.
 func (r *TaxonomyRepository) CountScopeInput(
 	ctx context.Context,
 	scope models.TaxonomyScope,
@@ -133,25 +140,26 @@ func (r *TaxonomyRepository) CountScopeInput(
 	return recordCount, embeddingCount, fieldLabel, nil
 }
 
+// CreateRunIfAvailable creates a taxonomy run unless one is already pending or running.
 func (r *TaxonomyRepository) CreateRunIfAvailable(
 	ctx context.Context,
 	params CreateTaxonomyRunParams,
 ) (*models.TaxonomyRun, bool, error) {
-	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	transaction, err := r.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("begin taxonomy run create tx: %w", err)
 	}
 
 	defer func() {
-		_ = tx.Rollback(ctx)
+		_ = transaction.Rollback(ctx)
 	}()
 
 	lockKey := taxonomyScopeLockKey(params.TaxonomyScope)
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey); err != nil {
+	if _, err := transaction.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey); err != nil {
 		return nil, false, fmt.Errorf("lock taxonomy run scope: %w", err)
 	}
 
-	existing, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+`
+	existing, err := queryTaxonomyRun(ctx, transaction, taxonomyRunSelect+`
 		FROM taxonomy_runs
 		WHERE tenant_id = $1
 		  AND source_type = $2
@@ -165,15 +173,16 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, false, fmt.Errorf("find in-progress taxonomy run: %w", err)
 	}
+
 	if existing != nil {
-		if err := tx.Commit(ctx); err != nil {
+		if err := transaction.Commit(ctx); err != nil {
 			return nil, false, fmt.Errorf("commit existing taxonomy run tx: %w", err)
 		}
 
 		return existing, false, nil
 	}
 
-	run, err := queryTaxonomyRun(ctx, tx, `
+	run, err := queryTaxonomyRun(ctx, transaction, `
 		WITH taxonomy_runs AS (
 			INSERT INTO taxonomy_runs (
 				tenant_id, source_type, source_id, field_id, field_label,
@@ -195,7 +204,7 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 		return nil, false, fmt.Errorf("insert taxonomy run: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err := transaction.Commit(ctx); err != nil {
 		return nil, false, fmt.Errorf("commit taxonomy run create tx: %w", err)
 	}
 
@@ -212,6 +221,7 @@ func taxonomyScopeLockKey(scope models.TaxonomyScope) string {
 	)
 }
 
+// MarkRunRunning transitions a taxonomy run to running.
 func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, `
 		WITH taxonomy_runs AS (
@@ -233,6 +243,7 @@ func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID
 	return run, nil
 }
 
+// MarkRunFailed transitions a taxonomy run to failed with an error message.
 func (r *TaxonomyRepository) MarkRunFailed(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, `
 		WITH taxonomy_runs AS (
@@ -254,6 +265,7 @@ func (r *TaxonomyRepository) MarkRunFailed(ctx context.Context, runID uuid.UUID,
 	return run, nil
 }
 
+// GetRun returns a taxonomy run by ID.
 func (r *TaxonomyRepository) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1`, runID)
 	if err != nil {
@@ -267,6 +279,7 @@ func (r *TaxonomyRepository) GetRun(ctx context.Context, runID uuid.UUID) (*mode
 	return run, nil
 }
 
+// GetActiveRun returns the active taxonomy run for a scope.
 func (r *TaxonomyRepository) GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+`
 		FROM taxonomy_active_runs ar
@@ -288,6 +301,7 @@ func (r *TaxonomyRepository) GetActiveRun(ctx context.Context, scope models.Taxo
 	return run, nil
 }
 
+// ListRuns returns taxonomy run history for a tenant and optional scope filters.
 func (r *TaxonomyRepository) ListRuns(
 	ctx context.Context,
 	filters models.ListTaxonomyRunsFilters,
@@ -325,6 +339,7 @@ func (r *TaxonomyRepository) ListRuns(
 	return scanTaxonomyRuns(rows)
 }
 
+// GetRunInput returns feedback records and embeddings for a taxonomy run.
 func (r *TaxonomyRepository) GetRunInput(
 	ctx context.Context,
 	runID uuid.UUID,
@@ -355,6 +370,7 @@ func (r *TaxonomyRepository) GetRunInput(
 	defer rows.Close()
 
 	records := make([]models.TaxonomyRunInputRecord, 0, run.EmbeddingCount)
+
 	for rows.Next() {
 		var (
 			record models.TaxonomyRunInputRecord
@@ -375,21 +391,22 @@ func (r *TaxonomyRepository) GetRunInput(
 	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
 }
 
+// StoreResultAndActivate stores generated taxonomy artifacts and activates the run.
 func (r *TaxonomyRepository) StoreResultAndActivate(
 	ctx context.Context,
 	runID uuid.UUID,
 	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
-	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	transaction, err := r.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin taxonomy result tx: %w", err)
 	}
 
 	defer func() {
-		_ = tx.Rollback(ctx)
+		_ = transaction.Rollback(ctx)
 	}()
 
-	run, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1 FOR UPDATE`, runID)
+	run, err := queryTaxonomyRun(ctx, transaction, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1 FOR UPDATE`, runID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
@@ -401,7 +418,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 	clusterIDs := make(map[int]uuid.UUID, len(req.Clusters))
 	for _, cluster := range req.Clusters {
 		var clusterID uuid.UUID
-		if err := tx.QueryRow(ctx, `
+		if err := transaction.QueryRow(ctx, `
 			INSERT INTO taxonomy_clusters (
 				run_id, cluster_key, label, llm_label, keywords, size, is_outlier, metrics
 			)
@@ -428,7 +445,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 			return nil, huberrors.NewValidationError("memberships.cluster_key", "references an unknown cluster")
 		}
 
-		if _, err := tx.Exec(ctx, `
+		if _, err := transaction.Exec(ctx, `
 			INSERT INTO taxonomy_cluster_memberships (
 				run_id, tenant_id, cluster_id, feedback_record_id, confidence, distance, metadata
 			)
@@ -457,6 +474,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 	nodeIDs := make(map[string]uuid.UUID, len(nodes))
 	for _, node := range nodes {
 		var parentID *uuid.UUID
+
 		if node.ParentKey != nil {
 			resolved, ok := nodeIDs[*node.ParentKey]
 			if !ok {
@@ -467,6 +485,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		}
 
 		var clusterID *uuid.UUID
+
 		if node.ClusterKey != nil {
 			resolved, ok := clusterIDs[*node.ClusterKey]
 			if !ok {
@@ -477,7 +496,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		}
 
 		var nodeID uuid.UUID
-		if err := tx.QueryRow(ctx, `
+		if err := transaction.QueryRow(ctx, `
 			INSERT INTO taxonomy_nodes (
 				run_id, parent_id, cluster_id, node_type, label, original_label,
 				description, level, sort_order, metadata
@@ -501,7 +520,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 	}
 
 	activatedBy := taxonomyRunRequestedBy(run.Params)
-	if _, err := tx.Exec(ctx, `
+	if _, err := transaction.Exec(ctx, `
 		INSERT INTO taxonomy_active_runs (
 			tenant_id, source_type, source_id, field_id, run_id, activated_by
 		)
@@ -521,7 +540,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		return nil, fmt.Errorf("activate taxonomy run: %w", err)
 	}
 
-	updated, err := queryTaxonomyRun(ctx, tx, `
+	updated, err := queryTaxonomyRun(ctx, transaction, `
 		WITH taxonomy_runs AS (
 			UPDATE taxonomy_runs
 			SET status = 'succeeded',
@@ -543,13 +562,14 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		return nil, fmt.Errorf("mark taxonomy run succeeded: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err := transaction.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit taxonomy result tx: %w", err)
 	}
 
 	return updated, nil
 }
 
+// GetTree returns the visible taxonomy tree for a run.
 func (r *TaxonomyRepository) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
 	run, err := r.GetRun(ctx, runID)
 	if err != nil {
@@ -566,6 +586,7 @@ func (r *TaxonomyRepository) GetTree(ctx context.Context, runID uuid.UUID) (*mod
 	return &models.TaxonomyTreeResponse{Run: *run, Root: root}, nil
 }
 
+// RenameNode updates a taxonomy node label and records an edit event.
 func (r *TaxonomyRepository) RenameNode(
 	ctx context.Context,
 	nodeID uuid.UUID,
@@ -573,21 +594,21 @@ func (r *TaxonomyRepository) RenameNode(
 	actorID string,
 	label string,
 ) (*models.TaxonomyNode, error) {
-	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	transaction, err := r.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin taxonomy node rename tx: %w", err)
 	}
 
 	defer func() {
-		_ = tx.Rollback(ctx)
+		_ = transaction.Rollback(ctx)
 	}()
 
-	node, run, err := getNodeForUpdate(ctx, tx, nodeID, tenantID)
+	node, run, err := getNodeForUpdate(ctx, transaction, nodeID, tenantID)
 	if err != nil {
 		return nil, err
 	}
 
-	updated, err := queryTaxonomyNode(ctx, tx, `
+	updated, err := queryTaxonomyNode(ctx, transaction, `
 		WITH taxonomy_nodes AS (
 			UPDATE taxonomy_nodes
 			SET label = $2, updated_at = NOW()
@@ -600,40 +621,41 @@ func (r *TaxonomyRepository) RenameNode(
 		return nil, fmt.Errorf("rename taxonomy node: %w", err)
 	}
 
-	if err := insertNodeEvent(ctx, tx, run, nodeID, "rename", actorID,
+	if err := insertNodeEvent(ctx, transaction, run, nodeID, "rename", actorID,
 		map[string]string{"label": node.Label},
 		map[string]string{"label": label}); err != nil {
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err := transaction.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit taxonomy node rename tx: %w", err)
 	}
 
 	return updated, nil
 }
 
+// RemoveNode soft-removes a taxonomy node and records an edit event.
 func (r *TaxonomyRepository) RemoveNode(
 	ctx context.Context,
 	nodeID uuid.UUID,
 	tenantID string,
 	actorID string,
 ) (*models.TaxonomyNode, error) {
-	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	transaction, err := r.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin taxonomy node remove tx: %w", err)
 	}
 
 	defer func() {
-		_ = tx.Rollback(ctx)
+		_ = transaction.Rollback(ctx)
 	}()
 
-	_, run, err := getNodeForUpdate(ctx, tx, nodeID, tenantID)
+	_, run, err := getNodeForUpdate(ctx, transaction, nodeID, tenantID)
 	if err != nil {
 		return nil, err
 	}
 
-	updated, err := queryTaxonomyNode(ctx, tx, `
+	updated, err := queryTaxonomyNode(ctx, transaction, `
 		WITH taxonomy_nodes AS (
 			UPDATE taxonomy_nodes
 			SET removed_at = NOW(), removed_by = $2, updated_at = NOW()
@@ -646,19 +668,20 @@ func (r *TaxonomyRepository) RemoveNode(
 		return nil, fmt.Errorf("remove taxonomy node: %w", err)
 	}
 
-	if err := insertNodeEvent(ctx, tx, run, nodeID, "soft_remove", actorID,
+	if err := insertNodeEvent(ctx, transaction, run, nodeID, "soft_remove", actorID,
 		map[string]any{"removed_at": nil},
 		map[string]string{"removed_by": actorID}); err != nil {
 		return nil, err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err := transaction.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit taxonomy node remove tx: %w", err)
 	}
 
 	return updated, nil
 }
 
+// ListNodeRecords returns feedback records assigned to a visible taxonomy node or descendants.
 func (r *TaxonomyRepository) ListNodeRecords(
 	ctx context.Context,
 	nodeID uuid.UUID,
@@ -700,10 +723,11 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	defer rows.Close()
 
 	records := []models.FeedbackRecord{}
+
 	for rows.Next() {
 		record, err := scanFeedbackRecord(rows)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("scan taxonomy node record: %w", err)
 		}
 
 		records = append(records, *record)
@@ -729,6 +753,7 @@ func (r *TaxonomyRepository) listVisibleNodes(ctx context.Context, runID uuid.UU
 	defer rows.Close()
 
 	nodes := []models.TaxonomyNode{}
+
 	for rows.Next() {
 		node, err := scanTaxonomyNode(rows)
 		if err != nil {
@@ -788,7 +813,7 @@ func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
 		&run.CreatedAt,
 		&run.UpdatedAt,
 	); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan taxonomy run: %w", err)
 	}
 
 	return &run, nil
@@ -796,6 +821,7 @@ func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
 
 func scanTaxonomyRuns(rows pgx.Rows) ([]models.TaxonomyRun, error) {
 	out := make([]models.TaxonomyRun, 0)
+
 	for rows.Next() {
 		run, err := scanTaxonomyRun(rows)
 		if err != nil {
@@ -847,11 +873,11 @@ func scanTaxonomyNode(row scanner) (*models.TaxonomyNode, error) {
 
 func getNodeForUpdate(
 	ctx context.Context,
-	tx pgx.Tx,
+	transaction pgx.Tx,
 	nodeID uuid.UUID,
 	tenantID string,
 ) (*models.TaxonomyNode, *models.TaxonomyRun, error) {
-	node, err := queryTaxonomyNode(ctx, tx, taxonomyNodeSelect+`
+	node, err := queryTaxonomyNode(ctx, transaction, taxonomyNodeSelect+`
 		FROM taxonomy_nodes
 		WHERE id = $1 AND removed_at IS NULL
 		FOR UPDATE`,
@@ -865,7 +891,7 @@ func getNodeForUpdate(
 		return nil, nil, fmt.Errorf("lock taxonomy node: %w", err)
 	}
 
-	run, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+`
+	run, err := queryTaxonomyRun(ctx, transaction, taxonomyRunSelect+`
 		FROM taxonomy_runs
 		WHERE id = $1 AND tenant_id = $2`,
 		node.RunID, tenantID,
@@ -883,7 +909,7 @@ func getNodeForUpdate(
 
 func insertNodeEvent(
 	ctx context.Context,
-	tx pgx.Tx,
+	transaction pgx.Tx,
 	run *models.TaxonomyRun,
 	nodeID uuid.UUID,
 	eventType string,
@@ -901,7 +927,7 @@ func insertNodeEvent(
 		return fmt.Errorf("marshal taxonomy node event new value: %w", err)
 	}
 
-	if _, err := tx.Exec(ctx, `
+	if _, err := transaction.Exec(ctx, `
 		INSERT INTO taxonomy_node_events (
 			tenant_id, source_type, source_id, field_id, run_id, node_id,
 			event_type, actor_id, old_value, new_value
@@ -937,6 +963,7 @@ func buildTaxonomyTree(nodes []models.TaxonomyNode) *models.TaxonomyNode {
 	}
 
 	var root *models.TaxonomyNode
+
 	for _, node := range byID {
 		if node.ParentID == nil {
 			root = node

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -973,7 +973,7 @@ func sortTaxonomyChildren(node *models.TaxonomyNode) {
 	}
 }
 
-func rawOrDefault(raw json.RawMessage, fallback json.RawMessage) json.RawMessage {
+func rawOrDefault(raw, fallback json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
 		return fallback
 	}

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -1,0 +1,1024 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgvector/pgvector-go"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+)
+
+const (
+	defaultTaxonomyRunsLimit       = 20
+	defaultTaxonomyNodeRecordLimit = 50
+)
+
+var (
+	defaultJSONObj = json.RawMessage(`{}`)
+	defaultJSONArr = json.RawMessage(`[]`)
+)
+
+type TaxonomyRepository struct {
+	db *pgxpool.Pool
+}
+
+type CreateTaxonomyRunParams struct {
+	models.TaxonomyScope
+	FieldLabel     *string
+	Params         json.RawMessage
+	RecordCount    int
+	EmbeddingCount int
+}
+
+func NewTaxonomyRepository(db *pgxpool.Pool) *TaxonomyRepository {
+	return &TaxonomyRepository{db: db}
+}
+
+func (r *TaxonomyRepository) ListFieldOptions(
+	ctx context.Context,
+	tenantID string,
+	embeddingModel string,
+) ([]models.TaxonomyFieldOption, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT
+			fr.tenant_id,
+			fr.source_type,
+			fr.source_id,
+			COALESCE(MAX(fr.source_name) FILTER (WHERE fr.source_name IS NOT NULL AND btrim(fr.source_name) <> ''), ''),
+			fr.field_id,
+			COALESCE(MAX(fr.field_label) FILTER (WHERE fr.field_label IS NOT NULL AND btrim(fr.field_label) <> ''), ''),
+			COUNT(*)::int,
+			COUNT(e.feedback_record_id)::int
+		FROM feedback_records fr
+		LEFT JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $2
+		WHERE fr.tenant_id = $1
+		  AND fr.source_id IS NOT NULL
+		  AND btrim(fr.source_id) <> ''
+		  AND fr.value_text IS NOT NULL
+		  AND btrim(fr.value_text) <> ''
+		GROUP BY fr.tenant_id, fr.source_type, fr.source_id, fr.field_id
+		ORDER BY fr.source_type, fr.source_id, fr.field_id`,
+		tenantID, embeddingModel,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy field options: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]models.TaxonomyFieldOption, 0)
+	for rows.Next() {
+		var option models.TaxonomyFieldOption
+		if err := rows.Scan(
+			&option.TenantID,
+			&option.SourceType,
+			&option.SourceID,
+			&option.SourceName,
+			&option.FieldID,
+			&option.FieldLabel,
+			&option.RecordCount,
+			&option.EmbeddingCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan taxonomy field option: %w", err)
+		}
+
+		out = append(out, option)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate taxonomy field options: %w", err)
+	}
+
+	return out, nil
+}
+
+func (r *TaxonomyRepository) CountScopeInput(
+	ctx context.Context,
+	scope models.TaxonomyScope,
+	embeddingModel string,
+) (int, int, *string, error) {
+	var (
+		recordCount    int
+		embeddingCount int
+		fieldLabel     *string
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			COUNT(*)::int,
+			COUNT(e.feedback_record_id)::int,
+			MAX(fr.field_label) FILTER (WHERE fr.field_label IS NOT NULL AND btrim(fr.field_label) <> '')
+		FROM feedback_records fr
+		LEFT JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $5
+		WHERE fr.tenant_id = $1
+		  AND fr.source_type = $2
+		  AND fr.source_id = $3
+		  AND fr.field_id = $4
+		  AND fr.value_text IS NOT NULL
+		  AND btrim(fr.value_text) <> ''`,
+		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID, embeddingModel,
+	).Scan(&recordCount, &embeddingCount, &fieldLabel)
+	if err != nil {
+		return 0, 0, nil, fmt.Errorf("count taxonomy scope input: %w", err)
+	}
+
+	return recordCount, embeddingCount, fieldLabel, nil
+}
+
+func (r *TaxonomyRepository) CreateRunIfAvailable(
+	ctx context.Context,
+	params CreateTaxonomyRunParams,
+) (*models.TaxonomyRun, bool, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, false, fmt.Errorf("begin taxonomy run create tx: %w", err)
+	}
+
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	lockKey := taxonomyScopeLockKey(params.TaxonomyScope)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey); err != nil {
+		return nil, false, fmt.Errorf("lock taxonomy run scope: %w", err)
+	}
+
+	existing, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+`
+		FROM taxonomy_runs
+		WHERE tenant_id = $1
+		  AND source_type = $2
+		  AND source_id = $3
+		  AND field_id = $4
+		  AND status IN ('pending', 'running')
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1`,
+		params.TenantID, params.SourceType, params.SourceID, params.FieldID,
+	)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, fmt.Errorf("find in-progress taxonomy run: %w", err)
+	}
+	if existing != nil {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, fmt.Errorf("commit existing taxonomy run tx: %w", err)
+		}
+
+		return existing, false, nil
+	}
+
+	run, err := queryTaxonomyRun(ctx, tx, `
+		WITH taxonomy_runs AS (
+			INSERT INTO taxonomy_runs (
+				tenant_id, source_type, source_id, field_id, field_label,
+				status, params, record_count, embedding_count
+			)
+			VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7, $8)
+			RETURNING *
+		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
+		params.TenantID,
+		params.SourceType,
+		params.SourceID,
+		params.FieldID,
+		params.FieldLabel,
+		rawOrDefault(params.Params, defaultJSONObj),
+		params.RecordCount,
+		params.EmbeddingCount,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("insert taxonomy run: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, fmt.Errorf("commit taxonomy run create tx: %w", err)
+	}
+
+	return run, true, nil
+}
+
+func taxonomyScopeLockKey(scope models.TaxonomyScope) string {
+	return fmt.Sprintf(
+		"%d:%s|%d:%s|%d:%s|%d:%s",
+		len(scope.TenantID), scope.TenantID,
+		len(scope.SourceType), scope.SourceType,
+		len(scope.SourceID), scope.SourceID,
+		len(scope.FieldID), scope.FieldID,
+	)
+}
+
+func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+	run, err := queryTaxonomyRun(ctx, r.db, `
+		WITH taxonomy_runs AS (
+			UPDATE taxonomy_runs
+			SET status = 'running', started_at = COALESCE(started_at, NOW()), updated_at = NOW()
+			WHERE id = $1
+			RETURNING *
+		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
+		runID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("mark taxonomy run running: %w", err)
+	}
+
+	return run, nil
+}
+
+func (r *TaxonomyRepository) MarkRunFailed(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error) {
+	run, err := queryTaxonomyRun(ctx, r.db, `
+		WITH taxonomy_runs AS (
+			UPDATE taxonomy_runs
+			SET status = 'failed', error = $2, finished_at = NOW(), updated_at = NOW()
+			WHERE id = $1
+			RETURNING *
+		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
+		runID, message,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("mark taxonomy run failed: %w", err)
+	}
+
+	return run, nil
+}
+
+func (r *TaxonomyRepository) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1`, runID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	return run, nil
+}
+
+func (r *TaxonomyRepository) GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error) {
+	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+`
+		FROM taxonomy_active_runs ar
+		INNER JOIN taxonomy_runs ON taxonomy_runs.id = ar.run_id
+		WHERE ar.tenant_id = $1
+		  AND ar.source_type = $2
+		  AND ar.source_id = $3
+		  AND ar.field_id = $4`,
+		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_active_run", "active taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("get active taxonomy run: %w", err)
+	}
+
+	return run, nil
+}
+
+func (r *TaxonomyRepository) ListRuns(
+	ctx context.Context,
+	filters models.ListTaxonomyRunsFilters,
+) ([]models.TaxonomyRun, error) {
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = defaultTaxonomyRunsLimit
+	}
+
+	query := taxonomyRunSelect + ` FROM taxonomy_runs WHERE tenant_id = $1`
+	args := []any{filters.TenantID}
+
+	addFilter := func(column, value string) {
+		if value == "" {
+			return
+		}
+
+		args = append(args, value)
+		query += fmt.Sprintf(" AND %s = $%d", column, len(args))
+	}
+
+	addFilter("source_type", filters.SourceType)
+	addFilter("source_id", filters.SourceID)
+	addFilter("field_id", filters.FieldID)
+
+	args = append(args, limit)
+	query += fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", len(args))
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy runs: %w", err)
+	}
+	defer rows.Close()
+
+	return scanTaxonomyRuns(rows)
+}
+
+func (r *TaxonomyRepository) GetRunInput(
+	ctx context.Context,
+	runID uuid.UUID,
+	embeddingModel string,
+) (*models.TaxonomyRunInputResponse, error) {
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT fr.id, COALESCE(fr.field_label, ''), fr.value_text, e.embedding
+		FROM feedback_records fr
+		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
+		WHERE fr.tenant_id = $1
+		  AND fr.source_type = $2
+		  AND fr.source_id = $3
+		  AND fr.field_id = $4
+		  AND fr.value_text IS NOT NULL
+		  AND btrim(fr.value_text) <> ''
+		ORDER BY fr.collected_at DESC, fr.id ASC
+		LIMIT $5`,
+		run.TenantID, run.SourceType, run.SourceID, run.FieldID, run.EmbeddingCount, embeddingModel,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run input: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]models.TaxonomyRunInputRecord, 0, run.EmbeddingCount)
+	for rows.Next() {
+		var (
+			record models.TaxonomyRunInputRecord
+			vec    pgvector.HalfVector
+		)
+		if err := rows.Scan(&record.FeedbackRecordID, &record.FieldLabel, &record.ValueText, &vec); err != nil {
+			return nil, fmt.Errorf("scan taxonomy run input record: %w", err)
+		}
+
+		record.Embedding = vec.Slice()
+		records = append(records, record)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate taxonomy run input records: %w", err)
+	}
+
+	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
+}
+
+func (r *TaxonomyRepository) StoreResultAndActivate(
+	ctx context.Context,
+	runID uuid.UUID,
+	req models.TaxonomyRunResultRequest,
+) (*models.TaxonomyRun, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin taxonomy result tx: %w", err)
+	}
+
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	run, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1 FOR UPDATE`, runID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("lock taxonomy run: %w", err)
+	}
+
+	clusterIDs := make(map[int]uuid.UUID, len(req.Clusters))
+	for _, cluster := range req.Clusters {
+		var clusterID uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO taxonomy_clusters (
+				run_id, cluster_key, label, llm_label, keywords, size, is_outlier, metrics
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			RETURNING id`,
+			run.ID,
+			cluster.ClusterKey,
+			cluster.Label,
+			cluster.LLMLabel,
+			rawOrDefault(cluster.Keywords, defaultJSONArr),
+			cluster.Size,
+			cluster.IsOutlier,
+			rawOrDefault(cluster.Metrics, defaultJSONObj),
+		).Scan(&clusterID); err != nil {
+			return nil, fmt.Errorf("insert taxonomy cluster: %w", err)
+		}
+
+		clusterIDs[cluster.ClusterKey] = clusterID
+	}
+
+	for _, membership := range req.Memberships {
+		clusterID, ok := clusterIDs[membership.ClusterKey]
+		if !ok {
+			return nil, huberrors.NewValidationError("memberships.cluster_key", "references an unknown cluster")
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO taxonomy_cluster_memberships (
+				run_id, tenant_id, cluster_id, feedback_record_id, confidence, distance, metadata
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			run.ID,
+			run.TenantID,
+			clusterID,
+			membership.FeedbackRecordID,
+			membership.Confidence,
+			membership.Distance,
+			rawOrDefault(membership.Metadata, defaultJSONObj),
+		); err != nil {
+			return nil, fmt.Errorf("insert taxonomy cluster membership: %w", err)
+		}
+	}
+
+	nodes := append([]models.TaxonomyResultNode(nil), req.Nodes...)
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].Level == nodes[j].Level {
+			return nodes[i].SortOrder < nodes[j].SortOrder
+		}
+
+		return nodes[i].Level < nodes[j].Level
+	})
+
+	nodeIDs := make(map[string]uuid.UUID, len(nodes))
+	for _, node := range nodes {
+		var parentID *uuid.UUID
+		if node.ParentKey != nil {
+			resolved, ok := nodeIDs[*node.ParentKey]
+			if !ok {
+				return nil, huberrors.NewValidationError("nodes.parent_key", "references an unknown parent")
+			}
+
+			parentID = &resolved
+		}
+
+		var clusterID *uuid.UUID
+		if node.ClusterKey != nil {
+			resolved, ok := clusterIDs[*node.ClusterKey]
+			if !ok {
+				return nil, huberrors.NewValidationError("nodes.cluster_key", "references an unknown cluster")
+			}
+
+			clusterID = &resolved
+		}
+
+		var nodeID uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO taxonomy_nodes (
+				run_id, parent_id, cluster_id, node_type, label, original_label,
+				description, level, sort_order, metadata
+			)
+			VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9)
+			RETURNING id`,
+			run.ID,
+			parentID,
+			clusterID,
+			node.NodeType,
+			node.Label,
+			node.Description,
+			node.Level,
+			node.SortOrder,
+			rawOrDefault(node.Metadata, defaultJSONObj),
+		).Scan(&nodeID); err != nil {
+			return nil, fmt.Errorf("insert taxonomy node: %w", err)
+		}
+
+		nodeIDs[node.NodeKey] = nodeID
+	}
+
+	activatedBy := taxonomyRunRequestedBy(run.Params)
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO taxonomy_active_runs (
+			tenant_id, source_type, source_id, field_id, run_id, activated_by
+		)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (tenant_id, source_type, source_id, field_id)
+		DO UPDATE SET
+			run_id = EXCLUDED.run_id,
+			activated_by = EXCLUDED.activated_by,
+			activated_at = NOW()`,
+		run.TenantID,
+		run.SourceType,
+		run.SourceID,
+		run.FieldID,
+		run.ID,
+		activatedBy,
+	); err != nil {
+		return nil, fmt.Errorf("activate taxonomy run: %w", err)
+	}
+
+	updated, err := queryTaxonomyRun(ctx, tx, `
+		WITH taxonomy_runs AS (
+			UPDATE taxonomy_runs
+			SET status = 'succeeded',
+				metrics = $2,
+				cluster_count = $3,
+				node_count = $4,
+				error = NULL,
+				finished_at = NOW(),
+				updated_at = NOW()
+			WHERE id = $1
+			RETURNING *
+		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
+		run.ID,
+		rawOrDefault(req.Metrics, defaultJSONObj),
+		len(req.Clusters),
+		len(req.Nodes),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mark taxonomy run succeeded: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit taxonomy result tx: %w", err)
+	}
+
+	return updated, nil
+}
+
+func (r *TaxonomyRepository) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := r.listVisibleNodes(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	root := buildTaxonomyTree(nodes)
+
+	return &models.TaxonomyTreeResponse{Run: *run, Root: root}, nil
+}
+
+func (r *TaxonomyRepository) RenameNode(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	tenantID string,
+	actorID string,
+	label string,
+) (*models.TaxonomyNode, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin taxonomy node rename tx: %w", err)
+	}
+
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	node, run, err := getNodeForUpdate(ctx, tx, nodeID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := queryTaxonomyNode(ctx, tx, `
+		WITH taxonomy_nodes AS (
+			UPDATE taxonomy_nodes
+			SET label = $2, updated_at = NOW()
+			WHERE id = $1
+			RETURNING *
+		)`+taxonomyNodeSelect+` FROM taxonomy_nodes`,
+		nodeID, label,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("rename taxonomy node: %w", err)
+	}
+
+	if err := insertNodeEvent(ctx, tx, run, nodeID, "rename", actorID,
+		map[string]string{"label": node.Label},
+		map[string]string{"label": label}); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit taxonomy node rename tx: %w", err)
+	}
+
+	return updated, nil
+}
+
+func (r *TaxonomyRepository) RemoveNode(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	tenantID string,
+	actorID string,
+) (*models.TaxonomyNode, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin taxonomy node remove tx: %w", err)
+	}
+
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	_, run, err := getNodeForUpdate(ctx, tx, nodeID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := queryTaxonomyNode(ctx, tx, `
+		WITH taxonomy_nodes AS (
+			UPDATE taxonomy_nodes
+			SET removed_at = NOW(), removed_by = $2, updated_at = NOW()
+			WHERE id = $1
+			RETURNING *
+		)`+taxonomyNodeSelect+` FROM taxonomy_nodes`,
+		nodeID, actorID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("remove taxonomy node: %w", err)
+	}
+
+	if err := insertNodeEvent(ctx, tx, run, nodeID, "soft_remove", actorID,
+		map[string]any{"removed_at": nil},
+		map[string]string{"removed_by": actorID}); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit taxonomy node remove tx: %w", err)
+	}
+
+	return updated, nil
+}
+
+func (r *TaxonomyRepository) ListNodeRecords(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	tenantID string,
+	limit int,
+) ([]models.FeedbackRecord, int, error) {
+	if limit <= 0 {
+		limit = defaultTaxonomyNodeRecordLimit
+	}
+
+	rows, err := r.db.Query(ctx, `
+		WITH RECURSIVE visible_nodes AS (
+			SELECT id, run_id, cluster_id
+			FROM taxonomy_nodes
+			WHERE id = $1 AND removed_at IS NULL
+			UNION ALL
+			SELECT child.id, child.run_id, child.cluster_id
+			FROM taxonomy_nodes child
+			INNER JOIN visible_nodes parent ON parent.id = child.parent_id AND parent.run_id = child.run_id
+			WHERE child.removed_at IS NULL
+		)
+		SELECT fr.id, fr.collected_at, fr.created_at, fr.updated_at,
+			fr.source_type, fr.source_id, fr.source_name,
+			fr.field_id, fr.field_label, fr.field_type, fr.field_group_id, fr.field_group_label,
+			fr.value_text, fr.value_number, fr.value_boolean, fr.value_date,
+			fr.metadata, fr.language, fr.user_id, fr.tenant_id, fr.submission_id
+		FROM visible_nodes vn
+		INNER JOIN taxonomy_runs tr ON tr.id = vn.run_id
+		INNER JOIN taxonomy_cluster_memberships tcm ON tcm.run_id = vn.run_id AND tcm.cluster_id = vn.cluster_id
+		INNER JOIN feedback_records fr ON fr.id = tcm.feedback_record_id AND fr.tenant_id = tcm.tenant_id
+		WHERE tr.tenant_id = $2
+		ORDER BY fr.collected_at DESC, fr.id ASC
+		LIMIT $3`,
+		nodeID, tenantID, limit,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list taxonomy node records: %w", err)
+	}
+	defer rows.Close()
+
+	records := []models.FeedbackRecord{}
+	for rows.Next() {
+		record, err := scanFeedbackRecord(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		records = append(records, *record)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate taxonomy node records: %w", err)
+	}
+
+	return records, limit, nil
+}
+
+func (r *TaxonomyRepository) listVisibleNodes(ctx context.Context, runID uuid.UUID) ([]models.TaxonomyNode, error) {
+	rows, err := r.db.Query(ctx, taxonomyNodeSelect+`
+		FROM taxonomy_nodes
+		WHERE run_id = $1 AND removed_at IS NULL
+		ORDER BY level, sort_order, id`,
+		runID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy nodes: %w", err)
+	}
+	defer rows.Close()
+
+	nodes := []models.TaxonomyNode{}
+	for rows.Next() {
+		node, err := scanTaxonomyNode(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, *node)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate taxonomy nodes: %w", err)
+	}
+
+	return nodes, nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+type queryer interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+const taxonomyRunSelect = `
+		SELECT taxonomy_runs.id, taxonomy_runs.tenant_id, taxonomy_runs.source_type,
+			taxonomy_runs.source_id, taxonomy_runs.field_id, taxonomy_runs.field_label,
+			taxonomy_runs.status, taxonomy_runs.params, taxonomy_runs.metrics,
+			taxonomy_runs.record_count, taxonomy_runs.embedding_count,
+			taxonomy_runs.cluster_count, taxonomy_runs.node_count, taxonomy_runs.error,
+			taxonomy_runs.started_at, taxonomy_runs.finished_at,
+			taxonomy_runs.created_at, taxonomy_runs.updated_at`
+
+func queryTaxonomyRun(ctx context.Context, q queryer, sql string, args ...any) (*models.TaxonomyRun, error) {
+	return scanTaxonomyRun(q.QueryRow(ctx, sql, args...))
+}
+
+func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
+	var run models.TaxonomyRun
+	if err := row.Scan(
+		&run.ID,
+		&run.TenantID,
+		&run.SourceType,
+		&run.SourceID,
+		&run.FieldID,
+		&run.FieldLabel,
+		&run.Status,
+		&run.Params,
+		&run.Metrics,
+		&run.RecordCount,
+		&run.EmbeddingCount,
+		&run.ClusterCount,
+		&run.NodeCount,
+		&run.Error,
+		&run.StartedAt,
+		&run.FinishedAt,
+		&run.CreatedAt,
+		&run.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	return &run, nil
+}
+
+func scanTaxonomyRuns(rows pgx.Rows) ([]models.TaxonomyRun, error) {
+	out := make([]models.TaxonomyRun, 0)
+	for rows.Next() {
+		run, err := scanTaxonomyRun(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan taxonomy run: %w", err)
+		}
+
+		out = append(out, *run)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate taxonomy runs: %w", err)
+	}
+
+	return out, nil
+}
+
+const taxonomyNodeSelect = `
+		SELECT id, run_id, parent_id, cluster_id, node_type, label, original_label,
+			description, level, sort_order, metadata, removed_at, removed_by, created_at, updated_at`
+
+func queryTaxonomyNode(ctx context.Context, q queryer, sql string, args ...any) (*models.TaxonomyNode, error) {
+	return scanTaxonomyNode(q.QueryRow(ctx, sql, args...))
+}
+
+func scanTaxonomyNode(row scanner) (*models.TaxonomyNode, error) {
+	var node models.TaxonomyNode
+	if err := row.Scan(
+		&node.ID,
+		&node.RunID,
+		&node.ParentID,
+		&node.ClusterID,
+		&node.NodeType,
+		&node.Label,
+		&node.OriginalLabel,
+		&node.Description,
+		&node.Level,
+		&node.SortOrder,
+		&node.Metadata,
+		&node.RemovedAt,
+		&node.RemovedBy,
+		&node.CreatedAt,
+		&node.UpdatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("scan taxonomy node: %w", err)
+	}
+
+	return &node, nil
+}
+
+func getNodeForUpdate(
+	ctx context.Context,
+	tx pgx.Tx,
+	nodeID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyNode, *models.TaxonomyRun, error) {
+	node, err := queryTaxonomyNode(ctx, tx, taxonomyNodeSelect+`
+		FROM taxonomy_nodes
+		WHERE id = $1 AND removed_at IS NULL
+		FOR UPDATE`,
+		nodeID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, huberrors.NewNotFoundError("taxonomy_node", "taxonomy node not found")
+		}
+
+		return nil, nil, fmt.Errorf("lock taxonomy node: %w", err)
+	}
+
+	run, err := queryTaxonomyRun(ctx, tx, taxonomyRunSelect+`
+		FROM taxonomy_runs
+		WHERE id = $1 AND tenant_id = $2`,
+		node.RunID, tenantID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, huberrors.NewNotFoundError("taxonomy_node", "taxonomy node not found")
+		}
+
+		return nil, nil, fmt.Errorf("get taxonomy node run: %w", err)
+	}
+
+	return node, run, nil
+}
+
+func insertNodeEvent(
+	ctx context.Context,
+	tx pgx.Tx,
+	run *models.TaxonomyRun,
+	nodeID uuid.UUID,
+	eventType string,
+	actorID string,
+	oldValue any,
+	newValue any,
+) error {
+	oldJSON, err := json.Marshal(oldValue)
+	if err != nil {
+		return fmt.Errorf("marshal taxonomy node event old value: %w", err)
+	}
+
+	newJSON, err := json.Marshal(newValue)
+	if err != nil {
+		return fmt.Errorf("marshal taxonomy node event new value: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO taxonomy_node_events (
+			tenant_id, source_type, source_id, field_id, run_id, node_id,
+			event_type, actor_id, old_value, new_value
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		run.TenantID,
+		run.SourceType,
+		run.SourceID,
+		run.FieldID,
+		run.ID,
+		nodeID,
+		eventType,
+		actorID,
+		oldJSON,
+		newJSON,
+	); err != nil {
+		return fmt.Errorf("insert taxonomy node event: %w", err)
+	}
+
+	return nil
+}
+
+func buildTaxonomyTree(nodes []models.TaxonomyNode) *models.TaxonomyNode {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	byID := make(map[uuid.UUID]*models.TaxonomyNode, len(nodes))
+	for _, node := range nodes {
+		copyNode := node
+		copyNode.Children = nil
+		byID[node.ID] = &copyNode
+	}
+
+	var root *models.TaxonomyNode
+	for _, node := range byID {
+		if node.ParentID == nil {
+			root = node
+
+			continue
+		}
+
+		parent := byID[*node.ParentID]
+		if parent != nil {
+			parent.Children = append(parent.Children, *node)
+		}
+	}
+
+	sortTaxonomyChildren(root)
+
+	return root
+}
+
+func sortTaxonomyChildren(node *models.TaxonomyNode) {
+	if node == nil {
+		return
+	}
+
+	sort.SliceStable(node.Children, func(i, j int) bool {
+		if node.Children[i].SortOrder == node.Children[j].SortOrder {
+			return node.Children[i].ID.String() < node.Children[j].ID.String()
+		}
+
+		return node.Children[i].SortOrder < node.Children[j].SortOrder
+	})
+
+	for i := range node.Children {
+		sortTaxonomyChildren(&node.Children[i])
+	}
+}
+
+func rawOrDefault(raw json.RawMessage, fallback json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return fallback
+	}
+
+	return raw
+}
+
+func taxonomyRunRequestedBy(raw json.RawMessage) *string {
+	var params struct {
+		RequestedBy string `json:"requested_by"`
+	}
+	if len(raw) == 0 || json.Unmarshal(raw, &params) != nil || strings.TrimSpace(params.RequestedBy) == "" {
+		return nil
+	}
+
+	return &params.RequestedBy
+}
+
+func scanFeedbackRecord(row scanner) (*models.FeedbackRecord, error) {
+	var record models.FeedbackRecord
+	if err := row.Scan(
+		&record.ID,
+		&record.CollectedAt,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+		&record.SourceType,
+		&record.SourceID,
+		&record.SourceName,
+		&record.FieldID,
+		&record.FieldLabel,
+		&record.FieldType,
+		&record.FieldGroupID,
+		&record.FieldGroupLabel,
+		&record.ValueText,
+		&record.ValueNumber,
+		&record.ValueBoolean,
+		&record.ValueDate,
+		&record.Metadata,
+		&record.Language,
+		&record.UserID,
+		&record.TenantID,
+		&record.SubmissionID,
+	); err != nil {
+		return nil, fmt.Errorf("scan feedback record: %w", err)
+	}
+
+	return &record, nil
+}

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -222,19 +222,23 @@ func taxonomyScopeLockKey(scope models.TaxonomyScope) string {
 }
 
 // MarkRunRunning transitions a taxonomy run to running.
-func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+func (r *TaxonomyRepository) MarkRunRunning(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, `
 		WITH taxonomy_runs AS (
 			UPDATE taxonomy_runs
 			SET status = 'running', started_at = COALESCE(started_at, NOW()), updated_at = NOW()
-			WHERE id = $1 AND status = 'pending'
+			WHERE id = $1 AND tenant_id = $2 AND status = 'pending'
 			RETURNING *
 		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
-		runID,
+		runID, tenantID,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, r.transitionError(ctx, runID, models.TaxonomyRunStatusRunning)
+			return nil, r.transitionError(ctx, runID, tenantID, models.TaxonomyRunStatusRunning)
 		}
 
 		return nil, fmt.Errorf("mark taxonomy run running: %w", err)
@@ -247,6 +251,7 @@ func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID
 func (r *TaxonomyRepository) MarkRunFailed(
 	ctx context.Context,
 	runID uuid.UUID,
+	tenantID string,
 	message string,
 	errorCode models.TaxonomyRunFailureCode,
 ) (*models.TaxonomyRun, error) {
@@ -254,14 +259,14 @@ func (r *TaxonomyRepository) MarkRunFailed(
 		WITH taxonomy_runs AS (
 			UPDATE taxonomy_runs
 			SET status = 'failed', error = $2, error_code = $3, finished_at = NOW(), updated_at = NOW()
-			WHERE id = $1 AND status IN ('pending', 'running')
+			WHERE id = $1 AND tenant_id = $4 AND status IN ('pending', 'running')
 			RETURNING *
 		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
-		runID, message, nullableFailureCode(errorCode),
+		runID, message, nullableFailureCode(errorCode), tenantID,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, r.transitionError(ctx, runID, models.TaxonomyRunStatusFailed)
+			return nil, r.transitionError(ctx, runID, tenantID, models.TaxonomyRunStatusFailed)
 		}
 
 		return nil, fmt.Errorf("mark taxonomy run failed: %w", err)
@@ -270,8 +275,11 @@ func (r *TaxonomyRepository) MarkRunFailed(
 	return run, nil
 }
 
-// GetRun returns a taxonomy run by ID.
-func (r *TaxonomyRepository) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+// GetRunForInternalService returns run metadata for internal taxonomy service-token workflows.
+func (r *TaxonomyRepository) GetRunForInternalService(
+	ctx context.Context,
+	runID uuid.UUID,
+) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1`, runID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -279,6 +287,28 @@ func (r *TaxonomyRepository) GetRun(ctx context.Context, runID uuid.UUID) (*mode
 		}
 
 		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	return run, nil
+}
+
+// GetRunForTenant returns a taxonomy run by ID scoped to a tenant.
+func (r *TaxonomyRepository) GetRunForTenant(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyRun, error) {
+	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+`
+		FROM taxonomy_runs
+		WHERE id = $1 AND tenant_id = $2`,
+		runID, tenantID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
+
+		return nil, fmt.Errorf("get taxonomy run for tenant: %w", err)
 	}
 
 	return run, nil
@@ -348,9 +378,10 @@ func (r *TaxonomyRepository) ListRuns(
 func (r *TaxonomyRepository) GetRunInput(
 	ctx context.Context,
 	runID uuid.UUID,
+	tenantID string,
 	embeddingModel string,
 ) (*models.TaxonomyRunInputResponse, error) {
-	run, err := r.GetRun(ctx, runID)
+	run, err := r.GetRunForTenant(ctx, runID, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -400,6 +431,7 @@ func (r *TaxonomyRepository) GetRunInput(
 func (r *TaxonomyRepository) StoreResultAndActivate(
 	ctx context.Context,
 	runID uuid.UUID,
+	tenantID string,
 	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
 	transaction, err := r.db.BeginTx(ctx, pgx.TxOptions{})
@@ -411,7 +443,12 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		_ = transaction.Rollback(ctx)
 	}()
 
-	run, err := queryTaxonomyRun(ctx, transaction, taxonomyRunSelect+` FROM taxonomy_runs WHERE id = $1 FOR UPDATE`, runID)
+	run, err := queryTaxonomyRun(ctx, transaction, taxonomyRunSelect+`
+		FROM taxonomy_runs
+		WHERE id = $1 AND tenant_id = $2
+		FOR UPDATE`,
+		runID, tenantID,
+	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
@@ -580,8 +617,12 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 }
 
 // GetTree returns the visible taxonomy tree for a run.
-func (r *TaxonomyRepository) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
-	run, err := r.GetRun(ctx, runID)
+func (r *TaxonomyRepository) GetTree(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyTreeResponse, error) {
+	run, err := r.GetRunForTenant(ctx, runID, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -783,9 +824,10 @@ func (r *TaxonomyRepository) listVisibleNodes(ctx context.Context, runID uuid.UU
 func (r *TaxonomyRepository) transitionError(
 	ctx context.Context,
 	runID uuid.UUID,
+	tenantID string,
 	target models.TaxonomyRunStatus,
 ) error {
-	run, err := r.GetRun(ctx, runID)
+	run, err := r.GetRunForTenant(ctx, runID, tenantID)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -227,14 +227,14 @@ func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID
 		WITH taxonomy_runs AS (
 			UPDATE taxonomy_runs
 			SET status = 'running', started_at = COALESCE(started_at, NOW()), updated_at = NOW()
-			WHERE id = $1
+			WHERE id = $1 AND status = 'pending'
 			RETURNING *
 		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
 		runID,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+			return nil, r.transitionError(ctx, runID, models.TaxonomyRunStatusRunning)
 		}
 
 		return nil, fmt.Errorf("mark taxonomy run running: %w", err)
@@ -244,19 +244,24 @@ func (r *TaxonomyRepository) MarkRunRunning(ctx context.Context, runID uuid.UUID
 }
 
 // MarkRunFailed transitions a taxonomy run to failed with an error message.
-func (r *TaxonomyRepository) MarkRunFailed(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error) {
+func (r *TaxonomyRepository) MarkRunFailed(
+	ctx context.Context,
+	runID uuid.UUID,
+	message string,
+	errorCode models.TaxonomyRunFailureCode,
+) (*models.TaxonomyRun, error) {
 	run, err := queryTaxonomyRun(ctx, r.db, `
 		WITH taxonomy_runs AS (
 			UPDATE taxonomy_runs
-			SET status = 'failed', error = $2, finished_at = NOW(), updated_at = NOW()
-			WHERE id = $1
+			SET status = 'failed', error = $2, error_code = $3, finished_at = NOW(), updated_at = NOW()
+			WHERE id = $1 AND status IN ('pending', 'running')
 			RETURNING *
 		)`+taxonomyRunSelect+` FROM taxonomy_runs`,
-		runID, message,
+		runID, message, nullableFailureCode(errorCode),
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+			return nil, r.transitionError(ctx, runID, models.TaxonomyRunStatusFailed)
 		}
 
 		return nil, fmt.Errorf("mark taxonomy run failed: %w", err)
@@ -415,6 +420,10 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 		return nil, fmt.Errorf("lock taxonomy run: %w", err)
 	}
 
+	if run.Status != models.TaxonomyRunStatusRunning {
+		return nil, taxonomyTransitionConflict(run, models.TaxonomyRunStatusSucceeded)
+	}
+
 	clusterIDs := make(map[int]uuid.UUID, len(req.Clusters))
 	for _, cluster := range req.Clusters {
 		var clusterID uuid.UUID
@@ -548,6 +557,7 @@ func (r *TaxonomyRepository) StoreResultAndActivate(
 				cluster_count = $3,
 				node_count = $4,
 				error = NULL,
+				error_code = NULL,
 				finished_at = NOW(),
 				updated_at = NOW()
 			WHERE id = $1
@@ -770,6 +780,35 @@ func (r *TaxonomyRepository) listVisibleNodes(ctx context.Context, runID uuid.UU
 	return nodes, nil
 }
 
+func (r *TaxonomyRepository) transitionError(
+	ctx context.Context,
+	runID uuid.UUID,
+	target models.TaxonomyRunStatus,
+) error {
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+
+	return taxonomyTransitionConflict(run, target)
+}
+
+func taxonomyTransitionConflict(run *models.TaxonomyRun, target models.TaxonomyRunStatus) error {
+	return huberrors.NewConflictError(
+		fmt.Sprintf("cannot transition taxonomy run from %s to %s", run.Status, target),
+	)
+}
+
+func nullableFailureCode(code models.TaxonomyRunFailureCode) *string {
+	if code == "" {
+		return nil
+	}
+
+	value := string(code)
+
+	return &value
+}
+
 type scanner interface {
 	Scan(dest ...any) error
 }
@@ -783,7 +822,7 @@ const taxonomyRunSelect = `
 			taxonomy_runs.source_id, taxonomy_runs.field_id, taxonomy_runs.field_label,
 			taxonomy_runs.status, taxonomy_runs.params, taxonomy_runs.metrics,
 			taxonomy_runs.record_count, taxonomy_runs.embedding_count,
-			taxonomy_runs.cluster_count, taxonomy_runs.node_count, taxonomy_runs.error,
+			taxonomy_runs.cluster_count, taxonomy_runs.node_count, taxonomy_runs.error, taxonomy_runs.error_code,
 			taxonomy_runs.started_at, taxonomy_runs.finished_at,
 			taxonomy_runs.created_at, taxonomy_runs.updated_at`
 
@@ -792,7 +831,11 @@ func queryTaxonomyRun(ctx context.Context, q queryer, sql string, args ...any) (
 }
 
 func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
-	var run models.TaxonomyRun
+	var (
+		run       models.TaxonomyRun
+		errorCode *string
+	)
+
 	if err := row.Scan(
 		&run.ID,
 		&run.TenantID,
@@ -808,12 +851,18 @@ func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
 		&run.ClusterCount,
 		&run.NodeCount,
 		&run.Error,
+		&errorCode,
 		&run.StartedAt,
 		&run.FinishedAt,
 		&run.CreatedAt,
 		&run.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("scan taxonomy run: %w", err)
+	}
+
+	if errorCode != nil {
+		code := models.TaxonomyRunFailureCode(*errorCode)
+		run.ErrorCode = &code
 	}
 
 	return &run, nil

--- a/internal/service/id_validation.go
+++ b/internal/service/id_validation.go
@@ -23,14 +23,14 @@ func normalizeRequiredTenantID(tenantID *string) (string, error) {
 }
 
 func normalizeRequiredTenantIDValue(tenantID string) (string, error) {
-	return normalizeRequiredIdentifier("tenant_id", tenantID, maxTenantIDLength)
+	return normalizeRequiredIdentifier("tenant_id", tenantID)
 }
 
 func normalizeRequiredUserIDValue(userID string) (string, error) {
-	return normalizeRequiredIdentifier("user_id", userID, maxUserIDLength)
+	return normalizeRequiredIdentifier("user_id", userID)
 }
 
-func normalizeRequiredIdentifier(fieldName, value string, maxLength int) (string, error) {
+func normalizeRequiredIdentifier(fieldName, value string) (string, error) {
 	normalized := strings.TrimSpace(value)
 	if normalized == "" {
 		return "", huberrors.NewValidationError(fieldName, fieldName+" is required and cannot be empty")
@@ -40,8 +40,8 @@ func normalizeRequiredIdentifier(fieldName, value string, maxLength int) (string
 		return "", huberrors.NewValidationError(fieldName, fieldName+" must not contain NULL bytes")
 	}
 
-	if utf8.RuneCountInString(normalized) > maxLength {
-		return "", huberrors.NewValidationError(fieldName, fieldName+" must be at most "+strconv.Itoa(maxLength)+" characters")
+	if utf8.RuneCountInString(normalized) > maxIdentifierLength {
+		return "", huberrors.NewValidationError(fieldName, fieldName+" must be at most "+strconv.Itoa(maxIdentifierLength)+" characters")
 	}
 
 	return normalized, nil

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -15,14 +15,18 @@ import (
 )
 
 var (
+	// ErrTaxonomyEmbeddingsNotConfigured is returned when Hub embeddings are not configured.
 	ErrTaxonomyEmbeddingsNotConfigured = errors.New("taxonomy requires EMBEDDING_MODEL to be configured")
-	ErrTaxonomyServiceNotConfigured    = errors.New("taxonomy service is not configured")
-	ErrTaxonomyServiceStartFailed      = errors.New("taxonomy service failed to start run")
+	// ErrTaxonomyServiceNotConfigured is returned when the taxonomy compute service is unavailable.
+	ErrTaxonomyServiceNotConfigured = errors.New("taxonomy service is not configured")
+	// ErrTaxonomyServiceStartFailed is returned when the taxonomy compute service rejects a run.
+	ErrTaxonomyServiceStartFailed = errors.New("taxonomy service failed to start run")
 )
 
 const defaultMinimumTaxonomyEmbeddingCount = 20
 
-type TaxonomyRepository interface {
+// TaxonomyRepository persists taxonomy run state and generated artifacts.
+type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service coordinates one cohesive repository boundary.
 	ListFieldOptions(ctx context.Context, tenantID, embeddingModel string) ([]models.TaxonomyFieldOption, error)
 	CountScopeInput(ctx context.Context, scope models.TaxonomyScope, embeddingModel string) (int, int, *string, error)
 	CreateRunIfAvailable(ctx context.Context, params repository.CreateTaxonomyRunParams) (*models.TaxonomyRun, bool, error)
@@ -43,10 +47,12 @@ type TaxonomyRepository interface {
 	ListNodeRecords(ctx context.Context, nodeID uuid.UUID, tenantID string, limit int) ([]models.FeedbackRecord, int, error)
 }
 
+// TaxonomyRunStarter starts asynchronous taxonomy compute work.
 type TaxonomyRunStarter interface {
 	StartRun(ctx context.Context, runID string) error
 }
 
+// TaxonomyService coordinates taxonomy run lifecycle and edits.
 type TaxonomyService struct {
 	repo                  TaxonomyRepository
 	starter               TaxonomyRunStarter
@@ -54,6 +60,7 @@ type TaxonomyService struct {
 	minimumEmbeddingCount int
 }
 
+// NewTaxonomyServiceParams configures a TaxonomyService.
 type NewTaxonomyServiceParams struct {
 	Repo                  TaxonomyRepository
 	Starter               TaxonomyRunStarter
@@ -61,6 +68,7 @@ type NewTaxonomyServiceParams struct {
 	MinimumEmbeddingCount int
 }
 
+// NewTaxonomyService creates a taxonomy application service.
 func NewTaxonomyService(params NewTaxonomyServiceParams) *TaxonomyService {
 	minimumEmbeddingCount := params.MinimumEmbeddingCount
 	if minimumEmbeddingCount <= 0 {
@@ -75,6 +83,7 @@ func NewTaxonomyService(params NewTaxonomyServiceParams) *TaxonomyService {
 	}
 }
 
+// ListFieldOptions returns feedback fields that can run taxonomy generation.
 func (s *TaxonomyService) ListFieldOptions(
 	ctx context.Context,
 	tenantID string,
@@ -96,6 +105,7 @@ func (s *TaxonomyService) ListFieldOptions(
 	return &models.TaxonomyFieldsResponse{Data: options}, nil
 }
 
+// StartManualRun creates and starts a manual taxonomy generation run.
 func (s *TaxonomyService) StartManualRun(
 	ctx context.Context,
 	req models.CreateTaxonomyRunRequest,
@@ -135,6 +145,7 @@ func (s *TaxonomyService) StartManualRun(
 	}
 
 	params := taxonomyRunParams(req.ActorID, s.embeddingModel)
+
 	run, created, err := s.repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
 		TaxonomyScope:  scope,
 		FieldLabel:     fieldLabel,
@@ -167,6 +178,7 @@ func (s *TaxonomyService) StartManualRun(
 	return &models.CreateTaxonomyRunResponse{Run: *runningRun}, nil
 }
 
+// ListRuns returns taxonomy run history for a scoped tenant.
 func (s *TaxonomyService) ListRuns(
 	ctx context.Context,
 	filters models.ListTaxonomyRunsFilters,
@@ -177,6 +189,7 @@ func (s *TaxonomyService) ListRuns(
 	}
 
 	filters.TenantID = normalizedTenantID
+
 	runs, err := s.repo.ListRuns(ctx, filters)
 	if err != nil {
 		return nil, fmt.Errorf("list taxonomy runs: %w", err)
@@ -185,10 +198,17 @@ func (s *TaxonomyService) ListRuns(
 	return &models.ListTaxonomyRunsResponse{Data: runs}, nil
 }
 
+// GetRun returns a taxonomy run by ID.
 func (s *TaxonomyService) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
-	return s.repo.GetRun(ctx, runID)
+	run, err := s.repo.GetRun(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	return run, nil
 }
 
+// GetActiveTree returns the active taxonomy tree for a field scope.
 func (s *TaxonomyService) GetActiveTree(
 	ctx context.Context,
 	scope models.TaxonomyScope,
@@ -200,16 +220,28 @@ func (s *TaxonomyService) GetActiveTree(
 
 	run, err := s.repo.GetActiveRun(ctx, normalizedScope)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get active taxonomy run: %w", err)
 	}
 
-	return s.repo.GetTree(ctx, run.ID)
+	tree, err := s.repo.GetTree(ctx, run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get active taxonomy tree: %w", err)
+	}
+
+	return tree, nil
 }
 
+// GetTree returns a taxonomy tree by run ID.
 func (s *TaxonomyService) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
-	return s.repo.GetTree(ctx, runID)
+	tree, err := s.repo.GetTree(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy tree: %w", err)
+	}
+
+	return tree, nil
 }
 
+// GetRunInput returns feedback text and embeddings for the taxonomy service.
 func (s *TaxonomyService) GetRunInput(
 	ctx context.Context,
 	runID uuid.UUID,
@@ -218,17 +250,29 @@ func (s *TaxonomyService) GetRunInput(
 		return nil, ErrTaxonomyEmbeddingsNotConfigured
 	}
 
-	return s.repo.GetRunInput(ctx, runID, s.embeddingModel)
+	input, err := s.repo.GetRunInput(ctx, runID, s.embeddingModel)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run input: %w", err)
+	}
+
+	return input, nil
 }
 
+// CompleteRun stores taxonomy output and activates the successful run.
 func (s *TaxonomyService) CompleteRun(
 	ctx context.Context,
 	runID uuid.UUID,
 	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
-	return s.repo.StoreResultAndActivate(ctx, runID, req)
+	run, err := s.repo.StoreResultAndActivate(ctx, runID, req)
+	if err != nil {
+		return nil, fmt.Errorf("complete taxonomy run: %w", err)
+	}
+
+	return run, nil
 }
 
+// FailRun records a taxonomy run failure.
 func (s *TaxonomyService) FailRun(
 	ctx context.Context,
 	runID uuid.UUID,
@@ -239,9 +283,15 @@ func (s *TaxonomyService) FailRun(
 		sanitized = "taxonomy run failed"
 	}
 
-	return s.repo.MarkRunFailed(ctx, runID, sanitized)
+	run, err := s.repo.MarkRunFailed(ctx, runID, sanitized)
+	if err != nil {
+		return nil, fmt.Errorf("fail taxonomy run: %w", err)
+	}
+
+	return run, nil
 }
 
+// RenameNode renames a taxonomy node.
 func (s *TaxonomyService) RenameNode(
 	ctx context.Context,
 	nodeID uuid.UUID,
@@ -252,7 +302,7 @@ func (s *TaxonomyService) RenameNode(
 		return nil, err
 	}
 
-	actorID, err := normalizeRequiredIdentifier("actor_id", req.ActorID, maxIdentifierLength)
+	actorID, err := normalizeRequiredIdentifier("actor_id", req.ActorID)
 	if err != nil {
 		return nil, err
 	}
@@ -262,9 +312,15 @@ func (s *TaxonomyService) RenameNode(
 		return nil, huberrors.NewValidationError("label", "label is required and cannot be empty")
 	}
 
-	return s.repo.RenameNode(ctx, nodeID, tenantID, actorID, label)
+	node, err := s.repo.RenameNode(ctx, nodeID, tenantID, actorID, label)
+	if err != nil {
+		return nil, fmt.Errorf("rename taxonomy node: %w", err)
+	}
+
+	return node, nil
 }
 
+// RemoveNode soft-removes a taxonomy node.
 func (s *TaxonomyService) RemoveNode(
 	ctx context.Context,
 	nodeID uuid.UUID,
@@ -275,14 +331,20 @@ func (s *TaxonomyService) RemoveNode(
 		return nil, err
 	}
 
-	actorID, err := normalizeRequiredIdentifier("actor_id", filters.ActorID, maxIdentifierLength)
+	actorID, err := normalizeRequiredIdentifier("actor_id", filters.ActorID)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.repo.RemoveNode(ctx, nodeID, tenantID, actorID)
+	node, err := s.repo.RemoveNode(ctx, nodeID, tenantID, actorID)
+	if err != nil {
+		return nil, fmt.Errorf("remove taxonomy node: %w", err)
+	}
+
+	return node, nil
 }
 
+// ListNodeRecords returns feedback records assigned to a taxonomy node.
 func (s *TaxonomyService) ListNodeRecords(
 	ctx context.Context,
 	nodeID uuid.UUID,
@@ -307,17 +369,17 @@ func normalizeTaxonomyScope(scope models.TaxonomyScope) (models.TaxonomyScope, e
 		return models.TaxonomyScope{}, err
 	}
 
-	sourceType, err := normalizeRequiredIdentifier("source_type", scope.SourceType, maxIdentifierLength)
+	sourceType, err := normalizeRequiredIdentifier("source_type", scope.SourceType)
 	if err != nil {
 		return models.TaxonomyScope{}, err
 	}
 
-	sourceID, err := normalizeRequiredIdentifier("source_id", scope.SourceID, maxIdentifierLength)
+	sourceID, err := normalizeRequiredIdentifier("source_id", scope.SourceID)
 	if err != nil {
 		return models.TaxonomyScope{}, err
 	}
 
-	fieldID, err := normalizeRequiredIdentifier("field_id", scope.FieldID, maxIdentifierLength)
+	fieldID, err := normalizeRequiredIdentifier("field_id", scope.FieldID)
 	if err != nil {
 		return models.TaxonomyScope{}, err
 	}

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -1,0 +1,349 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+)
+
+var (
+	ErrTaxonomyEmbeddingsNotConfigured = errors.New("taxonomy requires EMBEDDING_MODEL to be configured")
+	ErrTaxonomyServiceNotConfigured    = errors.New("taxonomy service is not configured")
+	ErrTaxonomyServiceStartFailed      = errors.New("taxonomy service failed to start run")
+)
+
+const defaultMinimumTaxonomyEmbeddingCount = 20
+
+type TaxonomyRepository interface {
+	ListFieldOptions(ctx context.Context, tenantID string, embeddingModel string) ([]models.TaxonomyFieldOption, error)
+	CountScopeInput(ctx context.Context, scope models.TaxonomyScope, embeddingModel string) (int, int, *string, error)
+	CreateRunIfAvailable(ctx context.Context, params repository.CreateTaxonomyRunParams) (*models.TaxonomyRun, bool, error)
+	MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	MarkRunFailed(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error)
+	GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error)
+	ListRuns(ctx context.Context, filters models.ListTaxonomyRunsFilters) ([]models.TaxonomyRun, error)
+	GetRunInput(ctx context.Context, runID uuid.UUID, embeddingModel string) (*models.TaxonomyRunInputResponse, error)
+	StoreResultAndActivate(
+		ctx context.Context,
+		runID uuid.UUID,
+		req models.TaxonomyRunResultRequest,
+	) (*models.TaxonomyRun, error)
+	GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error)
+	RenameNode(ctx context.Context, nodeID uuid.UUID, tenantID string, actorID string, label string) (*models.TaxonomyNode, error)
+	RemoveNode(ctx context.Context, nodeID uuid.UUID, tenantID string, actorID string) (*models.TaxonomyNode, error)
+	ListNodeRecords(ctx context.Context, nodeID uuid.UUID, tenantID string, limit int) ([]models.FeedbackRecord, int, error)
+}
+
+type TaxonomyRunStarter interface {
+	StartRun(ctx context.Context, runID string) error
+}
+
+type TaxonomyService struct {
+	repo                  TaxonomyRepository
+	starter               TaxonomyRunStarter
+	embeddingModel        string
+	minimumEmbeddingCount int
+}
+
+type NewTaxonomyServiceParams struct {
+	Repo                  TaxonomyRepository
+	Starter               TaxonomyRunStarter
+	EmbeddingModel        string
+	MinimumEmbeddingCount int
+}
+
+func NewTaxonomyService(params NewTaxonomyServiceParams) *TaxonomyService {
+	minimumEmbeddingCount := params.MinimumEmbeddingCount
+	if minimumEmbeddingCount <= 0 {
+		minimumEmbeddingCount = defaultMinimumTaxonomyEmbeddingCount
+	}
+
+	return &TaxonomyService{
+		repo:                  params.Repo,
+		starter:               params.Starter,
+		embeddingModel:        strings.TrimSpace(params.EmbeddingModel),
+		minimumEmbeddingCount: minimumEmbeddingCount,
+	}
+}
+
+func (s *TaxonomyService) ListFieldOptions(
+	ctx context.Context,
+	tenantID string,
+) (*models.TaxonomyFieldsResponse, error) {
+	if s.embeddingModel == "" {
+		return nil, ErrTaxonomyEmbeddingsNotConfigured
+	}
+
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	options, err := s.repo.ListFieldOptions(ctx, normalizedTenantID, s.embeddingModel)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy field options: %w", err)
+	}
+
+	return &models.TaxonomyFieldsResponse{Data: options}, nil
+}
+
+func (s *TaxonomyService) StartManualRun(
+	ctx context.Context,
+	req models.CreateTaxonomyRunRequest,
+) (*models.CreateTaxonomyRunResponse, error) {
+	if s.embeddingModel == "" {
+		return nil, ErrTaxonomyEmbeddingsNotConfigured
+	}
+
+	if s.starter == nil {
+		return nil, ErrTaxonomyServiceNotConfigured
+	}
+
+	scope, err := normalizeTaxonomyScope(req.TaxonomyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	recordCount, embeddingCount, discoveredFieldLabel, err := s.repo.CountScopeInput(ctx, scope, s.embeddingModel)
+	if err != nil {
+		return nil, fmt.Errorf("count taxonomy input: %w", err)
+	}
+
+	if recordCount == 0 {
+		return nil, huberrors.NewValidationError("field_id", "no text feedback records found for this field scope")
+	}
+
+	if embeddingCount < s.minimumEmbeddingCount {
+		return nil, huberrors.NewValidationError(
+			"field_id",
+			fmt.Sprintf("at least %d embedded text feedback records are required; found %d", s.minimumEmbeddingCount, embeddingCount),
+		)
+	}
+
+	fieldLabel := req.FieldLabel
+	if fieldLabel == nil {
+		fieldLabel = discoveredFieldLabel
+	}
+
+	params := taxonomyRunParams(req.ActorID, s.embeddingModel)
+	run, created, err := s.repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+		TaxonomyScope:  scope,
+		FieldLabel:     fieldLabel,
+		Params:         params,
+		RecordCount:    recordCount,
+		EmbeddingCount: embeddingCount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create taxonomy run: %w", err)
+	}
+
+	if !created {
+		return &models.CreateTaxonomyRunResponse{Run: *run, InProgress: true}, nil
+	}
+
+	runningRun, err := s.repo.MarkRunRunning(ctx, run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("mark taxonomy run running: %w", err)
+	}
+
+	if err := s.starter.StartRun(ctx, run.ID.String()); err != nil {
+		_, markErr := s.repo.MarkRunFailed(ctx, run.ID, "taxonomy service did not accept the run")
+		if markErr != nil {
+			return nil, fmt.Errorf("mark taxonomy run failed after start error: %w", markErr)
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrTaxonomyServiceStartFailed, err)
+	}
+
+	return &models.CreateTaxonomyRunResponse{Run: *runningRun}, nil
+}
+
+func (s *TaxonomyService) ListRuns(
+	ctx context.Context,
+	filters models.ListTaxonomyRunsFilters,
+) (*models.ListTaxonomyRunsResponse, error) {
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(filters.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	filters.TenantID = normalizedTenantID
+	runs, err := s.repo.ListRuns(ctx, filters)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy runs: %w", err)
+	}
+
+	return &models.ListTaxonomyRunsResponse{Data: runs}, nil
+}
+
+func (s *TaxonomyService) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+	return s.repo.GetRun(ctx, runID)
+}
+
+func (s *TaxonomyService) GetActiveTree(
+	ctx context.Context,
+	scope models.TaxonomyScope,
+) (*models.TaxonomyTreeResponse, error) {
+	normalizedScope, err := normalizeTaxonomyScope(scope)
+	if err != nil {
+		return nil, err
+	}
+
+	run, err := s.repo.GetActiveRun(ctx, normalizedScope)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.repo.GetTree(ctx, run.ID)
+}
+
+func (s *TaxonomyService) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
+	return s.repo.GetTree(ctx, runID)
+}
+
+func (s *TaxonomyService) GetRunInput(
+	ctx context.Context,
+	runID uuid.UUID,
+) (*models.TaxonomyRunInputResponse, error) {
+	if s.embeddingModel == "" {
+		return nil, ErrTaxonomyEmbeddingsNotConfigured
+	}
+
+	return s.repo.GetRunInput(ctx, runID, s.embeddingModel)
+}
+
+func (s *TaxonomyService) CompleteRun(
+	ctx context.Context,
+	runID uuid.UUID,
+	req models.TaxonomyRunResultRequest,
+) (*models.TaxonomyRun, error) {
+	return s.repo.StoreResultAndActivate(ctx, runID, req)
+}
+
+func (s *TaxonomyService) FailRun(
+	ctx context.Context,
+	runID uuid.UUID,
+	message string,
+) (*models.TaxonomyRun, error) {
+	sanitized := strings.TrimSpace(message)
+	if sanitized == "" {
+		sanitized = "taxonomy run failed"
+	}
+
+	return s.repo.MarkRunFailed(ctx, runID, sanitized)
+}
+
+func (s *TaxonomyService) RenameNode(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	req models.RenameTaxonomyNodeRequest,
+) (*models.TaxonomyNode, error) {
+	tenantID, err := normalizeRequiredTenantIDValue(req.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	actorID, err := normalizeRequiredIdentifier("actor_id", req.ActorID, maxIdentifierLength)
+	if err != nil {
+		return nil, err
+	}
+
+	label := strings.TrimSpace(req.Label)
+	if label == "" {
+		return nil, huberrors.NewValidationError("label", "label is required and cannot be empty")
+	}
+
+	return s.repo.RenameNode(ctx, nodeID, tenantID, actorID, label)
+}
+
+func (s *TaxonomyService) RemoveNode(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	filters models.RemoveTaxonomyNodeFilters,
+) (*models.TaxonomyNode, error) {
+	tenantID, err := normalizeRequiredTenantIDValue(filters.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	actorID, err := normalizeRequiredIdentifier("actor_id", filters.ActorID, maxIdentifierLength)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.repo.RemoveNode(ctx, nodeID, tenantID, actorID)
+}
+
+func (s *TaxonomyService) ListNodeRecords(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	filters models.TaxonomyNodeRecordsFilters,
+) (*models.TaxonomyNodeRecordsResponse, error) {
+	tenantID, err := normalizeRequiredTenantIDValue(filters.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	records, limit, err := s.repo.ListNodeRecords(ctx, nodeID, tenantID, filters.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("list taxonomy node records: %w", err)
+	}
+
+	return &models.TaxonomyNodeRecordsResponse{Data: records, Limit: limit}, nil
+}
+
+func normalizeTaxonomyScope(scope models.TaxonomyScope) (models.TaxonomyScope, error) {
+	tenantID, err := normalizeRequiredTenantIDValue(scope.TenantID)
+	if err != nil {
+		return models.TaxonomyScope{}, err
+	}
+
+	sourceType, err := normalizeRequiredIdentifier("source_type", scope.SourceType, maxIdentifierLength)
+	if err != nil {
+		return models.TaxonomyScope{}, err
+	}
+
+	sourceID, err := normalizeRequiredIdentifier("source_id", scope.SourceID, maxIdentifierLength)
+	if err != nil {
+		return models.TaxonomyScope{}, err
+	}
+
+	fieldID, err := normalizeRequiredIdentifier("field_id", scope.FieldID, maxIdentifierLength)
+	if err != nil {
+		return models.TaxonomyScope{}, err
+	}
+
+	return models.TaxonomyScope{
+		TenantID:   tenantID,
+		SourceType: sourceType,
+		SourceID:   sourceID,
+		FieldID:    fieldID,
+	}, nil
+}
+
+func taxonomyRunParams(actorID *string, embeddingModel string) json.RawMessage {
+	params := map[string]string{
+		"trigger":         "manual",
+		"embedding_model": embeddingModel,
+	}
+
+	if actorID != nil && strings.TrimSpace(*actorID) != "" {
+		params["requested_by"] = strings.TrimSpace(*actorID)
+	}
+
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return json.RawMessage(`{"trigger":"manual"}`)
+	}
+
+	return raw
+}

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -23,7 +23,7 @@ var (
 const defaultMinimumTaxonomyEmbeddingCount = 20
 
 type TaxonomyRepository interface {
-	ListFieldOptions(ctx context.Context, tenantID string, embeddingModel string) ([]models.TaxonomyFieldOption, error)
+	ListFieldOptions(ctx context.Context, tenantID, embeddingModel string) ([]models.TaxonomyFieldOption, error)
 	CountScopeInput(ctx context.Context, scope models.TaxonomyScope, embeddingModel string) (int, int, *string, error)
 	CreateRunIfAvailable(ctx context.Context, params repository.CreateTaxonomyRunParams) (*models.TaxonomyRun, bool, error)
 	MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
@@ -38,8 +38,8 @@ type TaxonomyRepository interface {
 		req models.TaxonomyRunResultRequest,
 	) (*models.TaxonomyRun, error)
 	GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error)
-	RenameNode(ctx context.Context, nodeID uuid.UUID, tenantID string, actorID string, label string) (*models.TaxonomyNode, error)
-	RemoveNode(ctx context.Context, nodeID uuid.UUID, tenantID string, actorID string) (*models.TaxonomyNode, error)
+	RenameNode(ctx context.Context, nodeID uuid.UUID, tenantID, actorID, label string) (*models.TaxonomyNode, error)
+	RemoveNode(ctx context.Context, nodeID uuid.UUID, tenantID, actorID string) (*models.TaxonomyNode, error)
 	ListNodeRecords(ctx context.Context, nodeID uuid.UUID, tenantID string, limit int) ([]models.FeedbackRecord, int, error)
 }
 

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -31,7 +31,12 @@ type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service 
 	CountScopeInput(ctx context.Context, scope models.TaxonomyScope, embeddingModel string) (int, int, *string, error)
 	CreateRunIfAvailable(ctx context.Context, params repository.CreateTaxonomyRunParams) (*models.TaxonomyRun, bool, error)
 	MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
-	MarkRunFailed(ctx context.Context, runID uuid.UUID, message string) (*models.TaxonomyRun, error)
+	MarkRunFailed(
+		ctx context.Context,
+		runID uuid.UUID,
+		message string,
+		errorCode models.TaxonomyRunFailureCode,
+	) (*models.TaxonomyRun, error)
 	GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
 	GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error)
 	ListRuns(ctx context.Context, filters models.ListTaxonomyRunsFilters) ([]models.TaxonomyRun, error)
@@ -167,7 +172,12 @@ func (s *TaxonomyService) StartManualRun(
 	}
 
 	if err := s.starter.StartRun(ctx, run.ID.String()); err != nil {
-		_, markErr := s.repo.MarkRunFailed(ctx, run.ID, "taxonomy service did not accept the run")
+		_, markErr := s.repo.MarkRunFailed(
+			ctx,
+			run.ID,
+			"taxonomy service did not accept the run",
+			models.TaxonomyRunFailureCodeServiceUnavailable,
+		)
 		if markErr != nil {
 			return nil, fmt.Errorf("mark taxonomy run failed after start error: %w", markErr)
 		}
@@ -277,18 +287,45 @@ func (s *TaxonomyService) FailRun(
 	ctx context.Context,
 	runID uuid.UUID,
 	message string,
+	errorCode models.TaxonomyRunFailureCode,
 ) (*models.TaxonomyRun, error) {
-	sanitized := strings.TrimSpace(message)
-	if sanitized == "" {
-		sanitized = "taxonomy run failed"
-	}
+	sanitized, normalizedCode := normalizeRunFailure(message, errorCode)
 
-	run, err := s.repo.MarkRunFailed(ctx, runID, sanitized)
+	run, err := s.repo.MarkRunFailed(ctx, runID, sanitized, normalizedCode)
 	if err != nil {
 		return nil, fmt.Errorf("fail taxonomy run: %w", err)
 	}
 
 	return run, nil
+}
+
+func normalizeRunFailure(
+	message string,
+	errorCode models.TaxonomyRunFailureCode,
+) (string, models.TaxonomyRunFailureCode) {
+	sanitized := strings.TrimSpace(message)
+	if sanitized == "" {
+		sanitized = "taxonomy run failed"
+	}
+
+	if !knownTaxonomyFailureCode(errorCode) {
+		errorCode = models.TaxonomyRunFailureCodeGenerationFailed
+	}
+
+	return sanitized, errorCode
+}
+
+func knownTaxonomyFailureCode(errorCode models.TaxonomyRunFailureCode) bool {
+	switch errorCode {
+	case models.TaxonomyRunFailureCodeInsufficientData,
+		models.TaxonomyRunFailureCodeServiceUnavailable,
+		models.TaxonomyRunFailureCodeGenerationFailed,
+		models.TaxonomyRunFailureCodeInvalidOutput,
+		models.TaxonomyRunFailureCodeInternalError:
+		return true
+	default:
+		return false
+	}
 }
 
 // RenameNode renames a taxonomy node.

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -30,23 +30,31 @@ type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service 
 	ListFieldOptions(ctx context.Context, tenantID, embeddingModel string) ([]models.TaxonomyFieldOption, error)
 	CountScopeInput(ctx context.Context, scope models.TaxonomyScope, embeddingModel string) (int, int, *string, error)
 	CreateRunIfAvailable(ctx context.Context, params repository.CreateTaxonomyRunParams) (*models.TaxonomyRun, bool, error)
-	MarkRunRunning(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	MarkRunRunning(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyRun, error)
 	MarkRunFailed(
 		ctx context.Context,
 		runID uuid.UUID,
+		tenantID string,
 		message string,
 		errorCode models.TaxonomyRunFailureCode,
 	) (*models.TaxonomyRun, error)
-	GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	GetRunForInternalService(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
+	GetRunForTenant(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyRun, error)
 	GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error)
 	ListRuns(ctx context.Context, filters models.ListTaxonomyRunsFilters) ([]models.TaxonomyRun, error)
-	GetRunInput(ctx context.Context, runID uuid.UUID, embeddingModel string) (*models.TaxonomyRunInputResponse, error)
+	GetRunInput(
+		ctx context.Context,
+		runID uuid.UUID,
+		tenantID string,
+		embeddingModel string,
+	) (*models.TaxonomyRunInputResponse, error)
 	StoreResultAndActivate(
 		ctx context.Context,
 		runID uuid.UUID,
+		tenantID string,
 		req models.TaxonomyRunResultRequest,
 	) (*models.TaxonomyRun, error)
-	GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error)
+	GetTree(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyTreeResponse, error)
 	RenameNode(ctx context.Context, nodeID uuid.UUID, tenantID, actorID, label string) (*models.TaxonomyNode, error)
 	RemoveNode(ctx context.Context, nodeID uuid.UUID, tenantID, actorID string) (*models.TaxonomyNode, error)
 	ListNodeRecords(ctx context.Context, nodeID uuid.UUID, tenantID string, limit int) ([]models.FeedbackRecord, int, error)
@@ -166,7 +174,7 @@ func (s *TaxonomyService) StartManualRun(
 		return &models.CreateTaxonomyRunResponse{Run: *run, InProgress: true}, nil
 	}
 
-	runningRun, err := s.repo.MarkRunRunning(ctx, run.ID)
+	runningRun, err := s.repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("mark taxonomy run running: %w", err)
 	}
@@ -175,6 +183,7 @@ func (s *TaxonomyService) StartManualRun(
 		_, markErr := s.repo.MarkRunFailed(
 			ctx,
 			run.ID,
+			scope.TenantID,
 			"taxonomy service did not accept the run",
 			models.TaxonomyRunFailureCodeServiceUnavailable,
 		)
@@ -209,8 +218,17 @@ func (s *TaxonomyService) ListRuns(
 }
 
 // GetRun returns a taxonomy run by ID.
-func (s *TaxonomyService) GetRun(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
-	run, err := s.repo.GetRun(ctx, runID)
+func (s *TaxonomyService) GetRun(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyRun, error) {
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	run, err := s.repo.GetRunForTenant(ctx, runID, normalizedTenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run: %w", err)
 	}
@@ -233,7 +251,7 @@ func (s *TaxonomyService) GetActiveTree(
 		return nil, fmt.Errorf("get active taxonomy run: %w", err)
 	}
 
-	tree, err := s.repo.GetTree(ctx, run.ID)
+	tree, err := s.repo.GetTree(ctx, run.ID, normalizedScope.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get active taxonomy tree: %w", err)
 	}
@@ -242,8 +260,17 @@ func (s *TaxonomyService) GetActiveTree(
 }
 
 // GetTree returns a taxonomy tree by run ID.
-func (s *TaxonomyService) GetTree(ctx context.Context, runID uuid.UUID) (*models.TaxonomyTreeResponse, error) {
-	tree, err := s.repo.GetTree(ctx, runID)
+func (s *TaxonomyService) GetTree(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyTreeResponse, error) {
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, err := s.repo.GetTree(ctx, runID, normalizedTenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy tree: %w", err)
 	}
@@ -260,7 +287,12 @@ func (s *TaxonomyService) GetRunInput(
 		return nil, ErrTaxonomyEmbeddingsNotConfigured
 	}
 
-	input, err := s.repo.GetRunInput(ctx, runID, s.embeddingModel)
+	run, err := s.repo.GetRunForInternalService(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	input, err := s.repo.GetRunInput(ctx, runID, run.TenantID, s.embeddingModel)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run input: %w", err)
 	}
@@ -274,7 +306,12 @@ func (s *TaxonomyService) CompleteRun(
 	runID uuid.UUID,
 	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
-	run, err := s.repo.StoreResultAndActivate(ctx, runID, req)
+	existingRun, err := s.repo.GetRunForInternalService(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	run, err := s.repo.StoreResultAndActivate(ctx, runID, existingRun.TenantID, req)
 	if err != nil {
 		return nil, fmt.Errorf("complete taxonomy run: %w", err)
 	}
@@ -291,7 +328,12 @@ func (s *TaxonomyService) FailRun(
 ) (*models.TaxonomyRun, error) {
 	sanitized, normalizedCode := normalizeRunFailure(message, errorCode)
 
-	run, err := s.repo.MarkRunFailed(ctx, runID, sanitized, normalizedCode)
+	existingRun, err := s.repo.GetRunForInternalService(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	run, err := s.repo.MarkRunFailed(ctx, runID, existingRun.TenantID, sanitized, normalizedCode)
 	if err != nil {
 		return nil, fmt.Errorf("fail taxonomy run: %w", err)
 	}

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -1,0 +1,205 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+)
+
+type mockTaxonomyRepo struct {
+	countRecordCount     int
+	countEmbeddingCount  int
+	createRun            *models.TaxonomyRun
+	createRunCreated     bool
+	markRunFailedMessage string
+	markRunFailedCode    models.TaxonomyRunFailureCode
+}
+
+func (m *mockTaxonomyRepo) ListFieldOptions(
+	_ context.Context,
+	_ string,
+	_ string,
+) ([]models.TaxonomyFieldOption, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) CountScopeInput(
+	_ context.Context,
+	_ models.TaxonomyScope,
+	_ string,
+) (int, int, *string, error) {
+	return m.countRecordCount, m.countEmbeddingCount, nil, nil
+}
+
+func (m *mockTaxonomyRepo) CreateRunIfAvailable(
+	_ context.Context,
+	_ repository.CreateTaxonomyRunParams,
+) (*models.TaxonomyRun, bool, error) {
+	return m.createRun, m.createRunCreated, nil
+}
+
+func (m *mockTaxonomyRepo) MarkRunRunning(
+	_ context.Context,
+	runID uuid.UUID,
+) (*models.TaxonomyRun, error) {
+	return &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusRunning}, nil
+}
+
+func (m *mockTaxonomyRepo) MarkRunFailed(
+	_ context.Context,
+	runID uuid.UUID,
+	message string,
+	errorCode models.TaxonomyRunFailureCode,
+) (*models.TaxonomyRun, error) {
+	m.markRunFailedMessage = message
+	m.markRunFailedCode = errorCode
+
+	return &models.TaxonomyRun{
+		ID:        runID,
+		Status:    models.TaxonomyRunStatusFailed,
+		Error:     &message,
+		ErrorCode: &errorCode,
+	}, nil
+}
+
+func (m *mockTaxonomyRepo) GetRun(_ context.Context, _ uuid.UUID) (*models.TaxonomyRun, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) GetActiveRun(
+	_ context.Context,
+	_ models.TaxonomyScope,
+) (*models.TaxonomyRun, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) ListRuns(
+	_ context.Context,
+	_ models.ListTaxonomyRunsFilters,
+) ([]models.TaxonomyRun, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) GetRunInput(
+	_ context.Context,
+	_ uuid.UUID,
+	_ string,
+) (*models.TaxonomyRunInputResponse, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) StoreResultAndActivate(
+	_ context.Context,
+	_ uuid.UUID,
+	_ models.TaxonomyRunResultRequest,
+) (*models.TaxonomyRun, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) GetTree(
+	_ context.Context,
+	_ uuid.UUID,
+) (*models.TaxonomyTreeResponse, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) RenameNode(
+	_ context.Context,
+	_ uuid.UUID,
+	_ string,
+	_ string,
+	_ string,
+) (*models.TaxonomyNode, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) RemoveNode(
+	_ context.Context,
+	_ uuid.UUID,
+	_ string,
+	_ string,
+) (*models.TaxonomyNode, error) {
+	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) ListNodeRecords(
+	_ context.Context,
+	_ uuid.UUID,
+	_ string,
+	_ int,
+) ([]models.FeedbackRecord, int, error) {
+	return nil, 0, nil
+}
+
+type failingTaxonomyStarter struct{}
+
+func (f failingTaxonomyStarter) StartRun(_ context.Context, _ string) error {
+	return errors.New("taxonomy service unavailable")
+}
+
+func TestTaxonomyService_StartManualRunMarksServiceUnavailableFailure(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-111111111111")
+	repo := &mockTaxonomyRepo{
+		countRecordCount:    20,
+		countEmbeddingCount: 20,
+		createRun:           &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusPending},
+		createRunCreated:    true,
+	}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{
+		Repo:           repo,
+		Starter:        failingTaxonomyStarter{},
+		EmbeddingModel: "text-embedding-004",
+	})
+
+	result, err := svc.StartManualRun(context.Background(), models.CreateTaxonomyRunRequest{
+		TaxonomyScope: models.TaxonomyScope{
+			TenantID:   "tenant-1",
+			SourceType: "survey",
+			SourceID:   "survey-1",
+			FieldID:    "question-1",
+		},
+	})
+	if !errors.Is(err, ErrTaxonomyServiceStartFailed) {
+		t.Fatalf("StartManualRun() error = %v, want taxonomy service start failure", err)
+	}
+
+	if result != nil {
+		t.Fatalf("StartManualRun() result = %+v, want nil", result)
+	}
+
+	if repo.markRunFailedMessage != "taxonomy service did not accept the run" {
+		t.Fatalf("MarkRunFailed message = %q", repo.markRunFailedMessage)
+	}
+
+	if repo.markRunFailedCode != models.TaxonomyRunFailureCodeServiceUnavailable {
+		t.Fatalf("MarkRunFailed code = %q, want service_unavailable", repo.markRunFailedCode)
+	}
+}
+
+func TestTaxonomyService_FailRunDefaultsFailureCode(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222222")
+	repo := &mockTaxonomyRepo{}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	result, err := svc.FailRun(context.Background(), runID, " generated invalid taxonomy ", "")
+	if err != nil {
+		t.Fatalf("FailRun() error = %v", err)
+	}
+
+	if result == nil || result.ErrorCode == nil {
+		t.Fatalf("FailRun() result = %+v, want error code", result)
+	}
+
+	if repo.markRunFailedMessage != "generated invalid taxonomy" {
+		t.Fatalf("MarkRunFailed message = %q", repo.markRunFailedMessage)
+	}
+
+	if *result.ErrorCode != models.TaxonomyRunFailureCodeGenerationFailed {
+		t.Fatalf("result error code = %q, want generation_failed", *result.ErrorCode)
+	}
+}

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -16,8 +16,11 @@ type mockTaxonomyRepo struct {
 	countEmbeddingCount  int
 	createRun            *models.TaxonomyRun
 	createRunCreated     bool
+	internalRun          *models.TaxonomyRun
+	markRunRunningTenant string
 	markRunFailedMessage string
 	markRunFailedCode    models.TaxonomyRunFailureCode
+	markRunFailedTenant  string
 }
 
 func (m *mockTaxonomyRepo) ListFieldOptions(
@@ -46,16 +49,21 @@ func (m *mockTaxonomyRepo) CreateRunIfAvailable(
 func (m *mockTaxonomyRepo) MarkRunRunning(
 	_ context.Context,
 	runID uuid.UUID,
+	tenantID string,
 ) (*models.TaxonomyRun, error) {
+	m.markRunRunningTenant = tenantID
+
 	return &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusRunning}, nil
 }
 
 func (m *mockTaxonomyRepo) MarkRunFailed(
 	_ context.Context,
 	runID uuid.UUID,
+	tenantID string,
 	message string,
 	errorCode models.TaxonomyRunFailureCode,
 ) (*models.TaxonomyRun, error) {
+	m.markRunFailedTenant = tenantID
 	m.markRunFailedMessage = message
 	m.markRunFailedCode = errorCode
 
@@ -67,8 +75,20 @@ func (m *mockTaxonomyRepo) MarkRunFailed(
 	}, nil
 }
 
-func (m *mockTaxonomyRepo) GetRun(_ context.Context, _ uuid.UUID) (*models.TaxonomyRun, error) {
-	return nil, nil
+func (m *mockTaxonomyRepo) GetRunForInternalService(_ context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
+	if m.internalRun != nil {
+		return m.internalRun, nil
+	}
+
+	return &models.TaxonomyRun{ID: runID, TenantID: "tenant-1"}, nil
+}
+
+func (m *mockTaxonomyRepo) GetRunForTenant(
+	_ context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyRun, error) {
+	return &models.TaxonomyRun{ID: runID, TenantID: tenantID}, nil
 }
 
 func (m *mockTaxonomyRepo) GetActiveRun(
@@ -89,6 +109,7 @@ func (m *mockTaxonomyRepo) GetRunInput(
 	_ context.Context,
 	_ uuid.UUID,
 	_ string,
+	_ string,
 ) (*models.TaxonomyRunInputResponse, error) {
 	return nil, nil
 }
@@ -96,6 +117,7 @@ func (m *mockTaxonomyRepo) GetRunInput(
 func (m *mockTaxonomyRepo) StoreResultAndActivate(
 	_ context.Context,
 	_ uuid.UUID,
+	_ string,
 	_ models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
 	return nil, nil
@@ -104,6 +126,7 @@ func (m *mockTaxonomyRepo) StoreResultAndActivate(
 func (m *mockTaxonomyRepo) GetTree(
 	_ context.Context,
 	_ uuid.UUID,
+	_ string,
 ) (*models.TaxonomyTreeResponse, error) {
 	return nil, nil
 }
@@ -176,6 +199,14 @@ func TestTaxonomyService_StartManualRunMarksServiceUnavailableFailure(t *testing
 		t.Fatalf("MarkRunFailed message = %q", repo.markRunFailedMessage)
 	}
 
+	if repo.markRunRunningTenant != "tenant-1" {
+		t.Fatalf("MarkRunRunning tenant = %q, want tenant-1", repo.markRunRunningTenant)
+	}
+
+	if repo.markRunFailedTenant != "tenant-1" {
+		t.Fatalf("MarkRunFailed tenant = %q, want tenant-1", repo.markRunFailedTenant)
+	}
+
 	if repo.markRunFailedCode != models.TaxonomyRunFailureCodeServiceUnavailable {
 		t.Fatalf("MarkRunFailed code = %q, want service_unavailable", repo.markRunFailedCode)
 	}
@@ -197,6 +228,10 @@ func TestTaxonomyService_FailRunDefaultsFailureCode(t *testing.T) {
 
 	if repo.markRunFailedMessage != "generated invalid taxonomy" {
 		t.Fatalf("MarkRunFailed message = %q", repo.markRunFailedMessage)
+	}
+
+	if repo.markRunFailedTenant != "tenant-1" {
+		t.Fatalf("MarkRunFailed tenant = %q, want tenant-1", repo.markRunFailedTenant)
 	}
 
 	if *result.ErrorCode != models.TaxonomyRunFailureCodeGenerationFailed {

--- a/migrations/011_taxonomy_run_error_code.sql
+++ b/migrations/011_taxonomy_run_error_code.sql
@@ -1,0 +1,17 @@
+-- +goose up
+ALTER TABLE taxonomy_runs
+  ADD COLUMN error_code VARCHAR(64),
+  ADD CONSTRAINT taxonomy_runs_error_code_known CHECK (
+    error_code IS NULL OR error_code IN (
+      'insufficient_data',
+      'service_unavailable',
+      'generation_failed',
+      'invalid_output',
+      'internal_error'
+    )
+  );
+
+-- +goose down
+ALTER TABLE taxonomy_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_runs_error_code_known,
+  DROP COLUMN IF EXISTS error_code;


### PR DESCRIPTION
## Summary

- add Hub public taxonomy APIs for fields, manual run creation/status, active tree reads, node feedback drilldown, rename, and soft-remove
- add Hub internal taxonomy service APIs for run input and result/failure persistence
- add taxonomy repository/service models for runs, clusters, memberships, nodes, active runs, and node events
- wire taxonomy service outbound client/config for manual run orchestration
- address CodeRabbit tenant-scope review feedback by requiring tenant scoping on public run/tree reads and repository transitions/results

## Validation

- `make migrate-validate`
- `go test ./internal/...`
- `go test ./internal/service ./internal/repository ./internal/api/handlers`
- `go test -run '^$' ./tests`
- `golangci-lint run --timeout 10m ./...`
- local smoke: Formbricks Web -> Hub -> standalone Python taxonomy service -> Hub persistence succeeded with 20 records, 20 768-dim embeddings, 9 clusters, and 10 nodes

## Notes

The local smoke currently uses the taxonomy service's temporary simple generator. POC-backed clustering/LLM 5-level taxonomy generation remains tracked separately on the Python taxonomy service tickets.