### PR TITLE
chore: adds hub tests for taxonomy persistence, apis

### DIFF
--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -1,0 +1,460 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+)
+
+// taxonomyURL joins the server base, a path, and optional query params.
+func taxonomyURL(base, path string, query url.Values) string {
+	u := base + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	return u
+}
+
+// requestTaxonomyJSON issues a taxonomy HTTP request, asserts the status code, and (when
+// out is non-nil) decodes the JSON body. It always closes the response body.
+func requestTaxonomyJSON(
+	ctx context.Context, t *testing.T, method, url, token string, body any, wantStatus int, out any,
+) {
+	t.Helper()
+
+	resp := doTaxonomyRequest(ctx, t, method, url, token, body)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, wantStatus, resp.StatusCode)
+
+	if out != nil {
+		require.NoError(t, decodeData(resp, out))
+	}
+}
+
+// findTaxonomyNode returns the first node in the tree matching predicate.
+func findTaxonomyNode(node *models.TaxonomyNode, predicate func(models.TaxonomyNode) bool) *models.TaxonomyNode {
+	if node == nil {
+		return nil
+	}
+
+	if predicate(*node) {
+		return node
+	}
+
+	for i := range node.Children {
+		if found := findTaxonomyNode(&node.Children[i], predicate); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+// TestTaxonomyAPI_Auth covers both auth layers: the public Hub API key and the internal
+// service token, including that neither credential is accepted by the other layer.
+func TestTaxonomyAPI_Auth(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	fieldsURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/fields", url.Values{"tenant_id": {"auth-tenant"}})
+	authCheckURL := harness.server.URL + "/internal/v1/taxonomy/auth-check"
+
+	t.Run("public endpoint rejects missing and wrong credentials", func(t *testing.T) {
+		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, "", nil, http.StatusUnauthorized, nil)
+		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, "wrong-key", nil, http.StatusUnauthorized, nil)
+	})
+
+	t.Run("public endpoint accepts the Hub API key", func(t *testing.T) {
+		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, harness.apiKey, nil, http.StatusOK, nil)
+	})
+
+	t.Run("internal endpoint rejects missing and wrong credentials", func(t *testing.T) {
+		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, "", nil, http.StatusUnauthorized, nil)
+		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, "wrong-token", nil, http.StatusUnauthorized, nil)
+	})
+
+	t.Run("internal endpoint accepts the internal token", func(t *testing.T) {
+		var body map[string]any
+		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, harness.internalToken, nil, http.StatusOK, &body)
+		assert.Equal(t, "ok", body["status"])
+	})
+
+	t.Run("credentials do not cross auth layers", func(t *testing.T) {
+		// The internal token must not authorize the public API...
+		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, harness.internalToken, nil, http.StatusUnauthorized, nil)
+		// ...and the public API key must not authorize the internal service API.
+		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, harness.apiKey, nil, http.StatusUnauthorized, nil)
+	})
+}
+
+// TestTaxonomyAPI_PublicReadAndEdit covers the public read and edit endpoints against a
+// seeded, activated taxonomy graph.
+func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	scope := uniqueTaxonomyScope("tax-api-read")
+	ids := seedTaxonomyGraph(ctx, t, harness.db, scope)
+
+	scopeQuery := url.Values{
+		"tenant_id":   {scope.TenantID},
+		"source_type": {scope.SourceType},
+		"source_id":   {scope.SourceID},
+		"field_id":    {scope.FieldID},
+	}
+	tenantQuery := url.Values{"tenant_id": {scope.TenantID}}
+
+	t.Run("list runs returns the seeded run", func(t *testing.T) {
+		var resp models.ListTaxonomyRunsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs", tenantQuery), harness.apiKey, nil, http.StatusOK, &resp)
+
+		require.Len(t, resp.Data, 1)
+		assert.Equal(t, ids.RunID, resp.Data[0].ID)
+	})
+
+	t.Run("get run returns the run", func(t *testing.T) {
+		var run models.TaxonomyRun
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String(), tenantQuery), harness.apiKey, nil, http.StatusOK, &run)
+
+		assert.Equal(t, ids.RunID, run.ID)
+		assert.Equal(t, models.TaxonomyRunStatusSucceeded, run.Status)
+	})
+
+	t.Run("get run tree returns the hierarchy", func(t *testing.T) {
+		var tree models.TaxonomyTreeResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String()+"/tree", tenantQuery), harness.apiKey, nil, http.StatusOK, &tree)
+
+		require.NotNil(t, tree.Root)
+		assert.Equal(t, ids.RootID, tree.Root.ID)
+		require.True(t, treeContainsNode(tree.Root, ids.LeafID))
+	})
+
+	t.Run("get active tree returns the active run tree", func(t *testing.T) {
+		var tree models.TaxonomyTreeResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/active/tree", scopeQuery), harness.apiKey, nil, http.StatusOK, &tree)
+
+		assert.Equal(t, ids.RunID, tree.Run.ID)
+		require.NotNil(t, tree.Root)
+	})
+
+	t.Run("list node records returns the assigned feedback", func(t *testing.T) {
+		recordsURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.RootID.String()+"/records", tenantQuery)
+
+		var resp models.TaxonomyNodeRecordsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, recordsURL, harness.apiKey, nil, http.StatusOK, &resp)
+
+		require.Len(t, resp.Data, 1)
+		assert.Equal(t, ids.FeedbackRecordID, resp.Data[0].ID)
+	})
+
+	t.Run("rename node updates the label", func(t *testing.T) {
+		body := models.RenameTaxonomyNodeRequest{TenantID: scope.TenantID, ActorID: "api-actor", Label: "Renamed Access"}
+
+		var node models.TaxonomyNode
+		requestTaxonomyJSON(ctx, t, http.MethodPatch,
+			harness.server.URL+"/v1/taxonomy/nodes/"+ids.BranchID.String(), harness.apiKey, body, http.StatusOK, &node)
+
+		assert.Equal(t, "Renamed Access", node.Label)
+	})
+
+	t.Run("remove node soft-deletes it", func(t *testing.T) {
+		removeQuery := url.Values{"tenant_id": {scope.TenantID}, "actor_id": {"api-actor"}}
+
+		var node models.TaxonomyNode
+		requestTaxonomyJSON(ctx, t, http.MethodDelete,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.LeafID.String(), removeQuery), harness.apiKey, nil, http.StatusOK, &node)
+
+		require.NotNil(t, node.RemovedAt)
+
+		// The removed leaf no longer appears in the tree.
+		var tree models.TaxonomyTreeResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String()+"/tree", tenantQuery), harness.apiKey, nil, http.StatusOK, &tree)
+		require.False(t, treeContainsNode(tree.Root, ids.LeafID))
+	})
+}
+
+// TestTaxonomyAPI_TenantIsolation proves the public endpoints reject another tenant's
+// identifiers: reads and edits 404, and node record drilldown returns nothing.
+func TestTaxonomyAPI_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	scope := uniqueTaxonomyScope("tax-api-iso")
+	ids := seedTaxonomyGraph(ctx, t, harness.db, scope)
+
+	otherTenant := "tax-api-iso-other-" + uuid.NewString()
+	otherQuery := url.Values{"tenant_id": {otherTenant}}
+
+	t.Run("get run 404s for another tenant", func(t *testing.T) {
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String(), otherQuery), harness.apiKey, nil, http.StatusNotFound, nil)
+	})
+
+	t.Run("get tree 404s for another tenant", func(t *testing.T) {
+		treeURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String()+"/tree", otherQuery)
+		requestTaxonomyJSON(ctx, t, http.MethodGet, treeURL, harness.apiKey, nil, http.StatusNotFound, nil)
+	})
+
+	t.Run("rename 404s for another tenant", func(t *testing.T) {
+		body := models.RenameTaxonomyNodeRequest{TenantID: otherTenant, ActorID: "attacker", Label: "Hijacked"}
+		requestTaxonomyJSON(ctx, t, http.MethodPatch,
+			harness.server.URL+"/v1/taxonomy/nodes/"+ids.BranchID.String(), harness.apiKey, body, http.StatusNotFound, nil)
+	})
+
+	t.Run("remove 404s for another tenant", func(t *testing.T) {
+		removeQuery := url.Values{"tenant_id": {otherTenant}, "actor_id": {"attacker"}}
+		requestTaxonomyJSON(ctx, t, http.MethodDelete,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.BranchID.String(), removeQuery), harness.apiKey, nil, http.StatusNotFound, nil)
+	})
+
+	t.Run("node records return nothing for another tenant", func(t *testing.T) {
+		recordsURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.RootID.String()+"/records", otherQuery)
+
+		var resp models.TaxonomyNodeRecordsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, recordsURL, harness.apiKey, nil, http.StatusOK, &resp)
+		require.Empty(t, resp.Data)
+	})
+}
+
+// TestTaxonomyAPI_CreateRun covers the public run-creation endpoint: validation failures,
+// insufficient embedded input, the accepted happy path, and in-progress reuse.
+func TestTaxonomyAPI_CreateRun(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+	runsURL := harness.server.URL + "/v1/taxonomy/runs"
+
+	t.Run("missing scope fields are rejected", func(t *testing.T) {
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey,
+			map[string]any{"source_type": "formbricks"}, http.StatusBadRequest, nil)
+	})
+
+	t.Run("insufficient embedded records are rejected", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-api-create-insufficient")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		// One text record but no embeddings: below the embedding threshold.
+		insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusBadRequest, nil)
+	})
+
+	t.Run("accepts a new run and reuses an in-progress one", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-api-create-ok")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords+1)
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope, ActorID: new("creator")}
+
+		var first models.CreateTaxonomyRunResponse
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusAccepted, &first)
+		require.False(t, first.InProgress)
+		assert.Equal(t, models.TaxonomyRunStatusRunning, first.Run.Status)
+		assert.Contains(t, harness.starter.startedRunIDs(), first.Run.ID.String())
+
+		// A second request for the same scope reuses the running run (200, in_progress).
+		var second models.CreateTaxonomyRunResponse
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusOK, &second)
+		require.True(t, second.InProgress)
+		assert.Equal(t, first.Run.ID, second.Run.ID)
+	})
+}
+
+// TestTaxonomyAPI_InternalServiceEndpoints covers the internal service flow: fetching run
+// input, completing a run (storing artifacts and activating), and failing a run.
+func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	t.Run("get run input returns feedback text and embeddings", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords+1)
+
+		runID := startRunForScope(ctx, t, harness, scope)
+
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		// Auth is required.
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, "", nil, http.StatusUnauthorized, nil)
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+		assert.Equal(t, runID, input.Run.ID)
+		require.NotEmpty(t, input.Records)
+		assert.NotEmpty(t, input.Records[0].Embedding)
+		assert.NotEmpty(t, input.Records[0].ValueText)
+	})
+
+	t.Run("complete run stores artifacts and activates", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-complete")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+
+		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+		runID := createRunningRun(ctx, t, harness, scope)
+
+		result := models.TaxonomyRunResultRequest{
+			Clusters: []models.TaxonomyResultCluster{
+				{ClusterKey: 1, Label: new("login"), Size: 1},
+			},
+			Memberships: []models.TaxonomyResultMembership{
+				{ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9)},
+			},
+			Nodes: []models.TaxonomyResultNode{
+				{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
+				{NodeKey: "leaf", ParentKey: new("root"), ClusterKey: new(1), NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 1},
+			},
+		}
+
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+
+		// Auth is required.
+		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, "", result, http.StatusUnauthorized, nil)
+
+		var run models.TaxonomyRun
+		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, harness.internalToken, result, http.StatusOK, &run)
+		assert.Equal(t, models.TaxonomyRunStatusSucceeded, run.Status)
+
+		// The completed run is now the active run for its scope.
+		active, err := harness.repo.GetActiveRun(ctx, scope)
+		require.NoError(t, err)
+		assert.Equal(t, runID, active.ID)
+	})
+
+	t.Run("fail run records the failure", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-fail")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+
+		runID := createRunningRun(ctx, t, harness, scope)
+
+		body := models.TaxonomyRunFailedRequest{
+			Error:     "clustering did not converge",
+			ErrorCode: models.TaxonomyRunFailureCodeGenerationFailed,
+		}
+		failedURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/failed"
+
+		// Auth is required.
+		requestTaxonomyJSON(ctx, t, http.MethodPost, failedURL, "", body, http.StatusUnauthorized, nil)
+
+		var run models.TaxonomyRun
+		requestTaxonomyJSON(ctx, t, http.MethodPost, failedURL, harness.internalToken, body, http.StatusOK, &run)
+		assert.Equal(t, models.TaxonomyRunStatusFailed, run.Status)
+		require.NotNil(t, run.Error)
+		assert.Equal(t, "clustering did not converge", *run.Error)
+	})
+}
+
+// TestTaxonomyAPI_GenerationLifecycle drives the full path across both API layers: a public
+// create, the internal service fetching input and posting the result, then the public active
+// tree reflecting the generated taxonomy.
+func TestTaxonomyAPI_GenerationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	scope := uniqueTaxonomyScope("tax-lifecycle")
+	cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+	seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords+1)
+
+	// 1. Public create -> running run.
+	var created models.CreateTaxonomyRunResponse
+	requestTaxonomyJSON(ctx, t, http.MethodPost, harness.server.URL+"/v1/taxonomy/runs", harness.apiKey,
+		models.CreateTaxonomyRunRequest{TaxonomyScope: scope}, http.StatusAccepted, &created)
+	runID := created.Run.ID
+
+	// 2. Internal service fetches the run input (feedback + embeddings).
+	var input models.TaxonomyRunInputResponse
+	requestTaxonomyJSON(ctx, t, http.MethodGet, harness.server.URL+"/internal/v1/taxonomy/runs/"+runID.String()+"/input",
+		harness.internalToken, nil, http.StatusOK, &input)
+	require.NotEmpty(t, input.Records)
+
+	// 3. Internal service posts the generated result referencing a real input record.
+	result := models.TaxonomyRunResultRequest{
+		Clusters: []models.TaxonomyResultCluster{{ClusterKey: 1, Label: new("login"), Size: len(input.Records)}},
+		Memberships: []models.TaxonomyResultMembership{
+			{ClusterKey: 1, FeedbackRecordID: input.Records[0].FeedbackRecordID, Confidence: new(0.8)},
+		},
+		Nodes: []models.TaxonomyResultNode{
+			{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
+			{NodeKey: "leaf", ParentKey: new("root"), ClusterKey: new(1), NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 1},
+		},
+	}
+
+	var completed models.TaxonomyRun
+	requestTaxonomyJSON(ctx, t, http.MethodPut, harness.server.URL+"/internal/v1/taxonomy/runs/"+runID.String()+"/result",
+		harness.internalToken, result, http.StatusOK, &completed)
+	require.Equal(t, models.TaxonomyRunStatusSucceeded, completed.Status)
+
+	// 4. Public active tree now reflects the generated taxonomy, and its leaf is editable.
+	scopeQuery := url.Values{
+		"tenant_id":   {scope.TenantID},
+		"source_type": {scope.SourceType},
+		"source_id":   {scope.SourceID},
+		"field_id":    {scope.FieldID},
+	}
+
+	var tree models.TaxonomyTreeResponse
+	requestTaxonomyJSON(ctx, t, http.MethodGet,
+		taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/active/tree", scopeQuery), harness.apiKey, nil, http.StatusOK, &tree)
+	require.Equal(t, runID, tree.Run.ID)
+
+	leaf := findTaxonomyNode(tree.Root, func(n models.TaxonomyNode) bool { return n.NodeType == models.TaxonomyNodeTypeLeaf })
+	require.NotNil(t, leaf, "generated tree must contain a leaf node")
+
+	var renamed models.TaxonomyNode
+	requestTaxonomyJSON(ctx, t, http.MethodPatch, harness.server.URL+"/v1/taxonomy/nodes/"+leaf.ID.String(), harness.apiKey,
+		models.RenameTaxonomyNodeRequest{TenantID: scope.TenantID, ActorID: "curator", Label: "Authentication"},
+		http.StatusOK, &renamed)
+	assert.Equal(t, "Authentication", renamed.Label)
+}
+
+// startRunForScope creates and starts a run through the repository, returning its ID. It is
+// used to set up internal-endpoint tests without going through the public create endpoint.
+func startRunForScope(ctx context.Context, t *testing.T, harness *taxonomyTestServer, scope models.TaxonomyScope) uuid.UUID {
+	t.Helper()
+
+	recordCount, embeddingCount, _, err := harness.repo.CountScopeInput(ctx, scope, taxonomyEmbeddingModel)
+	require.NoError(t, err)
+
+	run, created, err := harness.repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+		TaxonomyScope: scope, RecordCount: recordCount, EmbeddingCount: embeddingCount,
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	_, err = harness.repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+	require.NoError(t, err)
+
+	return run.ID
+}
+
+// createRunningRun creates a run in the running state without requiring seeded embeddings,
+// for internal endpoints that only need a run in the correct state.
+func createRunningRun(ctx context.Context, t *testing.T, harness *taxonomyTestServer, scope models.TaxonomyScope) uuid.UUID {
+	t.Helper()
+
+	run, created, err := harness.repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+		TaxonomyScope: scope, RecordCount: 1, EmbeddingCount: 1,
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	_, err = harness.repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+	require.NoError(t, err)
+
+	return run.ID
+}

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -1,0 +1,380 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+)
+
+// cleanupTaxonomyTenant removes all taxonomy runs (cascading their artifacts) and feedback
+// records for a tenant once the test finishes, keeping the shared test database tidy. It
+// reuses the caller's context (the test bodies use context.Background(), which is never
+// canceled) so the cleanup still runs after the test returns.
+func cleanupTaxonomyTenant(ctx context.Context, t *testing.T, db *pgxpool.Pool, tenantID string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(ctx, `DELETE FROM taxonomy_runs WHERE tenant_id = $1`, tenantID)
+		_, _ = db.Exec(ctx, `DELETE FROM feedback_records WHERE tenant_id = $1`, tenantID)
+	})
+}
+
+// insertScopeFeedbackRecord inserts a single text feedback record for a scope and returns
+// its ID, so membership rows in StoreResultAndActivate reference a real feedback record.
+func insertScopeFeedbackRecord(ctx context.Context, t *testing.T, db *pgxpool.Pool, scope models.TaxonomyScope) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+
+	err := db.QueryRow(ctx, `
+		INSERT INTO feedback_records (
+			source_type, source_id, field_id, field_label, field_type,
+			value_text, tenant_id, submission_id
+		)
+		VALUES ($1, NULLIF($2, ''), $3, 'Feedback', 'text'::field_type_enum, $4, $5, $6)
+		RETURNING id`,
+		scope.SourceType, scope.SourceID, scope.FieldID,
+		"Login was confusing", scope.TenantID, "submission-"+uuid.NewString(),
+	).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+// TestTaxonomyRepository_RunLifecycle covers the run state machine: create/reuse, the
+// pending->running transition, and the terminal failed transition, including the conflicts
+// that guard illegal transitions.
+func TestTaxonomyRepository_RunLifecycle(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	t.Run("create persists a pending run and a second call reuses it", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-create")
+		cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+		run, created, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+			TaxonomyScope: scope, RecordCount: 5, EmbeddingCount: 5,
+		})
+		require.NoError(t, err)
+		require.True(t, created)
+		require.Equal(t, models.TaxonomyRunStatusPending, run.Status)
+		requireUUIDv7(t, run.ID)
+
+		reused, createdAgain, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+			TaxonomyScope: scope, RecordCount: 5, EmbeddingCount: 5,
+		})
+		require.NoError(t, err)
+		require.False(t, createdAgain, "an in-progress run must be reused, not duplicated")
+		require.Equal(t, run.ID, reused.ID)
+	})
+
+	t.Run("mark running transitions pending to running and rejects a repeat", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-running")
+		cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+		run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: scope})
+		require.NoError(t, err)
+
+		running, err := repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+		require.NoError(t, err)
+		require.Equal(t, models.TaxonomyRunStatusRunning, running.Status)
+		require.NotNil(t, running.StartedAt)
+
+		_, err = repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+		require.ErrorIs(t, err, huberrors.ErrConflict, "running->running must conflict")
+	})
+
+	t.Run("mark failed records error and code and rejects a terminal run", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-failed")
+		cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+		run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: scope})
+		require.NoError(t, err)
+
+		failed, err := repo.MarkRunFailed(
+			ctx, run.ID, scope.TenantID, "clustering failed", models.TaxonomyRunFailureCodeInsufficientData,
+		)
+		require.NoError(t, err)
+		require.Equal(t, models.TaxonomyRunStatusFailed, failed.Status)
+		require.NotNil(t, failed.Error)
+		require.Equal(t, "clustering failed", *failed.Error)
+		require.NotNil(t, failed.ErrorCode)
+		require.Equal(t, models.TaxonomyRunFailureCodeInsufficientData, *failed.ErrorCode)
+		require.NotNil(t, failed.FinishedAt)
+
+		_, err = repo.MarkRunFailed(
+			ctx, run.ID, scope.TenantID, "again", models.TaxonomyRunFailureCodeInternalError,
+		)
+		require.ErrorIs(t, err, huberrors.ErrConflict, "failed->failed must conflict")
+	})
+
+	t.Run("unknown run id is not found", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-missing")
+		_, err := repo.MarkRunRunning(ctx, uuid.New(), scope.TenantID)
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+	})
+}
+
+// TestTaxonomyRepository_StoreResultAndActivate covers persisting the full artifact graph
+// (clusters, memberships, nodes), activating the run, replacing a prior active run, and the
+// conflict when the run is not in the running state.
+func TestTaxonomyRepository_StoreResultAndActivate(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	scope := uniqueTaxonomyScope("tax-store")
+	cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+	feedbackRecordID := insertScopeFeedbackRecord(ctx, t, db, scope)
+
+	result := models.TaxonomyRunResultRequest{
+		Clusters: []models.TaxonomyResultCluster{
+			{ClusterKey: 1, Label: new("login"), LLMLabel: new("Login issues"), Size: 1},
+		},
+		Memberships: []models.TaxonomyResultMembership{
+			{ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9)},
+		},
+		Nodes: []models.TaxonomyResultNode{
+			{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
+			{NodeKey: "branch", ParentKey: new("root"), NodeType: models.TaxonomyNodeTypeBranch, Label: "Access", Level: 1},
+			{NodeKey: "leaf", ParentKey: new("branch"), ClusterKey: new(1), NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 2},
+		},
+	}
+
+	runReadyToStore := func(t *testing.T) uuid.UUID {
+		t.Helper()
+
+		run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
+			TaxonomyScope: scope, RecordCount: 1, EmbeddingCount: 1,
+		})
+		require.NoError(t, err)
+
+		_, err = repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+		require.NoError(t, err)
+
+		return run.ID
+	}
+
+	firstRunID := runReadyToStore(t)
+
+	stored, err := repo.StoreResultAndActivate(ctx, firstRunID, scope.TenantID, result)
+	require.NoError(t, err)
+	require.Equal(t, models.TaxonomyRunStatusSucceeded, stored.Status)
+	require.Equal(t, 1, stored.ClusterCount)
+	require.Equal(t, 3, stored.NodeCount)
+	require.NotNil(t, stored.FinishedAt)
+
+	// Every artifact table is populated for the run.
+	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_clusters WHERE run_id = $1`, firstRunID))
+	assert.Equal(t, int64(1),
+		countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_cluster_memberships WHERE run_id = $1`, firstRunID))
+	assert.Equal(t, int64(3), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_nodes WHERE run_id = $1`, firstRunID))
+
+	// The run is now the active run for its scope.
+	active, err := repo.GetActiveRun(ctx, scope)
+	require.NoError(t, err)
+	require.Equal(t, firstRunID, active.ID)
+
+	// A second completed run for the same scope replaces the active pointer (upsert).
+	secondRunID := runReadyToStore(t)
+	_, err = repo.StoreResultAndActivate(ctx, secondRunID, scope.TenantID, result)
+	require.NoError(t, err)
+
+	active, err = repo.GetActiveRun(ctx, scope)
+	require.NoError(t, err)
+	require.Equal(t, secondRunID, active.ID, "activating a new run must replace the previous active run")
+	assert.Equal(t, int64(1),
+		countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_active_runs WHERE tenant_id = $1`, scope.TenantID))
+
+	// Storing a result for a run that is not running conflicts (it is already succeeded).
+	_, err = repo.StoreResultAndActivate(ctx, firstRunID, scope.TenantID, result)
+	require.ErrorIs(t, err, huberrors.ErrConflict)
+}
+
+// TestTaxonomyRepository_RenameAndRemoveNode covers node edits, the audit events they emit,
+// and soft-remove visibility in the tree.
+func TestTaxonomyRepository_RenameAndRemoveNode(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	scope := uniqueTaxonomyScope("tax-edit")
+	ids := seedTaxonomyGraph(ctx, t, db, scope)
+
+	t.Run("rename updates the label and records a rename event", func(t *testing.T) {
+		renamed, err := repo.RenameNode(ctx, ids.BranchID, scope.TenantID, "actor-rename", "Account Access")
+		require.NoError(t, err)
+		require.Equal(t, "Account Access", renamed.Label)
+
+		events := countTenantDataRows(ctx, t, db, `
+			SELECT COUNT(*) FROM taxonomy_node_events
+			WHERE node_id = $1 AND event_type = 'rename' AND actor_id = 'actor-rename'
+				AND new_value->>'label' = 'Account Access'`, ids.BranchID)
+		assert.Equal(t, int64(1), events, "a rename must record exactly one rename event")
+	})
+
+	t.Run("soft-remove sets removed metadata, records an event, and hides the node", func(t *testing.T) {
+		removed, err := repo.RemoveNode(ctx, ids.LeafID, scope.TenantID, "actor-remove")
+		require.NoError(t, err)
+		require.NotNil(t, removed.RemovedAt)
+		require.NotNil(t, removed.RemovedBy)
+		require.Equal(t, "actor-remove", *removed.RemovedBy)
+
+		events := countTenantDataRows(ctx, t, db, `
+			SELECT COUNT(*) FROM taxonomy_node_events
+			WHERE node_id = $1 AND event_type = 'soft_remove' AND actor_id = 'actor-remove'`, ids.LeafID)
+		assert.Equal(t, int64(1), events)
+
+		tree, err := repo.GetTree(ctx, ids.RunID, scope.TenantID)
+		require.NoError(t, err)
+		require.NotNil(t, tree.Root)
+		require.False(t, treeContainsNode(tree.Root, ids.LeafID), "a soft-removed node must not appear in the tree")
+		require.True(t, treeContainsNode(tree.Root, ids.BranchID), "non-removed nodes must remain visible")
+	})
+}
+
+// treeContainsNode reports whether nodeID appears anywhere in the visible tree.
+func treeContainsNode(node *models.TaxonomyNode, nodeID uuid.UUID) bool {
+	if node == nil {
+		return false
+	}
+
+	if node.ID == nodeID {
+		return true
+	}
+
+	for i := range node.Children {
+		if treeContainsNode(&node.Children[i], nodeID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestTaxonomyRepository_ListNodeRecords covers the recursive drilldown from a node to the
+// feedback records assigned to it and its descendants.
+func TestTaxonomyRepository_ListNodeRecords(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	scope := uniqueTaxonomyScope("tax-noderecords")
+	ids := seedTaxonomyGraph(ctx, t, db, scope)
+
+	// The root aggregates records from its descendant leaf's cluster membership.
+	records, _, err := repo.ListNodeRecords(ctx, ids.RootID, scope.TenantID, 50)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, ids.FeedbackRecordID, records[0].ID)
+
+	// A different tenant sees nothing for the same node id.
+	otherTenantRecords, _, err := repo.ListNodeRecords(ctx, ids.RootID, "other-tenant-"+uuid.NewString(), 50)
+	require.NoError(t, err)
+	require.Empty(t, otherTenantRecords, "node records must be tenant-scoped")
+}
+
+// TestTaxonomyRepository_TenantIsolation proves every tenant-scoped read and mutation refuses
+// to touch another tenant's run and nodes.
+func TestTaxonomyRepository_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	scope := uniqueTaxonomyScope("tax-isolation-a")
+	ids := seedTaxonomyGraph(ctx, t, db, scope)
+
+	otherTenant := "tax-isolation-b-" + uuid.NewString()
+
+	t.Run("get run is tenant scoped but internal lookup is not", func(t *testing.T) {
+		_, err := repo.GetRunForTenant(ctx, ids.RunID, scope.TenantID)
+		require.NoError(t, err)
+
+		_, err = repo.GetRunForTenant(ctx, ids.RunID, otherTenant)
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+
+		internalRun, err := repo.GetRunForInternalService(ctx, ids.RunID)
+		require.NoError(t, err, "internal lookup intentionally has no tenant scope")
+		require.Equal(t, scope.TenantID, internalRun.TenantID)
+	})
+
+	t.Run("get tree refuses another tenant", func(t *testing.T) {
+		_, err := repo.GetTree(ctx, ids.RunID, otherTenant)
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+	})
+
+	t.Run("rename and remove refuse another tenant", func(t *testing.T) {
+		_, err := repo.RenameNode(ctx, ids.BranchID, otherTenant, "attacker", "Hijacked")
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+
+		_, err = repo.RemoveNode(ctx, ids.BranchID, otherTenant, "attacker")
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+
+		// The node is untouched by the rejected cross-tenant edits.
+		tree, err := repo.GetTree(ctx, ids.RunID, scope.TenantID)
+		require.NoError(t, err)
+		require.True(t, treeContainsNode(tree.Root, ids.BranchID))
+	})
+
+	t.Run("list runs and active run are tenant scoped", func(t *testing.T) {
+		runs, err := repo.ListRuns(ctx, models.ListTaxonomyRunsFilters{TenantID: otherTenant})
+		require.NoError(t, err)
+		require.Empty(t, runs)
+
+		otherScope := scope
+		otherScope.TenantID = otherTenant
+		_, err = repo.GetActiveRun(ctx, otherScope)
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+	})
+}
+
+// TestTaxonomyRepository_TenantDeletionCleansTaxonomy proves a tenant data purge removes all
+// taxonomy artifacts for the tenant while leaving another tenant's taxonomy intact.
+func TestTaxonomyRepository_TenantDeletionCleansTaxonomy(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+
+	scopeA := uniqueTaxonomyScope("tax-delete-a")
+	scopeB := uniqueTaxonomyScope("tax-delete-b")
+	idsA := seedTaxonomyGraph(ctx, t, db, scopeA)
+	idsB := seedTaxonomyGraph(ctx, t, db, scopeB)
+
+	tenantDataRepo := repository.NewTenantDataRepository(db, time.Second)
+	_, err := tenantDataRepo.DeleteByTenant(ctx, scopeA.TenantID)
+	require.NoError(t, err)
+
+	for _, table := range []string{
+		"taxonomy_runs", "taxonomy_clusters", "taxonomy_cluster_memberships",
+		"taxonomy_nodes", "taxonomy_active_runs", "taxonomy_node_events",
+	} {
+		var (
+			count int64
+			query string
+		)
+
+		switch table {
+		case "taxonomy_runs":
+			query = `SELECT COUNT(*) FROM taxonomy_runs WHERE id = $1`
+		default:
+			query = `SELECT COUNT(*) FROM ` + table + ` WHERE run_id = $1`
+		}
+
+		count = countTenantDataRows(ctx, t, db, query, idsA.RunID)
+		assert.Equalf(t, int64(0), count, "%s must be cleared for the purged tenant", table)
+	}
+
+	// The other tenant's taxonomy run and artifacts survive the purge.
+	assert.Equal(t, int64(1), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_runs WHERE id = $1`, idsB.RunID))
+	assert.Equal(t, int64(3), countTenantDataRows(ctx, t, db, `SELECT COUNT(*) FROM taxonomy_nodes WHERE run_id = $1`, idsB.RunID))
+}

--- a/tests/taxonomy_support_test.go
+++ b/tests/taxonomy_support_test.go
@@ -1,0 +1,372 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/api/handlers"
+	"github.com/formbricks/hub/internal/api/middleware"
+	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+	"github.com/formbricks/hub/internal/service"
+	"github.com/formbricks/hub/pkg/database"
+)
+
+// taxonomyEmbeddingModel is the embedding model taxonomy tests configure the service
+// with. Embeddings must be seeded with this model or CountScopeInput will not count
+// them (and StartManualRun will reject the run for insufficient embedded records).
+const taxonomyEmbeddingModel = "model-name"
+
+// testInternalToken authenticates the internal taxonomy service endpoints. It is
+// deliberately different from testAPIKey so cross-auth isolation can be asserted.
+const testInternalToken = "test-internal-token-67890"
+
+// taxonomyMinEmbeddedRecords keeps the StartManualRun embedding threshold low so the
+// happy path only needs a couple of seeded records instead of the production default (20).
+const taxonomyMinEmbeddedRecords = 2
+
+// taxonomyTestDB opens a Postgres pool for DB-backed taxonomy tests, mirroring the
+// existing integration helpers (DATABASE_URL env, falling back to the compose default).
+func taxonomyTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = defaultTestDatabaseURL
+	}
+
+	t.Setenv("DATABASE_URL", databaseURL)
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(context.Background(), cfg.Database.URL,
+		database.WithPoolConfig(cfg.Database.PoolConfig()),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(db.Close)
+
+	return db
+}
+
+// fakeTaxonomyStarter is an in-memory service.TaxonomyRunStarter. It records the run
+// IDs it was asked to start and returns the configured error, so tests can drive both
+// the accept and reject paths of StartManualRun without a real compute service.
+type fakeTaxonomyStarter struct {
+	mu       sync.Mutex
+	startErr error
+	runIDs   []string
+}
+
+func (f *fakeTaxonomyStarter) StartRun(_ context.Context, runID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.runIDs = append(f.runIDs, runID)
+
+	return f.startErr
+}
+
+func (f *fakeTaxonomyStarter) startedRunIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.runIDs...)
+}
+
+// taxonomyTestServer bundles the taxonomy HTTP test server with the dependencies tests
+// need to seed state and assert behavior.
+type taxonomyTestServer struct {
+	server         *httptest.Server
+	db             *pgxpool.Pool
+	repo           *repository.TaxonomyRepository
+	embeddingsRepo *repository.EmbeddingsRepository
+	starter        *fakeTaxonomyStarter
+	internalToken  string
+	apiKey         string
+}
+
+// setupTaxonomyAPIServer builds an httptest server that mirrors cmd/api/app.go's taxonomy
+// wiring: public taxonomy routes behind the Hub API key, and the internal taxonomy routes
+// behind a separate internal token. It returns the server plus the repo/embeddings/starter
+// so tests can seed data and inspect start calls.
+func setupTaxonomyAPIServer(t *testing.T) *taxonomyTestServer {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = defaultTestDatabaseURL
+	}
+
+	t.Setenv("API_KEY", testAPIKey)
+	t.Setenv("DATABASE_URL", databaseURL)
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(context.Background(), cfg.Database.URL,
+		database.WithPoolConfig(cfg.Database.PoolConfig()),
+	)
+	require.NoError(t, err)
+
+	repo := repository.NewTaxonomyRepository(db)
+	embeddingsRepo := repository.NewEmbeddingsRepository(db)
+	starter := &fakeTaxonomyStarter{}
+
+	taxonomyService := service.NewTaxonomyService(service.NewTaxonomyServiceParams{
+		Repo:                  repo,
+		Starter:               starter,
+		EmbeddingModel:        taxonomyEmbeddingModel,
+		MinimumEmbeddingCount: taxonomyMinEmbeddedRecords,
+	})
+	taxonomyHandler := handlers.NewTaxonomyHandler(taxonomyService)
+	taxonomyInternalHandler := handlers.NewTaxonomyInternalHandler(taxonomyService)
+
+	// Public taxonomy routes (Hub API key auth), matching cmd/api/app.go ordering so the
+	// {run_id} literal-vs-pattern precedence (active/tree before {run_id}) is preserved.
+	protected := http.NewServeMux()
+	protected.HandleFunc("GET /v1/taxonomy/fields", taxonomyHandler.ListFields)
+	protected.HandleFunc("POST /v1/taxonomy/runs", taxonomyHandler.CreateRun)
+	protected.HandleFunc("GET /v1/taxonomy/runs", taxonomyHandler.ListRuns)
+	protected.HandleFunc("GET /v1/taxonomy/runs/active/tree", taxonomyHandler.GetActiveTree)
+	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}", taxonomyHandler.GetRun)
+	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/tree", taxonomyHandler.GetTree)
+	protected.HandleFunc("PATCH /v1/taxonomy/nodes/{node_id}", taxonomyHandler.RenameNode)
+	protected.HandleFunc("DELETE /v1/taxonomy/nodes/{node_id}", taxonomyHandler.RemoveNode)
+	protected.HandleFunc("GET /v1/taxonomy/nodes/{node_id}/records", taxonomyHandler.ListNodeRecords)
+	protectedWithAuth := middleware.Auth(cfg.Server.HubAPIKey)(protected)
+
+	// Internal taxonomy routes (separate internal-service token auth).
+	internal := http.NewServeMux()
+	internal.HandleFunc("GET /internal/v1/taxonomy/auth-check", taxonomyInternalHandler.AuthCheck)
+	internal.HandleFunc("GET /internal/v1/taxonomy/runs/{run_id}/input", taxonomyInternalHandler.GetRunInput)
+	internal.HandleFunc("PUT /internal/v1/taxonomy/runs/{run_id}/result", taxonomyInternalHandler.CompleteRun)
+	internal.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/failed", taxonomyInternalHandler.FailRun)
+	internalWithAuth := middleware.Auth(testInternalToken)(internal)
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/", protectedWithAuth)
+	mux.Handle("/internal/v1/taxonomy/", internalWithAuth)
+
+	server := httptest.NewServer(mux)
+
+	t.Cleanup(func() {
+		server.Close()
+		db.Close()
+	})
+
+	return &taxonomyTestServer{
+		server:         server,
+		db:             db,
+		repo:           repo,
+		embeddingsRepo: embeddingsRepo,
+		starter:        starter,
+		internalToken:  testInternalToken,
+		apiKey:         testAPIKey,
+	}
+}
+
+// taxonomyGraphIDs holds the identifiers produced by seedTaxonomyGraph.
+type taxonomyGraphIDs struct {
+	FeedbackRecordID uuid.UUID
+	RunID            uuid.UUID
+	ClusterID        uuid.UUID
+	RootID           uuid.UUID
+	BranchID         uuid.UUID
+	LeafID           uuid.UUID
+	NodeEventID      uuid.UUID
+}
+
+// seedTaxonomyGraph inserts a complete, activated taxonomy graph for a scope using raw
+// SQL: one feedback record, a succeeded run, one cluster, one membership, a root/branch/leaf
+// node chain, an active-run pointer, and one node event. It returns every identifier so
+// tests can exercise reads, edits, and cross-tenant access against known rows.
+func seedTaxonomyGraph(ctx context.Context, t *testing.T, db *pgxpool.Pool, scope models.TaxonomyScope) taxonomyGraphIDs {
+	t.Helper()
+
+	var ids taxonomyGraphIDs
+
+	err := db.QueryRow(ctx, `
+		INSERT INTO feedback_records (
+			source_type, source_id, field_id, field_label, field_type,
+			value_text, tenant_id, submission_id
+		)
+		VALUES ($1, NULLIF($2, ''), $3, 'Feedback', 'text'::field_type_enum, $4, $5, $6)
+		RETURNING id`,
+		scope.SourceType, scope.SourceID, scope.FieldID,
+		"Login was confusing", scope.TenantID, "submission-"+uuid.NewString(),
+	).Scan(&ids.FeedbackRecordID)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_runs (
+			tenant_id, source_type, source_id, field_id, field_label, status,
+			record_count, embedding_count, cluster_count, node_count
+		)
+		VALUES ($1, $2, $3, $4, 'Feedback', 'succeeded'::taxonomy_run_status_enum, 1, 1, 1, 3)
+		RETURNING id`,
+		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID,
+	).Scan(&ids.RunID)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_clusters (run_id, cluster_key, label, llm_label, keywords, size)
+		VALUES ($1, 1, 'login', 'Login issues', '["login"]'::jsonb, 1)
+		RETURNING id`,
+		ids.RunID,
+	).Scan(&ids.ClusterID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO taxonomy_cluster_memberships (run_id, tenant_id, cluster_id, feedback_record_id, confidence)
+		VALUES ($1, $2, $3, $4, 0.95)`,
+		ids.RunID, scope.TenantID, ids.ClusterID, ids.FeedbackRecordID,
+	)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_nodes (run_id, node_type, label, original_label, level, sort_order)
+		VALUES ($1, 'root'::taxonomy_node_type_enum, 'Feedback', 'Feedback', 0, 0)
+		RETURNING id`,
+		ids.RunID,
+	).Scan(&ids.RootID)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_nodes (run_id, parent_id, node_type, label, original_label, level, sort_order)
+		VALUES ($1, $2, 'branch'::taxonomy_node_type_enum, 'Product Access', 'Product Access', 1, 0)
+		RETURNING id`,
+		ids.RunID, ids.RootID,
+	).Scan(&ids.BranchID)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_nodes (run_id, parent_id, cluster_id, node_type, label, original_label, level, sort_order)
+		VALUES ($1, $2, $3, 'leaf'::taxonomy_node_type_enum, 'Login Problems', 'Login Problems', 2, 0)
+		RETURNING id`,
+		ids.RunID, ids.BranchID, ids.ClusterID,
+	).Scan(&ids.LeafID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO taxonomy_active_runs (tenant_id, source_type, source_id, field_id, run_id, activated_by)
+		VALUES ($1, $2, $3, $4, $5, 'seed-user')`,
+		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID, ids.RunID,
+	)
+	require.NoError(t, err)
+
+	err = db.QueryRow(ctx, `
+		INSERT INTO taxonomy_node_events (
+			tenant_id, source_type, source_id, field_id, run_id, node_id,
+			event_type, actor_id, old_value, new_value
+		)
+		VALUES (
+			$1, $2, $3, $4, $5, $6,
+			'rename'::taxonomy_node_event_type_enum, 'seed-user',
+			'{"label":"Login Problems"}'::jsonb, '{"label":"Authentication Problems"}'::jsonb
+		)
+		RETURNING id`,
+		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID, ids.RunID, ids.LeafID,
+	).Scan(&ids.NodeEventID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// taxonomy_runs cascade removes clusters/memberships/nodes/active-runs/events.
+		_, _ = db.Exec(ctx, `DELETE FROM taxonomy_runs WHERE tenant_id = $1`, scope.TenantID)
+		_, _ = db.Exec(ctx, `DELETE FROM feedback_records WHERE tenant_id = $1`, scope.TenantID)
+	})
+
+	return ids
+}
+
+// seedEmbeddedFeedback inserts count text feedback records for a scope, each with an
+// embedding under taxonomyEmbeddingModel, so StartManualRun's input counts are satisfied.
+func seedEmbeddedFeedback(
+	ctx context.Context, t *testing.T, harness *taxonomyTestServer, scope models.TaxonomyScope, count int,
+) {
+	t.Helper()
+
+	for range count {
+		var recordID uuid.UUID
+
+		err := harness.db.QueryRow(ctx, `
+			INSERT INTO feedback_records (
+				source_type, source_id, field_id, field_label, field_type,
+				value_text, tenant_id, submission_id
+			)
+			VALUES ($1, NULLIF($2, ''), $3, 'Feedback', 'text'::field_type_enum, $4, $5, $6)
+			RETURNING id`,
+			scope.SourceType, scope.SourceID, scope.FieldID,
+			"Feedback text for embedding", scope.TenantID, "submission-"+uuid.NewString(),
+		).Scan(&recordID)
+		require.NoError(t, err)
+
+		embedding := make([]float32, models.EmbeddingVectorDimensions)
+		embedding[0] = 0.25
+
+		require.NoError(t, harness.embeddingsRepo.Upsert(ctx, recordID, taxonomyEmbeddingModel, embedding))
+	}
+
+	t.Cleanup(func() {
+		_, _ = harness.db.Exec(ctx, `DELETE FROM feedback_records WHERE tenant_id = $1`, scope.TenantID)
+	})
+}
+
+// doTaxonomyRequest issues an HTTP request against the taxonomy test server. When token is
+// non-empty it is sent as a Bearer credential; when body is non-nil it is JSON-encoded.
+// The caller owns closing the returned response body.
+func doTaxonomyRequest(
+	ctx context.Context, t *testing.T, method, url, token string, body any,
+) *http.Response {
+	t.Helper()
+
+	var reader *bytes.Reader
+
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		require.NoError(t, err)
+
+		reader = bytes.NewReader(encoded)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	require.NoError(t, err)
+
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+
+	return resp
+}
+
+// uniqueTaxonomyScope builds a scope with a unique tenant ID so parallel/repeated runs of
+// a test never collide on tenant-scoped rows.
+func uniqueTaxonomyScope(prefix string) models.TaxonomyScope {
+	return models.TaxonomyScope{
+		TenantID:   prefix + "-" + uuid.NewString(),
+		SourceType: "formbricks",
+		SourceID:   "survey-" + uuid.NewString(),
+		FieldID:    "feedback",
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Implements **ENG-1169** — adds Hub backend test coverage for the taxonomy feature, which had little/no automated tests. As Hub becomes the source of truth for generated taxonomy artifacts, this locks in persistence, API, auth, and tenant-isolation behavior.

These are **integration tests** (package `tests`): they run against a real Postgres database and, for the API tests, a real in-process `httptest` server wiring the actual handler → service → repository stack. The only stubbed dependency is the external taxonomy compute service (a fake `TaxonomyRunStarter`), which does not run in the test environment. No production code is changed — this PR is tests only.

### Files added

| File | Purpose |
|---|---|
| `tests/taxonomy_support_test.go` | Shared scaffolding: DB pool helper, fake `TaxonomyRunStarter`, a taxonomy-aware `httptest` server mirroring `cmd/api/app.go` (public routes behind the Hub API key, internal routes behind a separate internal-service token), a full-graph seeder (`seedTaxonomyGraph`), an embedded-feedback seeder, and an authed request helper |
| `tests/taxonomy_persistence_test.go` | Repository/persistence tests + repo-level tenant isolation + tenant-deletion cleanup |
| `tests/taxonomy_api_test.go` | Public + internal HTTP endpoints, both auth layers, HTTP-level tenant isolation, and a full generation lifecycle |

### Acceptance-criteria coverage

- **Persistence covers all six taxonomy tables** — `taxonomy_runs` (create/reuse, `pending→running`, `→failed`), `taxonomy_clusters`, `taxonomy_cluster_memberships`, `taxonomy_nodes`, `taxonomy_active_runs`, and `taxonomy_node_events` (rename/soft-remove audit rows) are each written and asserted via `StoreResultAndActivate`, `RenameNode`, `RemoveNode`, `GetTree`, and `ListNodeRecords`.
- **Public API endpoints** — `GET /v1/taxonomy/fields`, `POST /v1/taxonomy/runs` (202 new / 200 in-progress / 400 invalid), `GET /v1/taxonomy/runs`, `GET /v1/taxonomy/runs/{run_id}`, `GET /v1/taxonomy/runs/{run_id}/tree`, `GET /v1/taxonomy/runs/active/tree`, `PATCH /v1/taxonomy/nodes/{node_id}`, `DELETE /v1/taxonomy/nodes/{node_id}`, `GET /v1/taxonomy/nodes/{node_id}/records`.
- **Internal service endpoints** — `GET /internal/v1/taxonomy/auth-check`, `GET .../runs/{run_id}/input`, `PUT .../runs/{run_id}/result` (complete + activate), `POST .../runs/{run_id}/failed`.
- **Auth (both layers)** — public Hub API key and internal service token, each tested for missing / wrong / correct credentials, plus cross-auth isolation (the internal token is rejected by the public API and vice-versa).
- **Tenant isolation** — cross-tenant access attempts return `404` (reads/edits) or an empty result (node-record drilldown), asserted at both the repository and HTTP layers against resources that genuinely exist for the other tenant.
- **Lifecycle** — run activation (including active-run replacement on re-run), node rename, node soft-remove (and its disappearance from the tree), and tenant-deletion cleanup of all taxonomy tables.

Invalid state transitions (`running→running`, completing a non-running run, failing a terminal run) are asserted to return `409 Conflict` / `huberrors.ErrConflict`.

## How should this be tested?

Requires a Postgres database with the schema applied. Config: `DATABASE_URL`, `API_KEY`.

```
make dev-setup            # or: bring up Postgres + make init-db + make river-migrate
make tests                # runs the integration tests in tests/
```

To run just the new tests:

```
go test -run 'TestTaxonomy' -count=1 -v ./tests/
```

**Results:** `make build`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint run ./tests/...` (0 issues), and the full `go test ./...` run against Postgres all pass. The new tests add persistence, API, auth, tenant-isolation, and lifecycle coverage that previously did not exist.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` — _N/A, no schema change_

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests — _N/A, no API change (tests exercise existing endpoints)_
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots — _N/A, no behavior change_
- [ ] Updated docs in `docs/` if changes were necessary — _N/A_
- [ ] Ran `make tests-coverage` for meaningful logic changes
