### PR TITLE
refactor(observability): share one implementation across enrichment metrics

### DIFF
--- a/internal/observability/embeddings.go
+++ b/internal/observability/embeddings.go
@@ -2,15 +2,13 @@ package observability
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 // EmbeddingMetrics records embedding pipeline metrics (provider, worker).
-// Methods accept ctx for future exemplar support.
+// Backed by the shared enrichmentMetrics implementation.
 type EmbeddingMetrics interface {
 	RecordJobsEnqueued(ctx context.Context, count int64)
 	RecordProviderError(ctx context.Context, reason string)
@@ -19,100 +17,35 @@ type EmbeddingMetrics interface {
 	RecordEmbeddingDuration(ctx context.Context, duration time.Duration, status string)
 }
 
-// embeddingMetrics implements EmbeddingMetrics.
-type embeddingMetrics struct {
-	jobsEnqueued   metric.Int64Counter
-	providerErrors metric.Int64Counter
-	outcomes       metric.Int64Counter
-	workerErrors   metric.Int64Counter
-	duration       metric.Float64Histogram
+// embeddingMetrics adapts the shared impl to the EmbeddingMetrics outcome/duration names.
+type embeddingMetrics struct{ *enrichmentMetrics }
+
+func (m embeddingMetrics) RecordEmbeddingOutcome(ctx context.Context, status string) {
+	m.recordOutcome(ctx, status)
+}
+
+func (m embeddingMetrics) RecordEmbeddingDuration(ctx context.Context, duration time.Duration, status string) {
+	m.recordDuration(ctx, duration, status)
 }
 
 // NewEmbeddingMetrics creates EmbeddingMetrics. Returns (nil, nil) when meter is nil (metrics disabled).
 func NewEmbeddingMetrics(meter metric.Meter) (EmbeddingMetrics, error) {
-	if meter == nil {
-		//nolint:nilnil // intentional: callers use "if metrics != nil" when metrics disabled
-		return nil, nil
+	shared, err := newEnrichmentMetrics(meter, enrichmentMetricsSpec{
+		jobsEnqueuedName:      MetricNameEmbeddingJobsEnqueued,
+		providerErrorsName:    MetricNameEmbeddingProviderErrors,
+		outcomesName:          MetricNameEmbeddingOutcomes,
+		workerErrorsName:      MetricNameEmbeddingWorkerErrors,
+		durationName:          MetricNameEmbeddingDuration,
+		providerErrorsDesc:    "Total embedding provider errors (enqueue failures)",
+		workerErrorsDesc:      "Total embedding worker errors (get record, openai, update)",
+		allowedProviderReason: AllowedEmbeddingProviderReason,
+		allowedWorkerReason:   AllowedEmbeddingWorkerReason,
+		allowedOutcomeStatus:  AllowedEmbeddingOutcomeStatus,
+	})
+	if err != nil || shared == nil {
+		// shared == nil means the meter is disabled; return a nil interface, not a typed nil.
+		return nil, err
 	}
 
-	jobsEnqueued, err := meter.Int64Counter(
-		MetricNameEmbeddingJobsEnqueued,
-		metric.WithDescription("Total embedding jobs enqueued"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create embedding jobs enqueued counter: %w", err)
-	}
-
-	providerErrors, err := meter.Int64Counter(
-		MetricNameEmbeddingProviderErrors,
-		metric.WithDescription("Total embedding provider errors (enqueue failures)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create embedding provider errors counter: %w", err)
-	}
-
-	outcomes, err := meter.Int64Counter(
-		MetricNameEmbeddingOutcomes,
-		metric.WithDescription("Total embedding job outcomes by status"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create embedding outcomes counter: %w", err)
-	}
-
-	workerErrors, err := meter.Int64Counter(
-		MetricNameEmbeddingWorkerErrors,
-		metric.WithDescription("Total embedding worker errors (get record, openai, update)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create embedding worker errors counter: %w", err)
-	}
-
-	duration, err := meter.Float64Histogram(
-		MetricNameEmbeddingDuration,
-		metric.WithDescription("Embedding job duration (seconds)"),
-		metric.WithUnit("s"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create embedding duration histogram: %w", err)
-	}
-
-	return &embeddingMetrics{
-		jobsEnqueued:   jobsEnqueued,
-		providerErrors: providerErrors,
-		outcomes:       outcomes,
-		workerErrors:   workerErrors,
-		duration:       duration,
-	}, nil
-}
-
-func (e *embeddingMetrics) RecordJobsEnqueued(ctx context.Context, count int64) {
-	e.jobsEnqueued.Add(ctx, count)
-}
-
-func (e *embeddingMetrics) RecordProviderError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedEmbeddingProviderReason)
-	e.providerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (e *embeddingMetrics) RecordEmbeddingOutcome(ctx context.Context, status string) {
-	status = normalizeEmbeddingStatus(status)
-	e.outcomes.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func (e *embeddingMetrics) RecordWorkerError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedEmbeddingWorkerReason)
-	e.workerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (e *embeddingMetrics) RecordEmbeddingDuration(ctx context.Context, duration time.Duration, status string) {
-	status = normalizeEmbeddingStatus(status)
-	e.duration.Record(ctx, duration.Seconds(), metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func normalizeEmbeddingStatus(status string) string {
-	if AllowedEmbeddingOutcomeStatus(status) {
-		return status
-	}
-
-	return "other"
+	return embeddingMetrics{shared}, nil
 }

--- a/internal/observability/enrichment_metrics.go
+++ b/internal/observability/enrichment_metrics.go
@@ -1,0 +1,127 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// enrichmentMetrics is the shared implementation behind the per-pipeline metrics
+// (EmbeddingMetrics, TranslationMetrics, SentimentMetrics): the three pipelines emit the same
+// five instruments — jobs enqueued, provider errors, job outcomes, worker errors, duration —
+// differing only in metric names and the bounded reason/status label sets. Each pipeline embeds
+// this and adds its two differently-named outcome/duration methods (see translation.go etc.).
+type enrichmentMetrics struct {
+	jobsEnqueued   metric.Int64Counter
+	providerErrors metric.Int64Counter
+	outcomes       metric.Int64Counter
+	workerErrors   metric.Int64Counter
+	duration       metric.Float64Histogram
+
+	allowedProviderReason func(string) bool
+	allowedWorkerReason   func(string) bool
+	allowedOutcomeStatus  func(string) bool
+}
+
+// enrichmentMetricsSpec parameterizes one pipeline: instrument names/descriptions and the
+// allow-list predicates that bound reason/status cardinality.
+type enrichmentMetricsSpec struct {
+	jobsEnqueuedName   string
+	providerErrorsName string
+	outcomesName       string
+	workerErrorsName   string
+	durationName       string
+
+	providerErrorsDesc string
+	workerErrorsDesc   string
+
+	allowedProviderReason func(string) bool
+	allowedWorkerReason   func(string) bool
+	allowedOutcomeStatus  func(string) bool
+}
+
+// newEnrichmentMetrics builds the five collectors from spec. Returns (nil, nil) when meter is nil
+// (metrics disabled); per-pipeline constructors propagate that as a nil interface.
+func newEnrichmentMetrics(meter metric.Meter, spec enrichmentMetricsSpec) (*enrichmentMetrics, error) {
+	if meter == nil {
+		//nolint:nilnil // intentional: callers translate a nil impl into a nil interface
+		return nil, nil
+	}
+
+	jobsEnqueued, err := meter.Int64Counter(spec.jobsEnqueuedName, metric.WithDescription("Total jobs enqueued"))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", spec.jobsEnqueuedName, err)
+	}
+
+	providerErrors, err := meter.Int64Counter(spec.providerErrorsName, metric.WithDescription(spec.providerErrorsDesc))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", spec.providerErrorsName, err)
+	}
+
+	outcomes, err := meter.Int64Counter(spec.outcomesName, metric.WithDescription("Total job outcomes by status"))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", spec.outcomesName, err)
+	}
+
+	workerErrors, err := meter.Int64Counter(spec.workerErrorsName, metric.WithDescription(spec.workerErrorsDesc))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", spec.workerErrorsName, err)
+	}
+
+	duration, err := meter.Float64Histogram(
+		spec.durationName, metric.WithDescription("Job duration (seconds)"), metric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", spec.durationName, err)
+	}
+
+	return &enrichmentMetrics{
+		jobsEnqueued:          jobsEnqueued,
+		providerErrors:        providerErrors,
+		outcomes:              outcomes,
+		workerErrors:          workerErrors,
+		duration:              duration,
+		allowedProviderReason: spec.allowedProviderReason,
+		allowedWorkerReason:   spec.allowedWorkerReason,
+		allowedOutcomeStatus:  spec.allowedOutcomeStatus,
+	}, nil
+}
+
+// RecordJobsEnqueued, RecordProviderError, and RecordWorkerError share the same name across the
+// three pipeline interfaces, so they are promoted directly from the embedded impl.
+func (m *enrichmentMetrics) RecordJobsEnqueued(ctx context.Context, count int64) {
+	m.jobsEnqueued.Add(ctx, count)
+}
+
+func (m *enrichmentMetrics) RecordProviderError(ctx context.Context, reason string) {
+	reason = NormalizeReason(reason, m.allowedProviderReason)
+	m.providerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
+}
+
+func (m *enrichmentMetrics) RecordWorkerError(ctx context.Context, reason string) {
+	reason = NormalizeReason(reason, m.allowedWorkerReason)
+	m.workerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
+}
+
+// recordOutcome and recordDuration are unexported; each pipeline exposes them under its own
+// method name (RecordTranslationOutcome, RecordEmbeddingDuration, …) so the public contracts
+// are unchanged.
+func (m *enrichmentMetrics) recordOutcome(ctx context.Context, status string) {
+	m.outcomes.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrStatus, m.normalizeStatus(status))))
+}
+
+func (m *enrichmentMetrics) recordDuration(ctx context.Context, duration time.Duration, status string) {
+	m.duration.Record(ctx, duration.Seconds(), metric.WithAttributes(attribute.String(AttrStatus, m.normalizeStatus(status))))
+}
+
+// normalizeStatus keeps outcome/duration status labels within the pipeline's allowed set,
+// bucketing anything else as "other" to bound cardinality.
+func (m *enrichmentMetrics) normalizeStatus(status string) string {
+	if m.allowedOutcomeStatus(status) {
+		return status
+	}
+
+	return "other"
+}

