### PR TITLE
fix: pass release tag to GHCR workflow

### DIFF
--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -100,6 +100,7 @@ jobs:
     uses: ./.github/workflows/release-docker-ghcr.yml
     secrets: inherit
     with:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
       MAKE_LATEST: ${{ needs.check-release.outputs.is_latest == 'true' }}
 
   docker-build-ecr:

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -3,6 +3,10 @@ name: Release Docker Image to GHCR
 on:
   workflow_call:
     inputs:
+      RELEASE_TAG:
+        description: "Release tag to publish (SemVer, e.g., 1.0.0)"
+        required: true
+        type: string
       MAKE_LATEST:
         description: "Whether to tag as latest (from GitHub release 'Set as the latest release' option)"
         required: false
@@ -42,21 +46,15 @@ jobs:
 
       - name: Extract release version from tag
         id: extract_version
+        env:
+          RELEASE_TAG: ${{ inputs.RELEASE_TAG }}
         run: |
           set -euo pipefail
 
-          # Extract tag name with fallback logic
-          if [[ "$GITHUB_REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]] || [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
-            TAG="$GITHUB_REF_NAME"
-            echo "Using GITHUB_REF_NAME: $TAG"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-            if [[ -z "$TAG" || "$TAG" == "$GITHUB_REF" ]]; then
-              TAG="$GITHUB_REF_NAME"
-              echo "Using GITHUB_REF_NAME as fallback: $TAG"
-            else
-              echo "Extracted from GITHUB_REF: $TAG"
-            fi
+          TAG="${RELEASE_TAG}"
+          if [[ -z "$TAG" ]]; then
+            echo "ERROR: Release tag input is required."
+            exit 1
           fi
 
           # Strip v-prefix if present


### PR DESCRIPTION
## Summary
- Pass the release event tag from `hub-release.yml` into the reusable GHCR workflow.
- Make the GHCR workflow validate that explicit `RELEASE_TAG` input instead of inferring the version from `GITHUB_REF_NAME`/`GITHUB_REF`.

## Root cause
The `0.6.1` release run failed in `Extract release version from tag` because the called reusable workflow had empty `GITHUB_REF_NAME` and `GITHUB_REF` values, so it validated an empty tag and exited before building the GHCR image.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/hub-release.yml .github/workflows/release-docker-ghcr.yml`
- Simulated the version extraction block with `0.6.1`, `v0.6.1`, invalid branch-like input, and empty input.

## Release recovery note
The failed `0.6.1` run is pinned to commit `0f4e36f`, so rerunning that exact failed job will still use the old workflow. After this merges, publish a new release from a commit containing this fix, or recreate/retarget the `0.6.1` release tag to a commit containing the workflow fix if `0.6.1` must be preserved.