### PR TITLE
chore: updates tenant deletion to also remove taxonomy data

### DIFF
--- a/internal/api/handlers/tenant_data_handler.go
+++ b/internal/api/handlers/tenant_data_handler.go
@@ -35,11 +35,17 @@ func (h *TenantDataHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := models.TenantDataDeleteResponse{
-		TenantID:               result.TenantID,
-		DeletedFeedbackRecords: result.DeletedFeedbackRecords,
-		DeletedEmbeddings:      result.DeletedEmbeddings,
-		DeletedWebhooks:        result.DeletedWebhooks,
-		Message:                "Successfully deleted tenant data for " + result.TenantID,
+		TenantID:                          result.TenantID,
+		DeletedFeedbackRecords:            result.DeletedFeedbackRecords,
+		DeletedEmbeddings:                 result.DeletedEmbeddings,
+		DeletedWebhooks:                   result.DeletedWebhooks,
+		DeletedTaxonomyRuns:               result.DeletedTaxonomyRuns,
+		DeletedTaxonomyClusters:           result.DeletedTaxonomyClusters,
+		DeletedTaxonomyClusterMemberships: result.DeletedTaxonomyClusterMemberships,
+		DeletedTaxonomyNodes:              result.DeletedTaxonomyNodes,
+		DeletedTaxonomyActiveRuns:         result.DeletedTaxonomyActiveRuns,
+		DeletedTaxonomyNodeEvents:         result.DeletedTaxonomyNodeEvents,
+		Message:                           "Successfully deleted tenant data for " + result.TenantID,
 	}
 
 	response.RespondJSON(w, http.StatusOK, resp)

--- a/internal/api/handlers/tenant_data_handler_test.go
+++ b/internal/api/handlers/tenant_data_handler_test.go
@@ -39,9 +39,15 @@ func TestTenantDataHandler_Delete(t *testing.T) {
 				return &models.TenantDataDeleteResult{
 					TenantID: "org-123",
 					TenantDataDeleteCounts: models.TenantDataDeleteCounts{
-						DeletedFeedbackRecords: 3,
-						DeletedEmbeddings:      2,
-						DeletedWebhooks:        1,
+						DeletedFeedbackRecords:            3,
+						DeletedEmbeddings:                 2,
+						DeletedWebhooks:                   1,
+						DeletedTaxonomyRuns:               4,
+						DeletedTaxonomyClusters:           5,
+						DeletedTaxonomyClusterMemberships: 6,
+						DeletedTaxonomyNodes:              7,
+						DeletedTaxonomyActiveRuns:         8,
+						DeletedTaxonomyNodeEvents:         9,
 					},
 				}, nil
 			},
@@ -64,6 +70,12 @@ func TestTenantDataHandler_Delete(t *testing.T) {
 		assert.Equal(t, int64(3), resp.DeletedFeedbackRecords)
 		assert.Equal(t, int64(2), resp.DeletedEmbeddings)
 		assert.Equal(t, int64(1), resp.DeletedWebhooks)
+		assert.Equal(t, int64(4), resp.DeletedTaxonomyRuns)
+		assert.Equal(t, int64(5), resp.DeletedTaxonomyClusters)
+		assert.Equal(t, int64(6), resp.DeletedTaxonomyClusterMemberships)
+		assert.Equal(t, int64(7), resp.DeletedTaxonomyNodes)
+		assert.Equal(t, int64(8), resp.DeletedTaxonomyActiveRuns)
+		assert.Equal(t, int64(9), resp.DeletedTaxonomyNodeEvents)
 		assert.Equal(t, "Successfully deleted tenant data for org-123", resp.Message)
 	})
 

--- a/internal/models/tenant_data.go
+++ b/internal/models/tenant_data.go
@@ -5,6 +5,16 @@ type TenantDataDeleteCounts struct {
 	DeletedFeedbackRecords int64
 	DeletedEmbeddings      int64
 	DeletedWebhooks        int64
+
+	// Taxonomy artifacts are run-scoped Hub data removed explicitly during the
+	// purge (not via feedback-record cascades). Each field is the exact row
+	// count deleted from its taxonomy table for the tenant.
+	DeletedTaxonomyRuns               int64
+	DeletedTaxonomyClusters           int64
+	DeletedTaxonomyClusterMemberships int64
+	DeletedTaxonomyNodes              int64
+	DeletedTaxonomyActiveRuns         int64
+	DeletedTaxonomyNodeEvents         int64
 }
 
 // TenantDataDeleteResult is the service result for a tenant data purge.