--- a/internal/observability/sentiment.go
+++ b/internal/observability/sentiment.go
@@ -2,15 +2,13 @@ package observability
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 // SentimentMetrics records sentiment pipeline metrics (provider, worker).
-// Methods accept ctx for future exemplar support. Mirrors TranslationMetrics.
+// Backed by the shared enrichmentMetrics implementation.
 type SentimentMetrics interface {
 	RecordJobsEnqueued(ctx context.Context, count int64)
 	RecordProviderError(ctx context.Context, reason string)
@@ -19,100 +17,35 @@ type SentimentMetrics interface {
 	RecordSentimentDuration(ctx context.Context, duration time.Duration, status string)
 }
 
-// sentimentMetrics implements SentimentMetrics.
-type sentimentMetrics struct {
-	jobsEnqueued   metric.Int64Counter
-	providerErrors metric.Int64Counter
-	outcomes       metric.Int64Counter
-	workerErrors   metric.Int64Counter
-	duration       metric.Float64Histogram
+// sentimentMetrics adapts the shared impl to the SentimentMetrics outcome/duration names.
+type sentimentMetrics struct{ *enrichmentMetrics }
+
+func (m sentimentMetrics) RecordSentimentOutcome(ctx context.Context, status string) {
+	m.recordOutcome(ctx, status)
+}
+
+func (m sentimentMetrics) RecordSentimentDuration(ctx context.Context, duration time.Duration, status string) {
+	m.recordDuration(ctx, duration, status)
 }
 
 // NewSentimentMetrics creates SentimentMetrics. Returns (nil, nil) when meter is nil (metrics disabled).
 func NewSentimentMetrics(meter metric.Meter) (SentimentMetrics, error) {
-	if meter == nil {
-		//nolint:nilnil // intentional: callers use "if metrics != nil" when metrics disabled
-		return nil, nil
+	shared, err := newEnrichmentMetrics(meter, enrichmentMetricsSpec{
+		jobsEnqueuedName:      MetricNameSentimentJobsEnqueued,
+		providerErrorsName:    MetricNameSentimentProviderErrors,
+		outcomesName:          MetricNameSentimentOutcomes,
+		workerErrorsName:      MetricNameSentimentWorkerErrors,
+		durationName:          MetricNameSentimentDuration,
+		providerErrorsDesc:    "Total sentiment provider errors (settings/enqueue failures)",
+		workerErrorsDesc:      "Total sentiment worker errors (get record, provider, update)",
+		allowedProviderReason: AllowedSentimentProviderReason,
+		allowedWorkerReason:   AllowedSentimentWorkerReason,
+		allowedOutcomeStatus:  AllowedSentimentOutcomeStatus,
+	})
+	if err != nil || shared == nil {
+		// shared == nil means the meter is disabled; return a nil interface, not a typed nil.
+		return nil, err
 	}
 
-	jobsEnqueued, err := meter.Int64Counter(
-		MetricNameSentimentJobsEnqueued,
-		metric.WithDescription("Total sentiment jobs enqueued"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create sentiment jobs enqueued counter: %w", err)
-	}
-
-	providerErrors, err := meter.Int64Counter(
-		MetricNameSentimentProviderErrors,
-		metric.WithDescription("Total sentiment provider errors (enqueue failures)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create sentiment provider errors counter: %w", err)
-	}
-
-	outcomes, err := meter.Int64Counter(
-		MetricNameSentimentOutcomes,
-		metric.WithDescription("Total sentiment job outcomes by status"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create sentiment outcomes counter: %w", err)
-	}
-
-	workerErrors, err := meter.Int64Counter(
-		MetricNameSentimentWorkerErrors,
-		metric.WithDescription("Total sentiment worker errors (get record, provider, update)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create sentiment worker errors counter: %w", err)
-	}
-
-	duration, err := meter.Float64Histogram(
-		MetricNameSentimentDuration,
-		metric.WithDescription("Sentiment job duration (seconds)"),
-		metric.WithUnit("s"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create sentiment duration histogram: %w", err)
-	}
-
-	return &sentimentMetrics{
-		jobsEnqueued:   jobsEnqueued,
-		providerErrors: providerErrors,
-		outcomes:       outcomes,
-		workerErrors:   workerErrors,
-		duration:       duration,
-	}, nil
-}
-
-func (s *sentimentMetrics) RecordJobsEnqueued(ctx context.Context, count int64) {
-	s.jobsEnqueued.Add(ctx, count)
-}
-
-func (s *sentimentMetrics) RecordProviderError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedSentimentProviderReason)
-	s.providerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (s *sentimentMetrics) RecordSentimentOutcome(ctx context.Context, status string) {
-	status = normalizeSentimentStatus(status)
-	s.outcomes.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func (s *sentimentMetrics) RecordWorkerError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedSentimentWorkerReason)
-	s.workerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (s *sentimentMetrics) RecordSentimentDuration(ctx context.Context, duration time.Duration, status string) {
-	status = normalizeSentimentStatus(status)
-	s.duration.Record(ctx, duration.Seconds(), metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func normalizeSentimentStatus(status string) string {
-	if AllowedSentimentOutcomeStatus(status) {
-		return status
-	}
-
-	return "other"
+	return sentimentMetrics{shared}, nil
 }

--- a/internal/observability/sentiment_test.go
+++ b/internal/observability/sentiment_test.go
@@ -27,13 +27,12 @@ func TestSentimentAllowedReasonsAndStatuses(t *testing.T) {
 
 	for _, status := range []string{"success", "retry", "failed_final", "skipped"} {
 		assert.True(t, AllowedSentimentOutcomeStatus(status), status)
-		assert.Equal(t, status, normalizeSentimentStatus(status))
 	}
 
 	// Unknown values normalize to a bounded "other" bucket (keeps metric cardinality fixed).
 	assert.False(t, AllowedSentimentProviderReason("nope"))
 	assert.Equal(t, "other", NormalizeReason("nope", AllowedSentimentProviderReason))
-	assert.Equal(t, "other", normalizeSentimentStatus("nope"))
+	assert.False(t, AllowedSentimentOutcomeStatus("nope"))
 }
 
 func TestNewSentimentMetricsNilMeterDisabled(t *testing.T) {
@@ -65,6 +64,7 @@ func TestSentimentMetricsRecordEmitsDataPoints(t *testing.T) {
 	metrics.RecordProviderError(ctx, "enqueue_failed")
 	metrics.RecordProviderError(ctx, "bogus") // unknown reason -> normalized to "other"
 	metrics.RecordSentimentOutcome(ctx, "success")
+	metrics.RecordSentimentOutcome(ctx, "bogus") // unknown status -> normalized to "other"
 	metrics.RecordWorkerError(ctx, "rate_limited")
 	metrics.RecordSentimentDuration(ctx, 150*time.Millisecond, "success")
 
@@ -75,6 +75,7 @@ func TestSentimentMetricsRecordEmitsDataPoints(t *testing.T) {
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameSentimentProviderErrors, AttrReason, "enqueue_failed"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameSentimentProviderErrors, AttrReason, "other"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameSentimentOutcomes, AttrStatus, "success"))
+	assert.Equal(t, int64(1), counterValue(collected, MetricNameSentimentOutcomes, AttrStatus, "other"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameSentimentWorkerErrors, AttrReason, "rate_limited"))
 	assert.Equal(t, uint64(1), histogramCount(collected, MetricNameSentimentDuration, "success"))
 }

--- a/internal/observability/translation.go
+++ b/internal/observability/translation.go
@@ -2,15 +2,13 @@ package observability
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 // TranslationMetrics records translation pipeline metrics (provider, worker).
-// Methods accept ctx for future exemplar support. Mirrors EmbeddingMetrics.
+// Backed by the shared enrichmentMetrics implementation.
 type TranslationMetrics interface {
 	RecordJobsEnqueued(ctx context.Context, count int64)
 	RecordProviderError(ctx context.Context, reason string)
@@ -19,100 +17,35 @@ type TranslationMetrics interface {
 	RecordTranslationDuration(ctx context.Context, duration time.Duration, status string)
 }
 
-// translationMetrics implements TranslationMetrics.
-type translationMetrics struct {
-	jobsEnqueued   metric.Int64Counter
-	providerErrors metric.Int64Counter
-	outcomes       metric.Int64Counter
-	workerErrors   metric.Int64Counter
-	duration       metric.Float64Histogram
+// translationMetrics adapts the shared impl to the TranslationMetrics outcome/duration names.
+type translationMetrics struct{ *enrichmentMetrics }
+
+func (m translationMetrics) RecordTranslationOutcome(ctx context.Context, status string) {
+	m.recordOutcome(ctx, status)
+}
+
+func (m translationMetrics) RecordTranslationDuration(ctx context.Context, duration time.Duration, status string) {
+	m.recordDuration(ctx, duration, status)
 }
 
 // NewTranslationMetrics creates TranslationMetrics. Returns (nil, nil) when meter is nil (metrics disabled).
 func NewTranslationMetrics(meter metric.Meter) (TranslationMetrics, error) {
-	if meter == nil {
-		//nolint:nilnil // intentional: callers use "if metrics != nil" when metrics disabled
-		return nil, nil
+	shared, err := newEnrichmentMetrics(meter, enrichmentMetricsSpec{
+		jobsEnqueuedName:      MetricNameTranslationJobsEnqueued,
+		providerErrorsName:    MetricNameTranslationProviderErrors,
+		outcomesName:          MetricNameTranslationOutcomes,
+		workerErrorsName:      MetricNameTranslationWorkerErrors,
+		durationName:          MetricNameTranslationDuration,
+		providerErrorsDesc:    "Total translation provider errors (settings/enqueue failures)",
+		workerErrorsDesc:      "Total translation worker errors (get record, provider, update)",
+		allowedProviderReason: AllowedTranslationProviderReason,
+		allowedWorkerReason:   AllowedTranslationWorkerReason,
+		allowedOutcomeStatus:  AllowedTranslationOutcomeStatus,
+	})
+	if err != nil || shared == nil {
+		// shared == nil means the meter is disabled; return a nil interface, not a typed nil.
+		return nil, err
 	}
 
-	jobsEnqueued, err := meter.Int64Counter(
-		MetricNameTranslationJobsEnqueued,
-		metric.WithDescription("Total translation jobs enqueued"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create translation jobs enqueued counter: %w", err)
-	}
-
-	providerErrors, err := meter.Int64Counter(
-		MetricNameTranslationProviderErrors,
-		metric.WithDescription("Total translation provider errors (settings/enqueue failures)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create translation provider errors counter: %w", err)
-	}
-
-	outcomes, err := meter.Int64Counter(
-		MetricNameTranslationOutcomes,
-		metric.WithDescription("Total translation job outcomes by status"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create translation outcomes counter: %w", err)
-	}
-
-	workerErrors, err := meter.Int64Counter(
-		MetricNameTranslationWorkerErrors,
-		metric.WithDescription("Total translation worker errors (get record, provider, update)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create translation worker errors counter: %w", err)
-	}
-
-	duration, err := meter.Float64Histogram(
-		MetricNameTranslationDuration,
-		metric.WithDescription("Translation job duration (seconds)"),
-		metric.WithUnit("s"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create translation duration histogram: %w", err)
-	}
-
-	return &translationMetrics{
-		jobsEnqueued:   jobsEnqueued,
-		providerErrors: providerErrors,
-		outcomes:       outcomes,
-		workerErrors:   workerErrors,
-		duration:       duration,
-	}, nil
-}
-
-func (t *translationMetrics) RecordJobsEnqueued(ctx context.Context, count int64) {
-	t.jobsEnqueued.Add(ctx, count)
-}
-
-func (t *translationMetrics) RecordProviderError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedTranslationProviderReason)
-	t.providerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (t *translationMetrics) RecordTranslationOutcome(ctx context.Context, status string) {
-	status = normalizeTranslationStatus(status)
-	t.outcomes.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func (t *translationMetrics) RecordWorkerError(ctx context.Context, reason string) {
-	reason = NormalizeReason(reason, AllowedTranslationWorkerReason)
-	t.workerErrors.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrReason, reason)))
-}
-
-func (t *translationMetrics) RecordTranslationDuration(ctx context.Context, duration time.Duration, status string) {
-	status = normalizeTranslationStatus(status)
-	t.duration.Record(ctx, duration.Seconds(), metric.WithAttributes(attribute.String(AttrStatus, status)))
-}
-
-func normalizeTranslationStatus(status string) string {
-	if AllowedTranslationOutcomeStatus(status) {
-		return status
-	}
-
-	return "other"
+	return translationMetrics{shared}, nil
 }

--- a/internal/observability/translation_test.go
+++ b/internal/observability/translation_test.go
@@ -28,13 +28,12 @@ func TestTranslationAllowedReasonsAndStatuses(t *testing.T) {
 
 	for _, status := range []string{"success", "retry", "failed_final", "skipped"} {
 		assert.True(t, AllowedTranslationOutcomeStatus(status), status)
-		assert.Equal(t, status, normalizeTranslationStatus(status))
 	}
 
 	// Unknown values normalize to a bounded "other" bucket (keeps metric cardinality fixed).
 	assert.False(t, AllowedTranslationProviderReason("nope"))
 	assert.Equal(t, "other", NormalizeReason("nope", AllowedTranslationProviderReason))
-	assert.Equal(t, "other", normalizeTranslationStatus("nope"))
+	assert.False(t, AllowedTranslationOutcomeStatus("nope"))
 }
 
 func TestNewTranslationMetricsNilMeterDisabled(t *testing.T) {
@@ -70,6 +69,7 @@ func TestTranslationMetricsRecordEmitsDataPoints(t *testing.T) {
 	metrics.RecordProviderError(ctx, "enqueue_failed")
 	metrics.RecordProviderError(ctx, "bogus") // unknown reason -> normalized to "other"
 	metrics.RecordTranslationOutcome(ctx, "success")
+	metrics.RecordTranslationOutcome(ctx, "bogus") // unknown status -> normalized to "other"
 	metrics.RecordWorkerError(ctx, "tenant_write_conflict")
 	metrics.RecordTranslationDuration(ctx, 150*time.Millisecond, "success")
 
@@ -80,6 +80,7 @@ func TestTranslationMetricsRecordEmitsDataPoints(t *testing.T) {
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameTranslationProviderErrors, AttrReason, "enqueue_failed"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameTranslationProviderErrors, AttrReason, "other"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameTranslationOutcomes, AttrStatus, "success"))
+	assert.Equal(t, int64(1), counterValue(collected, MetricNameTranslationOutcomes, AttrStatus, "other"))
 	assert.Equal(t, int64(1), counterValue(collected, MetricNameTranslationWorkerErrors, AttrReason, "tenant_write_conflict"))
 	assert.Equal(t, uint64(1), histogramCount(collected, MetricNameTranslationDuration, "success"))
 }


### PR DESCRIPTION
## What does this PR do?

Removes the largest copy-paste in the enrichment code. The embedding, translation, and sentiment metrics were three ~118-line files of near-identical logic — the same five instruments, the same `Record*` methods, the same status normalization — differing only in metric names and the bounded reason/status label sets. That meant a fix or a new label had to be made in three places.

This extracts **one** `enrichmentMetrics` implementation (instrument creation + the shared `Record*` methods + normalization), parameterized by a small per-pipeline spec. Each pipeline keeps its public interface and constructor but becomes a 2-method adapter (its differently-named `Record{X}Outcome` / `Record{X}Duration`) over the shared impl. So:

- The three public interfaces (`EmbeddingMetrics`, `TranslationMetrics`, `SentimentMetrics`) and **every caller** — workers, providers, wiring, the aggregate `Metrics` bundle — are unchanged. The change is confined to `internal/observability`.
- A future enrichment (e.g. emotion, ENG-1573) is a slim adapter + a spec, not another 118-line copy.

**Stacked on `feat/ENG-1529_sentiment-analysis` (#94)** — the refactor unifies all three enrichments and sentiment only exists on that branch, so this targets it and should merge after #94.

### Deliberately left alone
The client factories and worker error-handlers *look* parallel but genuinely diverge per pipeline (different client types; embedding's `DocPrefix`; translation's supersession case; the `google-vertex` legacy alias). Collapsing them would need long parameter lists / generics-over-config that read worse than the parallel code — a worse abstraction, not a cleaner one. The duplication that mattered (identical metrics *logic*) is gone; the rest is readable structural parallelism.

## How should this be tested?

No behavior change — the public metric names, labels, and the three interfaces are identical; this is a pure internal refactor.

```
make build
make fmt && make lint        # 0 issues
make test-unit               # observability tests assert each pipeline still emits the right instruments + labels
make tests
```

The observability unit tests cover all three pipelines (emit-datapoints with the correct names, plus the bounded "other" bucketing for unknown reason/status); the workers and providers compile unchanged against the same interfaces, which is itself the regression check that no caller was affected.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main` <!-- via the base branch, which is current with main -->
- [ ] If database schema changed: added migration <!-- no schema change -->

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec <!-- no API change; internal refactor -->
- [ ] Updated docs in `docs/` if changes were necessary <!-- not needed -->
- [ ] Ran `make tests-coverage` for meaningful logic changes <!-- behavior-preserving; existing tests cover it -->