@@ -16,9 +26,15 @@ type TenantDataDeleteResult struct {
 
 // TenantDataDeleteResponse represents the response for deleting all Hub-owned tenant data.
 type TenantDataDeleteResponse struct {
-	TenantID               string `json:"tenant_id"`
-	DeletedFeedbackRecords int64  `json:"deleted_feedback_records"`
-	DeletedEmbeddings      int64  `json:"deleted_embeddings"`
-	DeletedWebhooks        int64  `json:"deleted_webhooks"`
-	Message                string `json:"message"`
+	TenantID                          string `json:"tenant_id"`
+	DeletedFeedbackRecords            int64  `json:"deleted_feedback_records"`
+	DeletedEmbeddings                 int64  `json:"deleted_embeddings"`
+	DeletedWebhooks                   int64  `json:"deleted_webhooks"`
+	DeletedTaxonomyRuns               int64  `json:"deleted_taxonomy_runs"`
+	DeletedTaxonomyClusters           int64  `json:"deleted_taxonomy_clusters"`
+	DeletedTaxonomyClusterMemberships int64  `json:"deleted_taxonomy_cluster_memberships"`
+	DeletedTaxonomyNodes              int64  `json:"deleted_taxonomy_nodes"`
+	DeletedTaxonomyActiveRuns         int64  `json:"deleted_taxonomy_active_runs"`
+	DeletedTaxonomyNodeEvents         int64  `json:"deleted_taxonomy_node_events"`
+	Message                           string `json:"message"`
 }

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -99,7 +99,54 @@ func deleteTenantDataInTx(
 		return nil, fmt.Errorf("delete tenant embeddings: %w", err)
 	}
 
-	_, err = exec.Exec(ctx, `
+	// Taxonomy generation artifacts are run-scoped Hub data. Deleting
+	// feedback_records only cascades cluster memberships (via the membership ->
+	// feedback_records FK), leaving runs, clusters, nodes, active-run rows, and
+	// node events orphaned. Remove every taxonomy table explicitly here, children
+	// before parents, so each delete count is exact and the purge never relies on
+	// cascades. Ordering rules:
+	//   - node_events and cluster_memberships reference runs/nodes/clusters, so
+	//     they go first.
+	//   - taxonomy_clusters and taxonomy_nodes have no tenant_id column; they are
+	//     scoped through their run via a taxonomy_runs subquery, which means
+	//     taxonomy_runs MUST be deleted last (after nodes and clusters) or the
+	//     subquery would match nothing and orphan them.
+	taxonomyNodeEventsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_node_events
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy node events: %w", err)
+	}
+
+	taxonomyClusterMembershipsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_cluster_memberships
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy cluster memberships: %w", err)
+	}
+
+	taxonomyNodesTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_nodes
+		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy nodes: %w", err)
+	}
+
+	taxonomyClustersTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_clusters
+		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy clusters: %w", err)
+	}
+
+	taxonomyActiveRunsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_active_runs
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy active runs: %w", err)
+	}
+
+	taxonomyRunsTag, err := exec.Exec(ctx, `
 		DELETE FROM taxonomy_runs
 		WHERE tenant_id = $1`, tenantID)
 	if err != nil {
@@ -129,8 +176,14 @@ func deleteTenantDataInTx(
 	}
 
 	return &models.TenantDataDeleteCounts{
-		DeletedFeedbackRecords: feedbackRecordsTag.RowsAffected(),
-		DeletedEmbeddings:      embeddingTag.RowsAffected(),
-		DeletedWebhooks:        webhooksTag.RowsAffected(),
+		DeletedFeedbackRecords:            feedbackRecordsTag.RowsAffected(),
+		DeletedEmbeddings:                 embeddingTag.RowsAffected(),
+		DeletedWebhooks:                   webhooksTag.RowsAffected(),
+		DeletedTaxonomyRuns:               taxonomyRunsTag.RowsAffected(),
+		DeletedTaxonomyClusters:           taxonomyClustersTag.RowsAffected(),
+		DeletedTaxonomyClusterMemberships: taxonomyClusterMembershipsTag.RowsAffected(),
+		DeletedTaxonomyNodes:              taxonomyNodesTag.RowsAffected(),
+		DeletedTaxonomyActiveRuns:         taxonomyActiveRunsTag.RowsAffected(),
+		DeletedTaxonomyNodeEvents:         taxonomyNodeEventsTag.RowsAffected(),
 	}, nil
 }

--- a/internal/repository/tenant_data_repository_test.go
+++ b/internal/repository/tenant_data_repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
 )
 
 // fakeTenantDataExecutor is the shared Exec recorder embedded by
@@ -56,16 +57,56 @@ func purgeLockTags() []pgconn.CommandTag {
 	}
 }
 
+// tenantDeleteTags returns command tags for the ten DELETE statements
+// deleteTenantDataInTx issues, in execution order, each with a distinct row
+// count so tests can assert the per-table count mapping (see
+// assertTenantDeleteCounts).
+func tenantDeleteTags() []pgconn.CommandTag {
+	return []pgconn.CommandTag{
+		pgconn.NewCommandTag("DELETE 2"),  // embeddings
+		pgconn.NewCommandTag("DELETE 11"), // taxonomy_node_events
+		pgconn.NewCommandTag("DELETE 12"), // taxonomy_cluster_memberships
+		pgconn.NewCommandTag("DELETE 13"), // taxonomy_nodes
+		pgconn.NewCommandTag("DELETE 14"), // taxonomy_clusters
+		pgconn.NewCommandTag("DELETE 15"), // taxonomy_active_runs
+		pgconn.NewCommandTag("DELETE 16"), // taxonomy_runs
+		pgconn.NewCommandTag("DELETE 3"),  // feedback_records
+		pgconn.NewCommandTag("DELETE 1"),  // webhooks
+		pgconn.NewCommandTag("DELETE 99"), // tenant_settings (count not surfaced)
+	}
+}
+
+// assertTenantDeleteCounts verifies the counts produced from tenantDeleteTags(),
+// including every taxonomy table (tenant_settings is intentionally not surfaced).
+func assertTenantDeleteCounts(t *testing.T, counts *models.TenantDataDeleteCounts) {
+	t.Helper()
+
+	want := models.TenantDataDeleteCounts{
+		DeletedFeedbackRecords:            3,
+		DeletedEmbeddings:                 2,
+		DeletedWebhooks:                   1,
+		DeletedTaxonomyRuns:               16,
+		DeletedTaxonomyClusters:           14,
+		DeletedTaxonomyClusterMemberships: 12,
+		DeletedTaxonomyNodes:              13,
+		DeletedTaxonomyActiveRuns:         15,
+		DeletedTaxonomyNodeEvents:         11,
+	}
+
+	if counts == nil {
+		t.Fatalf("counts = nil, want %+v", want)
+	}
+
+	if *counts != want {
+		t.Fatalf("counts = %+v, want %+v", *counts, want)
+	}
+}
+
 func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 	t.Run("locks tenant exclusively, commits transaction, and returns counts", func(t *testing.T) {
 		transaction := &fakeTenantWriteTx{
 			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(),
-					pgconn.NewCommandTag("DELETE 2"),
-					pgconn.NewCommandTag("DELETE 4"),
-					pgconn.NewCommandTag("DELETE 3"),
-					pgconn.NewCommandTag("DELETE 1"),
-				),
+				tags: append(purgeLockTags(), tenantDeleteTags()...),
 			},
 			rollbackErr: pgx.ErrTxClosed,
 		}
@@ -76,9 +117,7 @@ func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 			t.Fatalf("DeleteByTenant() error = %v", err)
 		}
 
-		if counts.DeletedEmbeddings != 2 || counts.DeletedFeedbackRecords != 3 || counts.DeletedWebhooks != 1 {
-			t.Fatalf("counts = %+v, want embeddings=2 feedback=3 webhooks=1", counts)
-		}
+		assertTenantDeleteCounts(t, counts)
 
 		if !transaction.committed {
 			t.Fatal("transaction was not committed")
@@ -88,15 +127,15 @@ func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 			t.Fatal("deferred rollback was not called")
 		}
 
-		if len(transaction.queries) != 8 {
-			t.Fatalf("queries = %d, want 8 (3 lock statements + 5 deletes)", len(transaction.queries))
+		if len(transaction.queries) != 13 {
+			t.Fatalf("queries = %d, want 13 (3 lock statements + 10 deletes)", len(transaction.queries))
 		}
 
 		assertQueryContains(t, transaction.queries[0], "set_config('lock_timeout', $1, true)")
 		assertQueryContains(t, transaction.queries[1], "pg_advisory_xact_lock(hashtextextended($1, 0))")
 		assertQueryContains(t, transaction.queries[2], "set_config('lock_timeout', '0', true)")
 		assertQueryContains(t, transaction.queries[3], "DELETE FROM embeddings")
-		assertQueryContains(t, transaction.queries[7], "DELETE FROM tenant_settings")
+		assertQueryContains(t, transaction.queries[12], "DELETE FROM tenant_settings")
 
 		if len(transaction.args[1]) != 1 || transaction.args[1][0] != TenantWriteLockKey("org-123") {
 			t.Fatalf("lock args = %#v, want tenant write lock key", transaction.args[1])
@@ -183,12 +222,7 @@ func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 		commitErr := errors.New("commit failed")
 		transaction := &fakeTenantWriteTx{
 			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(),
-					pgconn.NewCommandTag("DELETE 2"),
-					pgconn.NewCommandTag("DELETE 4"),
-					pgconn.NewCommandTag("DELETE 3"),
-					pgconn.NewCommandTag("DELETE 1"),
-				),
+				tags: append(purgeLockTags(), tenantDeleteTags()...),
 			},
 			commitErr:   commitErr,
 			rollbackErr: pgx.ErrTxClosed,
@@ -208,34 +242,37 @@ func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 
 func TestDeleteTenantDataInTx(t *testing.T) {
 	t.Run("deletes explicit tenant owned tables and returns counts", func(t *testing.T) {
-		exec := &fakeTenantDataExecutor{
-			tags: []pgconn.CommandTag{
-				pgconn.NewCommandTag("DELETE 2"),
-				pgconn.NewCommandTag("DELETE 4"),
-				pgconn.NewCommandTag("DELETE 3"),
-				pgconn.NewCommandTag("DELETE 1"),
-			},
-		}
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags()}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
 		if err != nil {
 			t.Fatalf("deleteTenantDataInTx() error = %v", err)
 		}
 
-		if counts.DeletedEmbeddings != 2 || counts.DeletedFeedbackRecords != 3 || counts.DeletedWebhooks != 1 {
-			t.Fatalf("counts = %+v, want embeddings=2 feedback=3 webhooks=1", counts)
+		assertTenantDeleteCounts(t, counts)
+
+		if len(exec.queries) != 10 {
+			t.Fatalf("queries = %d, want 10", len(exec.queries))
 		}
 
-		if len(exec.queries) != 5 {
-			t.Fatalf("queries = %d, want 5", len(exec.queries))
-		}
-
+		// Children before parents, with taxonomy_runs deleted after the
+		// run-scoped nodes/clusters and before feedback_records.
 		assertQueryContains(t, exec.queries[0], "DELETE FROM embeddings")
 		assertQueryContains(t, exec.queries[0], "USING feedback_records")
-		assertQueryContains(t, exec.queries[1], "DELETE FROM taxonomy_runs")
-		assertQueryContains(t, exec.queries[2], "DELETE FROM feedback_records")
-		assertQueryContains(t, exec.queries[3], "DELETE FROM webhooks")
-		assertQueryContains(t, exec.queries[4], "DELETE FROM tenant_settings")
+		assertQueryContains(t, exec.queries[1], "DELETE FROM taxonomy_node_events")
+		assertQueryContains(t, exec.queries[2], "DELETE FROM taxonomy_cluster_memberships")
+		assertQueryContains(t, exec.queries[3], "DELETE FROM taxonomy_nodes")
+		assertQueryContains(t, exec.queries[4], "DELETE FROM taxonomy_clusters")
+		assertQueryContains(t, exec.queries[5], "DELETE FROM taxonomy_active_runs")
+		assertQueryContains(t, exec.queries[6], "DELETE FROM taxonomy_runs")
+		assertQueryContains(t, exec.queries[7], "DELETE FROM feedback_records")
+		assertQueryContains(t, exec.queries[8], "DELETE FROM webhooks")
+		assertQueryContains(t, exec.queries[9], "DELETE FROM tenant_settings")
+
+		// taxonomy_nodes and taxonomy_clusters have no tenant_id column, so they
+		// must be scoped through their run via a taxonomy_runs subquery.
+		assertQueryContains(t, exec.queries[3], "SELECT id FROM taxonomy_runs WHERE tenant_id = $1")
+		assertQueryContains(t, exec.queries[4], "SELECT id FROM taxonomy_runs WHERE tenant_id = $1")
 
 		for queryIndex, args := range exec.args {
 			if len(args) != 1 || args[0] != "org-123" {
@@ -261,13 +298,8 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 		}
 	})
 
-	t.Run("stops before feedback records after taxonomy runs delete error", func(t *testing.T) {
-		exec := &fakeTenantDataExecutor{
-			tags: []pgconn.CommandTag{
-				pgconn.NewCommandTag("DELETE 2"),
-			},
-			errAtQuery: 2,
-		}
+	t.Run("stops after taxonomy node events delete error", func(t *testing.T) {
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 2}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
 		if err == nil {
@@ -281,16 +313,39 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 		if len(exec.queries) != 2 {
 			t.Fatalf("queries = %d, want 2", len(exec.queries))
 		}
+
+		assertQueryContains(t, exec.queries[1], "DELETE FROM taxonomy_node_events")
+	})
+
+	t.Run("stops before feedback records after taxonomy runs delete error", func(t *testing.T) {
+		// taxonomy_runs is the seventh delete (errAtQuery is 1-based).
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 7}
+
+		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
+		if err == nil {
+			t.Fatal("deleteTenantDataInTx() error = nil, want error")
+		}
+
+		if counts != nil {
+			t.Fatalf("counts = %+v, want nil", counts)
+		}
+
+		if len(exec.queries) != 7 {
+			t.Fatalf("queries = %d, want 7", len(exec.queries))
+		}
+
+		assertQueryContains(t, exec.queries[6], "DELETE FROM taxonomy_runs")
+
+		for _, query := range exec.queries {
+			if strings.Contains(query, "DELETE FROM feedback_records") {
+				t.Fatalf("feedback_records deleted before taxonomy runs error: %q", query)
+			}
+		}
 	})
 
 	t.Run("stops before webhooks after feedback delete error", func(t *testing.T) {
-		exec := &fakeTenantDataExecutor{
-			tags: []pgconn.CommandTag{
-				pgconn.NewCommandTag("DELETE 2"),
-				pgconn.NewCommandTag("DELETE 4"),
-			},
-			errAtQuery: 3,
-		}
+		// feedback_records is the eighth delete.
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 8}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
 		if err == nil {
@@ -301,21 +356,16 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 			t.Fatalf("counts = %+v, want nil", counts)
 		}
 
-		if len(exec.queries) != 3 {
-			t.Fatalf("queries = %d, want 3", len(exec.queries))
+		if len(exec.queries) != 8 {
+			t.Fatalf("queries = %d, want 8", len(exec.queries))
 		}
+
+		assertQueryContains(t, exec.queries[7], "DELETE FROM feedback_records")
 	})
 
 	t.Run("stops after tenant settings delete error", func(t *testing.T) {
-		exec := &fakeTenantDataExecutor{
-			tags: []pgconn.CommandTag{
-				pgconn.NewCommandTag("DELETE 2"),
-				pgconn.NewCommandTag("DELETE 4"),
-				pgconn.NewCommandTag("DELETE 3"),
-				pgconn.NewCommandTag("DELETE 1"),
-			},
-			errAtQuery: 5,
-		}
+		// tenant_settings is the tenth (final) delete.
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 10}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
 		if err == nil {
@@ -326,11 +376,11 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 			t.Fatalf("counts = %+v, want nil", counts)
 		}
 
-		if len(exec.queries) != 5 {
-			t.Fatalf("queries = %d, want 5", len(exec.queries))
+		if len(exec.queries) != 10 {
+			t.Fatalf("queries = %d, want 10", len(exec.queries))
 		}
 
-		assertQueryContains(t, exec.queries[4], "DELETE FROM tenant_settings")
+		assertQueryContains(t, exec.queries[9], "DELETE FROM tenant_settings")
 	})
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1177,6 +1177,12 @@ paths:
                                         deleted_feedback_records: 42
                                         deleted_embeddings: 17
                                         deleted_webhooks: 3
+                                        deleted_taxonomy_runs: 4
+                                        deleted_taxonomy_clusters: 28
+                                        deleted_taxonomy_cluster_memberships: 1200
+                                        deleted_taxonomy_nodes: 36
+                                        deleted_taxonomy_active_runs: 2
+                                        deleted_taxonomy_node_events: 9
                                         message: "Successfully deleted tenant data for org-123"
                 "400":
                     description: Bad Request (e.g. missing or invalid tenant_id)
@@ -1452,6 +1458,30 @@ components:
                     type: integer
                     description: Number of webhooks deleted
                     format: int64
+                deleted_taxonomy_runs:
+                    type: integer
+                    description: Number of taxonomy runs deleted
+                    format: int64
+                deleted_taxonomy_clusters:
+                    type: integer
+                    description: Number of taxonomy clusters deleted
+                    format: int64
+                deleted_taxonomy_cluster_memberships:
+                    type: integer
+                    description: Number of taxonomy cluster memberships deleted
+                    format: int64
+                deleted_taxonomy_nodes:
+                    type: integer
+                    description: Number of taxonomy nodes deleted
+                    format: int64
+                deleted_taxonomy_active_runs:
+                    type: integer
+                    description: Number of taxonomy active-run rows deleted
+                    format: int64
+                deleted_taxonomy_node_events:
+                    type: integer
+                    description: Number of taxonomy node events deleted
+                    format: int64
                 message:
                     type: string
                     description: Human-readable status message
@@ -1460,6 +1490,12 @@ components:
                 - deleted_feedback_records
                 - deleted_embeddings
                 - deleted_webhooks
+                - deleted_taxonomy_runs
+                - deleted_taxonomy_clusters
+                - deleted_taxonomy_cluster_memberships
+                - deleted_taxonomy_nodes
+                - deleted_taxonomy_active_runs
+                - deleted_taxonomy_node_events
                 - message
         EnrichmentSettings:
             type: object

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1083,6 +1083,14 @@ func TestDeleteTenantData(t *testing.T) {
 	assert.Equal(t, int64(2), deleteResp.DeletedFeedbackRecords)
 	assert.Equal(t, int64(2), deleteResp.DeletedEmbeddings)
 	assert.Equal(t, int64(1), deleteResp.DeletedWebhooks)
+	// createTenantDataTaxonomyGraph builds one run with one cluster, one
+	// membership, three nodes (root/branch/leaf), one active run, and one event.
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyRuns)
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyClusters)
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyClusterMemberships)
+	assert.Equal(t, int64(3), deleteResp.DeletedTaxonomyNodes)
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyActiveRuns)
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyNodeEvents)
 	requireNoTenantDataDeleteEvents(t, eventRecorder)
 
 	requireTenantDataResourceStatus(
@@ -1110,6 +1118,12 @@ func TestDeleteTenantData(t *testing.T) {
 	assert.Equal(t, int64(0), repeatedResp.DeletedFeedbackRecords)
 	assert.Equal(t, int64(0), repeatedResp.DeletedEmbeddings)
 	assert.Equal(t, int64(0), repeatedResp.DeletedWebhooks)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyRuns)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyClusters)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyClusterMemberships)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyNodes)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyActiveRuns)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyNodeEvents)
 	requireNoTenantDataDeleteEvents(t, eventRecorder)
 }
 
@@ -1337,6 +1351,11 @@ func requireTenantDataTaxonomyRunPresent(ctx context.Context, t *testing.T, db *
 	t.Helper()
 
 	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_runs WHERE id = $1`, runID))
+	// taxonomy_clusters and taxonomy_nodes are scoped through their run via a
+	// taxonomy_runs subquery in the purge; assert they survive for the other
+	// tenant to prove the run-scoped deletes do not cross tenants.
+	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_clusters WHERE run_id = $1`, runID))
+	assert.Equal(t, int64(3), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_nodes WHERE run_id = $1`, runID))
 	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_cluster_memberships WHERE run_id = $1`, runID))
 	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_active_runs WHERE run_id = $1`, runID))
 	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_node_events WHERE run_id = $1`, runID))


### PR DESCRIPTION
## What does this PR do?

Implements **ENG-1167** — extends the tenant data purge (`DELETE /v1/tenants/{tenant_id}/data`) to remove all taxonomy artifacts for a tenant.

Previously the purge issued a single `DELETE FROM taxonomy_runs` and relied on `ON DELETE CASCADE` to clear the child tables, and it surfaced no taxonomy delete counts. Taxonomy runs/clusters/nodes are **run-scoped**, not feedback-scoped, so deleting feedback records alone would leave them orphaned.

This PR:

- Deletes all six taxonomy tables **explicitly**, children before parents, so the purge never relies on cascades and every delete count is exact:
  `taxonomy_node_events → taxonomy_cluster_memberships → taxonomy_nodes → taxonomy_clusters → taxonomy_active_runs → taxonomy_runs` (all before `feedback_records`).
- `taxonomy_clusters` and `taxonomy_nodes` have no `tenant_id` column, so they are scoped through their run via `run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`. This is why `taxonomy_runs` is deleted **last** — deleting it first would empty the subquery and orphan those rows.
- Surfaces per-table taxonomy delete counts in the model, handler response, and OpenAPI spec.
- Leaves existing feedback-record and embedding deletion behavior unchanged; the purge still runs inside the exclusive tenant write lock, so serialization against tenant-owned writes is unaffected.

### API change — response now includes taxonomy counts

`DELETE /v1/tenants/{tenant_id}/data` response:

```json
{
  "tenant_id": "org-123",
  "deleted_feedback_records": 42,
  "deleted_embeddings": 17,
  "deleted_webhooks": 3,
  "deleted_taxonomy_runs": 4,
  "deleted_taxonomy_clusters": 28,
  "deleted_taxonomy_cluster_memberships": 1200,
  "deleted_taxonomy_nodes": 36,
  "deleted_taxonomy_active_runs": 2,
  "deleted_taxonomy_node_events": 9,
  "message": "Successfully deleted tenant data for org-123"
}
```

### Files

- `internal/repository/tenant_data_repository.go` — explicit per-table taxonomy deletes in FK-safe order + count capture (**core change**)
- `internal/models/tenant_data.go` — six taxonomy count fields on `TenantDataDeleteCounts` and `TenantDataDeleteResponse`
- `internal/api/handlers/tenant_data_handler.go` — maps the counts into the response
- `openapi.yaml` — `TenantDataDeleteOutputBody` schema (properties + `required`) and example
- Tests: `internal/repository/tenant_data_repository_test.go`, `internal/api/handlers/tenant_data_handler_test.go`, `tests/integration_test.go`

## How should this be tested?

Config: `DATABASE_URL`, `API_KEY`. Ensure the schema is current first (`make init-db && make river-migrate`).

- **Unit (no DB):** `go test ./internal/repository/ ./internal/api/handlers/ ./internal/service/`
  Covers the 10-statement delete pipeline, exact count → field mapping (each table uses a distinct row count so a swapped field is caught), and error-boundary / rollback behavior at each stage.
- **Integration (`make tests`):** `TestDeleteTenantData` builds a full taxonomy graph (run, cluster, membership, root/branch/leaf nodes, active run, node event) for two tenants, purges tenant A, and asserts:
  - exact delete counts (`runs=1, clusters=1, memberships=1, nodes=3, active_runs=1, node_events=1`);
  - all six taxonomy tables emptied for tenant A;
  - **tenant B's taxonomy — including its run-scoped clusters and nodes — is untouched** (cross-tenant isolation regression guard for the `run_id`-subquery deletes);
  - a repeated purge returns zero counts (idempotent).

**Results:** `make build`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint` (0 issues), and the full `go test ./...` run against Postgres — all pass.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` — _N/A, no schema change_

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary — _N/A_
- [ ] Ran `make tests-coverage` for meaningful logic changes
