### PR TITLE
feat(observability): enrichment round-2 (event correlation, HNSW-degradation gauge) + perf nits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,19 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `cmd/api/` holds the API server (hub-api): HTTP API, ingestion, record retrieval, tenant/auth; enqueues jobs to River (insert-only). Build/run: `go run ./cmd/api` or `make run`.
-- `cmd/worker/` holds the worker (hub-worker): runs River job workers (webhook delivery, embeddings). No HTTP. Build/run: `go run ./cmd/worker` or `make run-worker`.
-- `internal/` contains core application layers: `api/handlers`, `api/middleware`, `service`, `repository`, `models`, `config`, and `workers`.
-- `pkg/` provides shared utilities (currently `pkg/database`).
+- `cmd/api/` holds the API server (hub-api): HTTP API, ingestion, record retrieval, tenant/auth, semantic search; enqueues jobs to River (insert-only). Build/run: `go run ./cmd/api` or `make run`.
+- `cmd/worker/` holds the worker (hub-worker): runs River job workers — webhook delivery and the enrichment pipelines (embeddings, translation, sentiment, emotions). No HTTP. Build/run: `go run ./cmd/worker` or `make run-worker`.
+- `cmd/backfill-*/` are one-off enqueue commands that (re)enrich an existing backlog: `backfill-embeddings`, `backfill-translations`, and `backfill-classify -type sentiment|emotions`. hub-worker processes the jobs they enqueue.
+- `internal/` contains the application layers: `api/handlers`, `api/middleware`, `service`, `repository`, `models`, `config`, `workers`, `observability` (OTel metrics/tracing), the LLM seam (`llm`, `openai`, `googleai`), `datatypes`, and `huberrors`.
+- `pkg/` provides shared utilities: `database`, `cursor` (keyset pagination), and `embeddings`.
 - `migrations/` stores SQL migration files (goose); use `-- +goose up` / `-- +goose down` annotations.
-- `tests/` contains integration tests.
+- `tests/` contains integration tests (they require a pgvector database — see Testing Guidelines).
 
 ## Build, Test, and Development Commands
 - `make dev-setup`: start Postgres via Docker, install Go deps/tools, and initialize database schema.
-- `make run`: run hub-api (config from `.env` if present and environment variables; copy `.env.example` to `.env` or set env vars).
-- `make run-worker`: run hub-worker (requires DATABASE_URL from `.env` or environment variables).
+- `make run`: apply River migrations, then run both hub-api and hub-worker (config from `.env` if present, else environment variables; copy `.env.example` to `.env` or set env vars).
+- `make run-api` / `make run-worker`: run a single process (worker requires DATABASE_URL from `.env` or environment variables).
+- `make run-backfill-embeddings` / `make run-backfill-translations` / `make run-backfill-classify TYPE=sentiment|emotions`: enqueue a one-off (re)enrichment of the existing backlog (loads `.env`). `make build-backfill-*` build the corresponding binaries.
 - `make build`: build both `bin/hub-api` and `bin/hub-worker`. Use `make build-api` or `make build-worker` for a single binary.
 - `make tests`: run integration tests in `tests/`.
 - `make tests-coverage`: generate `coverage.html`.
@@ -24,6 +26,18 @@
 - Language: Go; format with `make fmt` (golangci-lint applies gofumpt/gci).
 - Prefer Go naming conventions (CamelCase for exported, lowerCamel for unexported).
 - Keep package names short and domain-focused (e.g., `repository`, `service`).
+
+## Enrichment Framework
+
+Sentiment, emotions, and translation are "classify" enrichments (`text → structured result` via an LLM) that share one scaffold; embedding is a separate pipeline that reuses only the light shared layer (client registry, metrics, content-hash). **Do not copy an existing enrichment to add a new one** — reuse the shared pieces:
+
+- `internal/service/enrichment_client_factory.go` — provider registry + validation and the shared `EnrichmentClientConfig` (per-type configs are aliases of it).
+- `internal/service/enrichment_client.go` — `classifyStructured` + `structuredSpec[R]` (prompt/schema/parse); the single place that calls the provider.
+- `internal/service/enrichment_provider.go` — `EnrichmentProvider` (eligibility, per-type `triggers`, per-tenant gate, dedupe, `buildArgs`).
+- `internal/workers/enrichment_worker.go` — the generic `enrichmentWorker[A, R]` Work body (load → clear-on-empty or classify → persist, with all outcome/error mapping).
+- `internal/observability/enrichment_metrics.go` — one metrics impl behind the per-type interfaces.
+
+A new enrichment is then a thin per-type spec: an enum/result type in `models`, a `*_client.go` (prompt + parse + `structuredSpec`), a `*_provider.go` (config for `EnrichmentProvider`), a `*_job_args.go`, a one-line `*_worker.go` (a configured `enrichmentWorker`), a metrics adapter, a config struct, and wiring in `cmd/*`. Enrichment outputs are read-only, server-generated columns — `NULL` until enriched, cleared and re-enqueued when `value_text` changes (translation also on `language`). Writes are guarded against content supersession, so a job that read older text skips rather than overwriting a newer result; carry `tenant_id` (and, for correlation, the originating `event_id`) through job args and log lines.
 
 ## Multi-Tenancy & Data Isolation
 
@@ -40,9 +54,11 @@
 - For any tenant-scoping change, include verification at the boundary where the leak could happen: database query behavior, service fan-out, worker execution, and API behavior when relevant. Include at least one alternate-path regression test proving that data allowed through the primary path cannot leak through async dispatch, bulk operations, derived indexes, exports, or background workers. Tests are the evidence; the invariant belongs in the architecture.
 
 ## Testing Guidelines
-- Tests live under `tests/` and are run with `go test ./tests/...`.
+- Unit tests live beside the code in `internal/**` and need no database: `make test-unit`.
+- Integration tests live under `tests/` and require a pgvector-enabled Postgres (`DATABASE_URL` pointing at a `test_db` with migrations applied): `make tests`. `make test-all` runs both.
 - Name test files `*_test.go` and test functions `TestXxx`.
-- Use `make tests-coverage` when adding meaningful logic to track coverage output.
+- Use `make tests-coverage` / `make check-coverage` when adding meaningful logic (the threshold excludes the `cmd/*` main packages).
+- Tenant-isolation changes must include an alternate-path regression test (see Multi-Tenancy & Data Isolation).
 
 ## Commit & Pull Request Guidelines
 - Always create a pull request for changes and don't commit directly to main.
@@ -52,4 +68,5 @@
 
 ## Security & Configuration Tips
 - Configure `API_KEY` and `DATABASE_URL` via `.env` or environment variables.
+- Enrichment providers and other runtime options are env-configured (`EMBEDDING_*`, `TRANSLATION_*`, `SENTIMENT_*`, `EMOTIONS_*`, `TENANT_SETTINGS_CACHE_*`, `OTEL_*`); `.env.example` is the full, documented set.
 - Do not commit `.env` or secrets; use `.env.example` as the base.

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/riverqueue/river/rivertype"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
@@ -84,6 +85,7 @@ func setupEmbeddingSearchHandler(
 	embeddingsRepo *repository.EmbeddingsRepository,
 	embeddingMetrics observability.EmbeddingMetrics,
 	metrics *observability.Metrics,
+	meterProvider *sdkmetric.MeterProvider,
 	riverWorkers *river.Workers,
 ) (*handlers.SearchHandler, error) {
 	embeddingCfg := service.EmbeddingClientConfig{
@@ -126,6 +128,17 @@ func setupEmbeddingSearchHandler(
 		CacheMetrics:    cacheMetrics,
 		Logger:          slog.Default(),
 	})
+
+	// Surface HNSW iterative-scan degradation (pgvector < 0.8 fallback) as a gauge so capped recall
+	// is alertable, not just a one-time log line. No-op meter when metrics are disabled.
+	var meter metric.Meter
+	if meterProvider != nil {
+		meter = meterProvider.Meter("hub")
+	}
+
+	if err := observability.RegisterHNSWIterativeScanGauge(meter, embeddingsRepo.IterativeScanDegraded); err != nil {
+		return nil, fmt.Errorf("register hnsw iterative scan gauge: %w", err)
+	}
 
 	return handlers.NewSearchHandler(searchService), nil
 }
@@ -269,7 +282,7 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 			context.Background(), cfg,
 			embeddingProviderName, embeddingModel, embeddingDocPrefix,
 			feedbackRecordsService, embeddingsRepo, embeddingMetrics,
-			metrics, riverWorkers)
+			metrics, meterProvider, riverWorkers)
 		if err != nil {
 			cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
 

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -263,6 +263,12 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 		cfg.Translation.DefaultLanguage,
 	)
 
+	// The eager-clear (nulling stale enrichment outputs on a value_text edit) fires only on this
+	// API PATCH path, so wire its counter here; the worker/backfill service instances leave it unset.
+	if metrics != nil {
+		feedbackRecordsService.SetEnrichmentClearMetrics(metrics.EnrichmentClear)
+	}
+
 	// Tenant settings service: shared by the emotions worker's authoritative gate (registered
 	// below), the settings HTTP handler, and the enqueue-path settings cache.
 	tenantSettingsRepo := repository.NewTenantSettingsRepository(db)

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -119,6 +119,7 @@ func TestSetupEmbeddingSearchHandler(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		river.NewWorkers(),
 	)
 	if err != nil {
@@ -137,6 +138,7 @@ func TestSetupEmbeddingSearchHandlerValidatesConfig(t *testing.T) {
 		service.EmbeddingProviderOpenAI,
 		"text-embedding-3-small",
 		"",
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/observability/aggregate.go
+++ b/internal/observability/aggregate.go
@@ -18,6 +18,8 @@ type Metrics struct {
 	Sentiment   SentimentMetrics
 	Emotions    EmotionsMetrics
 	Cache       CacheMetrics
+	// EnrichmentClear counts enrichment outputs nulled by an edit's eager-clear.
+	EnrichmentClear EnrichmentClearMetrics
 }
 
 // NewMetrics creates EventMetrics, WebhookMetrics, EmbeddingMetrics, TranslationMetrics, and CacheMetrics from the given meter.
@@ -63,13 +65,19 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("cache metrics: %w", err)
 	}
 
+	enrichmentClear, err := NewEnrichmentClearMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("enrichment clear metrics: %w", err)
+	}
+
 	return &Metrics{
-		Events:      events,
-		Webhooks:    webhooks,
-		Embeddings:  embeddings,
-		Translation: translation,
-		Sentiment:   sentiment,
-		Emotions:    emotions,
-		Cache:       cache,
+		Events:          events,
+		Webhooks:        webhooks,
+		Embeddings:      embeddings,
+		Translation:     translation,
+		Sentiment:       sentiment,
+		Emotions:        emotions,
+		Cache:           cache,
+		EnrichmentClear: enrichmentClear,
 	}, nil
 }

--- a/internal/observability/embeddings.go
+++ b/internal/observability/embeddings.go
@@ -2,10 +2,41 @@ package observability
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
 )
+
+// RegisterHNSWIterativeScanGauge registers an observable gauge that reports 1 when HNSW
+// iterative_scan has been latched off (the pgvector < 0.8 fallback — nearest-neighbor recall is
+// capped at ef_search until restart) and 0 otherwise. degraded is polled on each metric export.
+// No-op when meter or degraded is nil (metrics disabled). Register once, at startup.
+func RegisterHNSWIterativeScanGauge(meter metric.Meter, degraded func() bool) error {
+	if meter == nil || degraded == nil {
+		return nil
+	}
+
+	_, err := meter.Int64ObservableGauge(
+		MetricNameHNSWIterativeScanDegraded,
+		metric.WithDescription("1 when HNSW iterative_scan is latched off (pgvector < 0.8 fallback; recall capped at ef_search), else 0"),
+		metric.WithInt64Callback(func(_ context.Context, observer metric.Int64Observer) error {
+			var value int64
+			if degraded() {
+				value = 1
+			}
+
+			observer.Observe(value)
+
+			return nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("hnsw iterative scan gauge: %w", err)
+	}
+
+	return nil
+}
 
 // EmbeddingMetrics records embedding pipeline metrics (provider, worker).
 // Backed by the shared enrichmentMetrics implementation.

--- a/internal/observability/embeddings_test.go
+++ b/internal/observability/embeddings_test.go
@@ -1,0 +1,71 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewEmbeddingMetricsNilMeterDisabled(t *testing.T) {
+	metrics, err := NewEmbeddingMetrics(nil)
+	require.NoError(t, err)
+	assert.Nil(t, metrics, "a nil meter disables metrics")
+}
+
+// TestRegisterHNSWIterativeScanGauge verifies the observable gauge reports the latch state polled
+// from its callback: 0 while healthy, 1 once degraded. The callback is invoked on each collect, so
+// flipping the source between collects must change the reported value.
+func TestRegisterHNSWIterativeScanGauge(t *testing.T) {
+	t.Run("nil meter and nil callback are no-ops", func(t *testing.T) {
+		require.NoError(t, RegisterHNSWIterativeScanGauge(nil, func() bool { return true }))
+
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		require.NoError(t, RegisterHNSWIterativeScanGauge(provider.Meter("test"), nil))
+	})
+
+	t.Run("reports 0 when healthy and 1 when degraded", func(t *testing.T) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+		degraded := false
+
+		require.NoError(t, RegisterHNSWIterativeScanGauge(provider.Meter("test"), func() bool { return degraded }))
+
+		assert.Equal(t, int64(0), hnswGaugeValue(t, reader), "healthy latch reports 0")
+
+		degraded = true
+
+		assert.Equal(t, int64(1), hnswGaugeValue(t, reader), "latched-off scan reports 1")
+	})
+}
+
+// hnswGaugeValue collects metrics and returns the single data point of the iterative-scan gauge.
+func hnswGaugeValue(t *testing.T, reader sdkmetric.Reader) int64 {
+	t.Helper()
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+
+	for _, scope := range collected.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != MetricNameHNSWIterativeScanDegraded {
+				continue
+			}
+
+			gauge, ok := metric.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "expected Gauge[int64] for %s", MetricNameHNSWIterativeScanDegraded)
+			require.Len(t, gauge.DataPoints, 1)
+
+			return gauge.DataPoints[0].Value
+		}
+	}
+
+	t.Fatalf("gauge %q not found in collected metrics", MetricNameHNSWIterativeScanDegraded)
+
+	return 0
+}

--- a/internal/observability/enrichment_clear.go
+++ b/internal/observability/enrichment_clear.go
@@ -1,0 +1,49 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// EnrichmentClearMetrics counts enrichment outputs nulled by the eager-clear when a record's
+// value_text changes, labeled by output (sentiment, emotions, translation). It makes the clear
+// rate queryable — an output that clears but never re-enriches is the backfill-recovery case —
+// rather than only grep-able in logs.
+type EnrichmentClearMetrics interface {
+	RecordOutputCleared(ctx context.Context, output string)
+}
+
+// enrichmentClearMetrics implements EnrichmentClearMetrics.
+type enrichmentClearMetrics struct {
+	cleared metric.Int64Counter
+}
+
+// NewEnrichmentClearMetrics creates EnrichmentClearMetrics. Returns (nil, nil) when meter is nil (metrics disabled).
+func NewEnrichmentClearMetrics(meter metric.Meter) (EnrichmentClearMetrics, error) {
+	if meter == nil {
+		//nolint:nilnil // intentional: callers use "if metrics != nil" when metrics disabled
+		return nil, nil
+	}
+
+	cleared, err := meter.Int64Counter(
+		MetricNameEnrichmentOutputsCleared,
+		metric.WithDescription(
+			"Enrichment outputs nulled by an edit's eager-clear, labeled by output "+
+				"(sentiment, emotions, translation). A high clear rate with no matching re-enrichment "+
+				"points at backfill-recovery cases.",
+		),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create enrichment cleared counter: %w", err)
+	}
+
+	return &enrichmentClearMetrics{cleared: cleared}, nil
+}
+
+func (m *enrichmentClearMetrics) RecordOutputCleared(ctx context.Context, output string) {
+	m.cleared.Add(ctx, 1, metric.WithAttributes(attribute.String(AttrOutput, NormalizeClearedOutput(output))))
+}

--- a/internal/observability/enrichment_clear_test.go
+++ b/internal/observability/enrichment_clear_test.go
@@ -1,0 +1,43 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewEnrichmentClearMetricsNilMeterDisabled(t *testing.T) {
+	metrics, err := NewEnrichmentClearMetrics(nil)
+	require.NoError(t, err)
+	assert.Nil(t, metrics, "a nil meter disables metrics")
+}
+
+// TestEnrichmentClearMetricsRecords verifies the counter increments per cleared output and bounds
+// the output label to the known set (unknown collapses to "other").
+func TestEnrichmentClearMetricsRecords(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	metrics, err := NewEnrichmentClearMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
+
+	ctx := context.Background()
+	metrics.RecordOutputCleared(ctx, "sentiment")
+	metrics.RecordOutputCleared(ctx, "sentiment")
+	metrics.RecordOutputCleared(ctx, "emotions")
+	metrics.RecordOutputCleared(ctx, "translation")
+	metrics.RecordOutputCleared(ctx, "bogus") // unknown output -> normalized to "other"
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &collected))
+
+	assert.Equal(t, int64(2), counterValue(collected, MetricNameEnrichmentOutputsCleared, AttrOutput, "sentiment"))
+	assert.Equal(t, int64(1), counterValue(collected, MetricNameEnrichmentOutputsCleared, AttrOutput, "emotions"))
+	assert.Equal(t, int64(1), counterValue(collected, MetricNameEnrichmentOutputsCleared, AttrOutput, "translation"))
+	assert.Equal(t, int64(1), counterValue(collected, MetricNameEnrichmentOutputsCleared, AttrOutput, "other"))
+}

--- a/internal/observability/names.go
+++ b/internal/observability/names.go
@@ -7,18 +7,19 @@ import (
 
 // Metric names (OpenTelemetry).
 const (
-	MetricNameEventsDiscarded         = "hub_events_discarded_total"
-	MetricNameFanOutDuration          = "hub_message_publisher_fan_out_duration_seconds"
-	MetricNameEventChannelDepth       = "hub_event_channel_depth"
-	MetricNameRiverQueueDepth         = "hub_river_queue_depth"
-	MetricNameRiverQueueOldestAge     = "hub_river_queue_oldest_age_seconds"
-	MetricNameProviderPanics          = "hub_provider_panics_total"
-	MetricNameWebhookJobsEnqueued     = "hub_webhook_jobs_enqueued_total"
-	MetricNameWebhookProviderErrors   = "hub_webhook_provider_errors_total"
-	MetricNameWebhookDeliveries       = "hub_webhook_deliveries_total"
-	MetricNameWebhookDisabled         = "hub_webhook_disabled_total"
-	MetricNameWebhookDispatchErrors   = "hub_webhook_dispatch_errors_total"
-	MetricNameWebhookDeliveryDuration = "hub_webhook_delivery_duration_seconds"
+	MetricNameEventsDiscarded           = "hub_events_discarded_total"
+	MetricNameFanOutDuration            = "hub_message_publisher_fan_out_duration_seconds"
+	MetricNameEventChannelDepth         = "hub_event_channel_depth"
+	MetricNameRiverQueueDepth           = "hub_river_queue_depth"
+	MetricNameRiverQueueOldestAge       = "hub_river_queue_oldest_age_seconds"
+	MetricNameProviderPanics            = "hub_provider_panics_total"
+	MetricNameHNSWIterativeScanDegraded = "hub_hnsw_iterative_scan_degraded"
+	MetricNameWebhookJobsEnqueued       = "hub_webhook_jobs_enqueued_total"
+	MetricNameWebhookProviderErrors     = "hub_webhook_provider_errors_total"
+	MetricNameWebhookDeliveries         = "hub_webhook_deliveries_total"
+	MetricNameWebhookDisabled           = "hub_webhook_disabled_total"
+	MetricNameWebhookDispatchErrors     = "hub_webhook_dispatch_errors_total"
+	MetricNameWebhookDeliveryDuration   = "hub_webhook_delivery_duration_seconds"
 
 	// MetricNameEmbeddingJobsEnqueued and related embedding pipeline metrics.
 	MetricNameEmbeddingJobsEnqueued   = "hub_embedding_jobs_enqueued_total"

--- a/internal/observability/names.go
+++ b/internal/observability/names.go
@@ -14,6 +14,7 @@ const (
 	MetricNameRiverQueueOldestAge       = "hub_river_queue_oldest_age_seconds"
 	MetricNameProviderPanics            = "hub_provider_panics_total"
 	MetricNameHNSWIterativeScanDegraded = "hub_hnsw_iterative_scan_degraded"
+	MetricNameEnrichmentOutputsCleared  = "hub_enrichment_outputs_cleared_total"
 	MetricNameWebhookJobsEnqueued       = "hub_webhook_jobs_enqueued_total"
 	MetricNameWebhookProviderErrors     = "hub_webhook_provider_errors_total"
 	MetricNameWebhookDeliveries         = "hub_webhook_deliveries_total"
@@ -58,6 +59,9 @@ const (
 	AttrEventType = "event_type"
 	AttrReason    = "reason"
 	AttrStatus    = "status"
+	// AttrOutput labels the enrichment-cleared counter; values come from a fixed set
+	// (sentiment, emotions, translation), so cardinality is bounded.
+	AttrOutput = "output"
 	// AttrQueue labels the River queue-depth gauge; values come from the poller's fixed queue
 	// set, so cardinality is bounded.
 	AttrQueue = "queue"
@@ -277,6 +281,22 @@ func AllowedCacheName(name string) bool { return allowedCacheNames[name] }
 func NormalizeCacheName(name string) string {
 	if AllowedCacheName(name) {
 		return name
+	}
+
+	return "other"
+}
+
+// allowedClearedOutputs for hub_enrichment_outputs_cleared_total (bounded cardinality).
+var allowedClearedOutputs = map[string]bool{
+	"sentiment":   true,
+	"emotions":    true,
+	"translation": true,
+}
+
+// NormalizeClearedOutput bounds the enrichment-cleared output label; unknown values collapse to "other".
+func NormalizeClearedOutput(output string) string {
+	if allowedClearedOutputs[output] {
+		return output
 	}
 
 	return "other"

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -52,6 +52,14 @@ func NewEmbeddingsRepository(db *pgxpool.Pool) *EmbeddingsRepository {
 	return &EmbeddingsRepository{db: db}
 }
 
+// IterativeScanDegraded reports whether HNSW iterative_scan has been latched off after the server
+// rejected it (pgvector < 0.8). While true, nearest-neighbor recall is capped at ef_search until
+// the process restarts. Surfaced as a gauge so the silent degradation is alertable, not just a
+// one-time log line.
+func (r *EmbeddingsRepository) IterativeScanDegraded() bool {
+	return r.iterativeScanUnavailable.Load()
+}
+
 // rollbackQuietly rolls back tx, logging (rather than returning) an unexpected rollback error.
 func rollbackQuietly(ctx context.Context, tx pgx.Tx, msg string) {
 	if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -322,7 +322,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbedding(
 	if excludeID == nil {
 		rows, err = dbTx.Query(ctx, `
 			SELECT e.feedback_record_id, (e.embedding <=> $1) AS distance,
-				(1 - (e.embedding <=> $1)) AS score, COALESCE(fr.field_label, ''), fr.value_text
+				COALESCE(fr.field_label, ''), fr.value_text
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3
@@ -331,7 +331,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbedding(
 	} else {
 		rows, err = dbTx.Query(ctx, `
 			SELECT e.feedback_record_id, (e.embedding <=> $1) AS distance,
-				(1 - (e.embedding <=> $1)) AS score, COALESCE(fr.field_label, ''), fr.value_text
+				COALESCE(fr.field_label, ''), fr.value_text
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3 AND e.feedback_record_id != $4
@@ -359,13 +359,17 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbedding(
 			row       models.FeedbackRecordWithScore
 			valueText *string
 		)
-		if err := rows.Scan(&row.FeedbackRecordID, &row.Distance, &row.Score, &row.FieldLabel, &valueText); err != nil {
+		if err := rows.Scan(&row.FeedbackRecordID, &row.Distance, &row.FieldLabel, &valueText); err != nil {
 			return nil, false, fmt.Errorf("scan feedback record with score: %w", err)
 		}
 
 		if valueText != nil {
 			row.ValueText = *valueText
 		}
+
+		// Derive the display score in Go rather than in SQL: computing it there evaluated the
+		// <=> distance operator a second time per row. Distance is what the query orders/cursors by.
+		row.Score = 1 - row.Distance
 
 		if row.Score >= minScore {
 			results = append(results, row)
@@ -423,7 +427,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbeddingAfterCursor(
 	if excludeID == nil {
 		rows, err = dbTx.Query(ctx, `
 			SELECT e.feedback_record_id, (e.embedding <=> $1) AS distance,
-				(1 - (e.embedding <=> $1)) AS score, COALESCE(fr.field_label, ''), fr.value_text
+				COALESCE(fr.field_label, ''), fr.value_text
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3
@@ -433,7 +437,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbeddingAfterCursor(
 	} else {
 		rows, err = dbTx.Query(ctx, `
 			SELECT e.feedback_record_id, (e.embedding <=> $1) AS distance,
-				(1 - (e.embedding <=> $1)) AS score, COALESCE(fr.field_label, ''), fr.value_text
+				COALESCE(fr.field_label, ''), fr.value_text
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3 AND e.feedback_record_id != $4
@@ -462,13 +466,17 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbeddingAfterCursor(
 			row       models.FeedbackRecordWithScore
 			valueText *string
 		)
-		if err := rows.Scan(&row.FeedbackRecordID, &row.Distance, &row.Score, &row.FieldLabel, &valueText); err != nil {
+		if err := rows.Scan(&row.FeedbackRecordID, &row.Distance, &row.FieldLabel, &valueText); err != nil {
 			return nil, false, fmt.Errorf("scan feedback record with score: %w", err)
 		}
 
 		if valueText != nil {
 			row.ValueText = *valueText
 		}
+
+		// Derive the display score in Go rather than in SQL: computing it there evaluated the
+		// <=> distance operator a second time per row. Distance is what the query orders/cursors by.
+		row.Score = 1 - row.Distance
 
 		if row.Score >= minScore {
 			results = append(results, row)

--- a/internal/service/embedding_job_args.go
+++ b/internal/service/embedding_job_args.go
@@ -17,6 +17,9 @@ const (
 // get a new job when value_text changes; same content within 24h is deduped; one job per record+model.
 type FeedbackEmbeddingArgs struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id" river:"unique"`
+	// EventID correlates this job to the domain event that enqueued it (uuid.Nil for backfill
+	// jobs, which have no originating event). Not part of the dedupe key — observability only.
+	EventID uuid.UUID `json:"event_id"`
 	// Model is the embedding model name; stored in embeddings.model.
 	Model string `json:"model" river:"unique"`
 	// ValueTextHash is a hash of the input (trimmed value_text, or "empty"/"backfill") for dedupe semantics.

--- a/internal/service/embedding_provider.go
+++ b/internal/service/embedding_provider.go
@@ -99,6 +99,7 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 
 	_, err := p.inserter.Insert(ctx, FeedbackEmbeddingArgs{
 		FeedbackRecordID: record.ID,
+		EventID:          event.ID,
 		Model:            p.model,
 		ValueTextHash:    valueTextHash,
 	}, opts)

--- a/internal/service/embedding_provider.go
+++ b/internal/service/embedding_provider.go
@@ -80,7 +80,7 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 
 	// On create, only enqueue when there is embeddable text. On update we enqueue regardless so the worker can clear.
 	if event.Type == datatypes.FeedbackRecordCreated && input == "" {
-		slog.Debug("embedding: skip, no value_text on create", "feedback_record_id", record.ID)
+		slog.Debug("embedding: skip, no value_text on create", "event_id", event.ID, "feedback_record_id", record.ID)
 
 		return
 	}

--- a/internal/service/embedding_provider.go
+++ b/internal/service/embedding_provider.go
@@ -74,15 +74,18 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 		return
 	}
 
+	// Build the embedding input once and reuse it for both the create-time empty check and the
+	// dedupe hash; it was otherwise computed twice on the create path.
+	input := BuildEmbeddingInput(record.FieldLabel, record.ValueText, p.docPrefix)
+
 	// On create, only enqueue when there is embeddable text. On update we enqueue regardless so the worker can clear.
-	if event.Type == datatypes.FeedbackRecordCreated &&
-		BuildEmbeddingInput(record.FieldLabel, record.ValueText, p.docPrefix) == "" {
+	if event.Type == datatypes.FeedbackRecordCreated && input == "" {
 		slog.Debug("embedding: skip, no value_text on create", "feedback_record_id", record.ID)
 
 		return
 	}
 
-	valueTextHash := embeddingValueTextHash(record.FieldLabel, record.ValueText, p.docPrefix)
+	valueTextHash := hashContent(input)
 
 	// Deliberately no UniqueOpts on the event path — mirrors the classify providers: River's
 	// completed-state dedupe swallowed the re-embed after content transitioned away and back
@@ -186,10 +189,4 @@ func BuildEmbeddingInput(fieldLabel, valueText *string, prefix string) string {
 	builder.WriteString(val)
 
 	return builder.String()
-}
-
-// embeddingValueTextHash returns a hash of the embedding input for dedupe (same content => same job within window).
-// Uses BuildEmbeddingInput; empty content returns "empty".
-func embeddingValueTextHash(fieldLabel, valueText *string, prefix string) string {
-	return hashContent(BuildEmbeddingInput(fieldLabel, valueText, prefix))
 }

--- a/internal/service/embedding_provider_test.go
+++ b/internal/service/embedding_provider_test.go
@@ -66,6 +66,7 @@ func TestEmbeddingProvider_PublishEvent_FeedbackRecordCreated_withValueText_enqu
 
 	require.Len(t, inserter.insertCalls, 1)
 	assert.Equal(t, recordID, inserter.insertCalls[0].args.FeedbackRecordID)
+	assert.Equal(t, event.ID, inserter.insertCalls[0].args.EventID, "event id is carried into the job args")
 	assert.Equal(t, "model-name", inserter.insertCalls[0].args.Model)
 	assert.NotEmpty(t, inserter.insertCalls[0].args.ValueTextHash, "dedupe key should include input hash")
 	assert.NotNil(t, inserter.insertCalls[0].opts)

--- a/internal/service/emotions_job_args.go
+++ b/internal/service/emotions_job_args.go
@@ -21,6 +21,9 @@ const (
 // are classified directly from the text, independent of language.
 type FeedbackEmotionsArgs struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id" river:"unique"`
+	// EventID correlates this job to the domain event that enqueued it (uuid.Nil for backfill
+	// jobs, which have no originating event). Not part of the dedupe key — observability only.
+	EventID uuid.UUID `json:"event_id"`
 	// ValueTextHash is a hash of the normalized value_text, or "empty" when value_text is blank.
 	ValueTextHash string `json:"value_text_hash" river:"unique"`
 }

--- a/internal/service/emotions_provider.go
+++ b/internal/service/emotions_provider.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 
 	"github.com/formbricks/hub/internal/models"
@@ -41,7 +42,7 @@ func NewEmotionsProvider(
 			hasContent:              (*models.FeedbackRecord).HasOpenText,
 			gated:                   true,
 			failOpenOnSettingsError: true,
-			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings) (river.JobArgs, bool) {
+			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings, eventID uuid.UUID) (river.JobArgs, bool) {
 				// Per-directory gate: skip tenants that switched emotion enrichment off. settings is
 				// nil when the read failed and we are failing open — enqueue and let the worker
 				// re-check the gate (the authoritative check before the LLM call).
@@ -51,6 +52,7 @@ func NewEmotionsProvider(
 
 				return FeedbackEmotionsArgs{
 					FeedbackRecordID: record.ID,
+					EventID:          eventID,
 					ValueTextHash:    emotionsContentHash(record.ValueText),
 				}, true
 			},

--- a/internal/service/emotions_provider_test.go
+++ b/internal/service/emotions_provider_test.go
@@ -47,15 +47,17 @@ func TestEmotionsProvider_PublishEvent_Created_withText_enqueues(t *testing.T) {
 	provider := NewEmotionsProvider(inserter, stubSettingsResolver{}, EmotionsQueueName, 3, nil)
 
 	recordID := uuid.Must(uuid.NewV7())
+	eventID := uuid.Must(uuid.NewV7())
 	text := "I am thrilled and a little scared"
 	provider.PublishEvent(context.Background(), Event{
-		ID:   uuid.Must(uuid.NewV7()),
+		ID:   eventID,
 		Type: datatypes.FeedbackRecordCreated,
 		Data: emotionsTextRecord(recordID, &text),
 	})
 
 	require.Len(t, inserter.calls, 1)
 	assert.Equal(t, recordID, inserter.calls[0].args.FeedbackRecordID)
+	assert.Equal(t, eventID, inserter.calls[0].args.EventID, "event id is carried into the job args")
 	assert.NotEmpty(t, inserter.calls[0].args.ValueTextHash)
 	assert.NotEqual(t, "empty", inserter.calls[0].args.ValueTextHash)
 	assert.Equal(t, EmotionsQueueName, inserter.calls[0].opts.Queue)

--- a/internal/service/enrichment_provider.go
+++ b/internal/service/enrichment_provider.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 
 	"github.com/formbricks/hub/internal/datatypes"
@@ -52,7 +53,7 @@ type enrichmentProviderConfig struct {
 	// enrichment is disabled for the tenant, or has no resolvable target. Folding the per-tenant
 	// gate, the dedupe hash, and the args into one hook lets a settings-derived value (e.g.
 	// translation's target language) be resolved exactly once.
-	buildArgs func(record *models.FeedbackRecord, settings *models.TenantSettings) (river.JobArgs, bool)
+	buildArgs func(record *models.FeedbackRecord, settings *models.TenantSettings, eventID uuid.UUID) (river.JobArgs, bool)
 }
 
 // enrichmentProvider implements eventPublisher by enqueueing one enrichment job per eligible
@@ -156,7 +157,7 @@ func (p *enrichmentProvider) PublishEvent(ctx context.Context, event Event) {
 	// enrichment which is now disabled skips even the empty-content clear above — a stale result is
 	// left until the enrichment is re-enabled (this preserves the pre-refactor gate-before-enqueue
 	// behavior).
-	args, enqueue := cfg.buildArgs(record, settings)
+	args, enqueue := cfg.buildArgs(record, settings, event.ID)
 	if !enqueue {
 		slog.Debug(cfg.name+": skip, not enabled for tenant", "feedback_record_id", record.ID)
 

--- a/internal/service/enrichment_provider.go
+++ b/internal/service/enrichment_provider.go
@@ -159,7 +159,7 @@ func (p *enrichmentProvider) PublishEvent(ctx context.Context, event Event) {
 	// behavior).
 	args, enqueue := cfg.buildArgs(record, settings, event.ID)
 	if !enqueue {
-		slog.Debug(cfg.name+": skip, not enabled for tenant", "feedback_record_id", record.ID)
+		slog.Debug(cfg.name+": skip, not enabled for tenant", "event_id", event.ID, "feedback_record_id", record.ID)
 
 		return
 	}

--- a/internal/service/enrichment_provider_test.go
+++ b/internal/service/enrichment_provider_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
 
@@ -14,7 +15,9 @@ import (
 // enrichment must have a resolver. All are enforced fail-fast at construction.
 func TestNewEnrichmentProvider_ValidatesConfig(t *testing.T) {
 	hasContent := func(*models.FeedbackRecord) bool { return true }
-	buildArgs := func(*models.FeedbackRecord, *models.TenantSettings) (river.JobArgs, bool) { return nil, false }
+	buildArgs := func(*models.FeedbackRecord, *models.TenantSettings, uuid.UUID) (river.JobArgs, bool) {
+		return nil, false
+	}
 
 	require.Panics(t, func() {
 		newEnrichmentProvider(enrichmentProviderConfig{name: "test", buildArgs: buildArgs})

--- a/internal/service/feedback_records_service.go
+++ b/internal/service/feedback_records_service.go
@@ -85,6 +85,13 @@ type EmbeddingsRepository interface {
 	) ([]uuid.UUID, error)
 }
 
+// EnrichmentClearMetrics records enrichment outputs nulled by an edit's eager-clear, labeled by
+// output. Optional: nil disables it; set via SetEnrichmentClearMetrics (the clear fires only on
+// the API's UpdateFeedbackRecord path).
+type EnrichmentClearMetrics interface {
+	RecordOutputCleared(ctx context.Context, output string)
+}
+
 // FeedbackRecordsService handles business logic for feedback records.
 type FeedbackRecordsService struct {
 	repo                   FeedbackRecordsRepository
@@ -95,6 +102,7 @@ type FeedbackRecordsService struct {
 	embeddingQueueName     string
 	embeddingMaxAttempts   int
 	translationDefaultLang string
+	clearMetrics           EnrichmentClearMetrics
 }
 
 // NewFeedbackRecordsService creates a new feedback records service.
@@ -131,6 +139,12 @@ func NewFeedbackRecordsService(
 // This allows a single service instance to be used by both handlers and the embedding worker.
 func (s *FeedbackRecordsService) SetEmbeddingInserter(inserter RiverJobInserter) {
 	s.embeddingInserter = inserter
+}
+
+// SetEnrichmentClearMetrics enables the eager-clear counter. Wire it on the API service instance
+// (the eager-clear fires on UpdateFeedbackRecord); leaving it unset disables the metric.
+func (s *FeedbackRecordsService) SetEnrichmentClearMetrics(m EnrichmentClearMetrics) {
+	s.clearMetrics = m
 }
 
 // CreateFeedbackRecord creates a new feedback record.
@@ -346,6 +360,12 @@ func (s *FeedbackRecordsService) UpdateFeedbackRecord(
 	if cleared := clearedEnrichmentFields(previous, record); len(cleared) > 0 {
 		slog.Info("update feedback record: enrichment outputs cleared by content edit",
 			"feedback_record_id", id, "tenant_id", record.TenantID, "cleared", cleared)
+
+		if s.clearMetrics != nil {
+			for _, output := range cleared {
+				s.clearMetrics.RecordOutputCleared(ctx, output)
+			}
+		}
 	}
 
 	return record, nil

--- a/internal/service/feedback_records_service_test.go
+++ b/internal/service/feedback_records_service_test.go
@@ -16,6 +16,7 @@ import (
 
 type mockFeedbackRecordsRepo struct {
 	record                     *models.FeedbackRecord
+	previousRecord             *models.FeedbackRecord // pre-update row Update returns; falls back to record when nil
 	createReq                  *models.CreateFeedbackRecordRequest
 	deleteByUserGroups         []models.DeletedFeedbackRecordsByTenant
 	deletedID                  uuid.UUID
@@ -70,7 +71,12 @@ func (m *mockFeedbackRecordsRepo) Update(
 	_ context.Context, _ uuid.UUID, _ *models.UpdateFeedbackRecordRequest,
 ) (*models.FeedbackRecord, *models.FeedbackRecord, error) {
 	if m.record != nil {
-		return m.record, m.record, nil
+		previous := m.record
+		if m.previousRecord != nil {
+			previous = m.previousRecord
+		}
+
+		return m.record, previous, nil
 	}
 
 	return nil, nil, errors.New("not implemented")
@@ -795,6 +801,41 @@ func TestFeedbackRecordsService_UpdateFeedbackRecord_RealChangePublishesChangedF
 
 	if len(publisher.changedFields) != 1 || publisher.changedFields[0] != "value_text" {
 		t.Fatalf("changedFields = %v, want [value_text] (only what actually changed)", publisher.changedFields)
+	}
+}
+
+type mockClearMetrics struct{ cleared []string }
+
+func (m *mockClearMetrics) RecordOutputCleared(_ context.Context, output string) {
+	m.cleared = append(m.cleared, output)
+}
+
+// TestFeedbackRecordsService_UpdateFeedbackRecord_RecordsClearedEnrichmentMetric locks that a
+// value_text edit which nulls a derived output records the eager-clear counter for that output.
+func TestFeedbackRecordsService_UpdateFeedbackRecord_RecordsClearedEnrichmentMetric(t *testing.T) {
+	newText := "brand new text"
+	sentiment := models.SentimentPositive
+	score := 0.8
+
+	// updated row: sentiment cleared; previous row: sentiment was set → eager-clear nulled it.
+	updated := &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeText, ValueText: &newText}
+	previous := &models.FeedbackRecord{
+		ID: updated.ID, FieldType: models.FieldTypeText, ValueText: &newText,
+		Sentiment: &sentiment, SentimentScore: &score,
+	}
+
+	repo := &mockFeedbackRecordsRepo{record: updated, previousRecord: previous}
+	clearMetrics := &mockClearMetrics{}
+	svc := NewFeedbackRecordsService(repo, nil, "", nil, nil, "", 0, "")
+	svc.SetEnrichmentClearMetrics(clearMetrics)
+
+	_, err := svc.UpdateFeedbackRecord(context.Background(), updated.ID, &models.UpdateFeedbackRecordRequest{ValueText: &newText})
+	if err != nil {
+		t.Fatalf("UpdateFeedbackRecord() error = %v", err)
+	}
+
+	if len(clearMetrics.cleared) != 1 || clearMetrics.cleared[0] != "sentiment" {
+		t.Fatalf("cleared outputs recorded = %v, want [sentiment]", clearMetrics.cleared)
 	}
 }
 

--- a/internal/service/sentiment_job_args.go
+++ b/internal/service/sentiment_job_args.go
@@ -20,6 +20,9 @@ const (
 // classified directly from the text, independent of language.
 type FeedbackSentimentArgs struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id" river:"unique"`
+	// EventID correlates this job to the domain event that enqueued it (uuid.Nil for backfill
+	// jobs, which have no originating event). Not part of the dedupe key — observability only.
+	EventID uuid.UUID `json:"event_id"`
 	// ValueTextHash is a hash of the normalized value_text, or "empty" when value_text is blank.
 	ValueTextHash string `json:"value_text_hash" river:"unique"`
 }

--- a/internal/service/sentiment_provider.go
+++ b/internal/service/sentiment_provider.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 
 	"github.com/formbricks/hub/internal/models"
@@ -41,7 +42,7 @@ func NewSentimentProvider(
 			hasContent:              (*models.FeedbackRecord).HasOpenText,
 			gated:                   true,
 			failOpenOnSettingsError: true,
-			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings) (river.JobArgs, bool) {
+			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings, eventID uuid.UUID) (river.JobArgs, bool) {
 				// Per-directory gate: skip tenants that switched sentiment enrichment off. settings is
 				// nil when the read failed and we are failing open — enqueue and let the worker
 				// re-check the gate (the authoritative check before the LLM call).
@@ -51,6 +52,7 @@ func NewSentimentProvider(
 
 				return FeedbackSentimentArgs{
 					FeedbackRecordID: record.ID,
+					EventID:          eventID,
 					ValueTextHash:    sentimentContentHash(record.ValueText),
 				}, true
 			},

--- a/internal/service/sentiment_provider_test.go
+++ b/internal/service/sentiment_provider_test.go
@@ -47,15 +47,17 @@ func TestSentimentProvider_PublishEvent_Created_withText_enqueues(t *testing.T) 
 	provider := NewSentimentProvider(inserter, stubSettingsResolver{}, SentimentsQueueName, 3, nil)
 
 	recordID := uuid.Must(uuid.NewV7())
+	eventID := uuid.Must(uuid.NewV7())
 	text := "Great product"
 	provider.PublishEvent(context.Background(), Event{
-		ID:   uuid.Must(uuid.NewV7()),
+		ID:   eventID,
 		Type: datatypes.FeedbackRecordCreated,
 		Data: sentimentTextRecord(recordID, &text),
 	})
 
 	require.Len(t, inserter.calls, 1)
 	assert.Equal(t, recordID, inserter.calls[0].args.FeedbackRecordID)
+	assert.Equal(t, eventID, inserter.calls[0].args.EventID, "event id is carried into the job args")
 	assert.NotEmpty(t, inserter.calls[0].args.ValueTextHash)
 	assert.NotEqual(t, "empty", inserter.calls[0].args.ValueTextHash)
 	assert.Equal(t, SentimentsQueueName, inserter.calls[0].opts.Queue)

--- a/internal/service/translation_job_args.go
+++ b/internal/service/translation_job_args.go
@@ -17,6 +17,9 @@ const (
 // new job, while identical content for the same target within the window is deduped.
 type FeedbackTranslationArgs struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id" river:"unique"`
+	// EventID correlates this job to the domain event that enqueued it (uuid.Nil for backfill
+	// jobs, which have no originating event). Not part of the dedupe key — observability only.
+	EventID uuid.UUID `json:"event_id"`
 	// TargetLang is the tenant's configured target language (BCP-47) at enqueue time.
 	TargetLang string `json:"target_lang" river:"unique"`
 	// ValueTextHash is a hash of the inputs that determine the translation — the

--- a/internal/service/translation_provider.go
+++ b/internal/service/translation_provider.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 
 	"github.com/formbricks/hub/internal/models"
@@ -52,7 +53,7 @@ func NewTranslationProvider(
 			eligible:   (*models.FeedbackRecord).IsTextField,
 			hasContent: (*models.FeedbackRecord).HasOpenText,
 			gated:      true,
-			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings) (river.JobArgs, bool) {
+			buildArgs: func(record *models.FeedbackRecord, settings *models.TenantSettings, eventID uuid.UUID) (river.JobArgs, bool) {
 				// Gate on a resolvable target language (resolved once, then reused in the args):
 				// the tenant's own target wins, else the configured default; an empty result keeps
 				// translation per-tenant opt-in (skip).
@@ -68,6 +69,7 @@ func NewTranslationProvider(
 
 				return FeedbackTranslationArgs{
 					FeedbackRecordID: record.ID,
+					EventID:          eventID,
 					TargetLang:       target,
 					ValueTextHash:    translationContentHash(record.ValueText, sourceLang),
 				}, true

--- a/internal/service/translation_provider_test.go
+++ b/internal/service/translation_provider_test.go
@@ -137,7 +137,9 @@ func TestTranslationProvider_UpdateWithValueTextChangeEnqueues(t *testing.T) {
 	inserter := &mockTranslationInserter{}
 	provider := newTestTranslationProvider(inserter, "de-DE", nil)
 
+	eventID := uuid.Must(uuid.NewV7())
 	provider.PublishEvent(context.Background(), Event{
+		ID:            eventID,
 		Type:          datatypes.FeedbackRecordUpdated,
 		Data:          textRecord("hi"),
 		ChangedFields: []string{"value_text"},
@@ -145,6 +147,10 @@ func TestTranslationProvider_UpdateWithValueTextChangeEnqueues(t *testing.T) {
 
 	if len(inserter.calls) != 1 {
 		t.Fatalf("enqueued %d jobs, want 1", len(inserter.calls))
+	}
+
+	if inserter.calls[0].EventID != eventID {
+		t.Fatalf("EventID = %v, want %v (event id carried into the job args)", inserter.calls[0].EventID, eventID)
 	}
 }
 

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -46,7 +46,10 @@ type enrichmentWorkerConfig[A river.JobArgs, R any] struct {
 	name    string // enrichment name, for log messages
 	timeout time.Duration
 
-	recordID   func(args A) uuid.UUID
+	recordID func(args A) uuid.UUID
+	// eventID, when set, adds the originating event id to every Work log line for correlation.
+	// nil ⇒ omitted (e.g. ungated/backfill-only paths).
+	eventID    func(args A) uuid.UUID
 	getRecord  func(ctx context.Context, id uuid.UUID) (*models.FeedbackRecord, error)
 	eligible   func(record *models.FeedbackRecord) bool // nil ⇒ always eligible
 	hasContent func(record *models.FeedbackRecord) bool
@@ -133,13 +136,18 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 	start := time.Now()
 	id := cfg.recordID(job.Args)
 
+	log := slog.With("feedback_record_id", id)
+	if cfg.eventID != nil {
+		log = log.With("event_id", cfg.eventID(job.Args))
+	}
+
 	record, err := cfg.getRecord(ctx, id)
 	if err != nil {
 		// Not-found means the record was deleted or its tenant purged between enqueue and now: a
 		// benign race, recorded as skipped so it does not trip failure alerts.
 		if errors.Is(err, huberrors.ErrNotFound) {
 			w.recordOutcome(ctx, "skipped", start)
-			slog.Info(cfg.name+": record gone before classify, skipping", "feedback_record_id", id)
+			log.Info(cfg.name + ": record gone before classify, skipping")
 
 			return nil
 		}
@@ -152,15 +160,15 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 
 		cfg.metrics.workerError(ctx, "get_record_failed")
 		w.recordOutcome(ctx, outcome, start)
-		slog.Error(cfg.name+": get record failed",
-			"feedback_record_id", id, "final_attempt", isLastAttempt, "error", err)
+		log.Error(cfg.name+": get record failed",
+			"final_attempt", isLastAttempt, "error", err)
 
 		return err // the getRecord hook (service) already wraps this context
 	}
 
 	if cfg.eligible != nil && !cfg.eligible(record) {
 		w.recordOutcome(ctx, "skipped", start)
-		slog.Info(cfg.name+": skipped, record not eligible", "feedback_record_id", id, "tenant_id", record.TenantID)
+		log.Info(cfg.name+": skipped, record not eligible", "tenant_id", record.TenantID)
 
 		return nil
 	}
@@ -176,15 +184,15 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 
 			cfg.metrics.workerError(ctx, "settings_read_failed")
 			w.recordOutcome(ctx, outcome, start)
-			slog.Error(cfg.name+": resolve tenant settings failed",
-				"feedback_record_id", id, "final_attempt", isLastAttempt, "error", err)
+			log.Error(cfg.name+": resolve tenant settings failed",
+				"final_attempt", isLastAttempt, "error", err)
 
 			return fmt.Errorf("resolve tenant settings: %w", err)
 		}
 
 		if !enabled {
 			w.recordOutcome(ctx, "skipped", start)
-			slog.Info(cfg.name+": skipped, disabled for tenant", "feedback_record_id", id, "tenant_id", record.TenantID)
+			log.Info(cfg.name+": skipped, disabled for tenant", "tenant_id", record.TenantID)
 
 			return nil
 		}
@@ -194,32 +202,32 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 	// than classify empty text.
 	if !cfg.hasContent(record) {
 		if err := cfg.persist(ctx, record, job.Args, nil); err != nil {
-			return w.handlePersistError(ctx, err, id, start, job.Attempt >= job.MaxAttempts)
+			return w.handlePersistError(ctx, err, log, start, job.Attempt >= job.MaxAttempts)
 		}
 
 		w.recordOutcome(ctx, "success", start)
-		slog.Info(cfg.name+": cleared (empty content)", "feedback_record_id", id, "tenant_id", record.TenantID)
+		log.Info(cfg.name+": cleared (empty content)", "tenant_id", record.TenantID)
 
 		return nil
 	}
 
 	result, err := cfg.classify(ctx, record, job.Args)
 	if err != nil {
-		return w.handleClassifyError(ctx, err, id, start, job)
+		return w.handleClassifyError(ctx, err, log, start, job)
 	}
 
 	if err := cfg.persist(ctx, record, job.Args, &result); err != nil {
-		return w.handlePersistError(ctx, err, id, start, job.Attempt >= job.MaxAttempts)
+		return w.handlePersistError(ctx, err, log, start, job.Attempt >= job.MaxAttempts)
 	}
 
 	w.recordOutcome(ctx, "success", start)
 
-	attrs := []any{"feedback_record_id", id, "tenant_id", record.TenantID}
+	attrs := []any{"tenant_id", record.TenantID}
 	if cfg.logResult != nil {
 		attrs = append(attrs, cfg.logResult(result)...)
 	}
 
-	slog.Info(cfg.name+": stored", attrs...)
+	log.Info(cfg.name+": stored", attrs...)
 
 	return nil
 }
@@ -228,7 +236,7 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 // snoozes (re-queues without consuming an attempt, so a burst defers rather than drops work); any
 // other error retries until the attempts are spent, then fails.
 func (w *enrichmentWorker[A, R]) handleClassifyError(
-	ctx context.Context, err error, id uuid.UUID, start time.Time, job *river.Job[A],
+	ctx context.Context, err error, log *slog.Logger, start time.Time, job *river.Job[A],
 ) error {
 	cfg := w.cfg
 
@@ -236,8 +244,8 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 		if delay, ok := rateLimitSnoozeDelay(err, job.CreatedAt); ok {
 			cfg.metrics.workerError(ctx, "rate_limited")
 			w.recordOutcome(ctx, "retry", start)
-			slog.Warn(cfg.name+": provider rate-limited, snoozing",
-				"feedback_record_id", id, "retry_after", delay.String())
+			log.Warn(cfg.name+": provider rate-limited, snoozing",
+				"retry_after", delay.String())
 
 			//nolint:wrapcheck // river sentinel: JobSnooze must be returned unwrapped for River to detect the snooze
 			return river.JobSnooze(delay)
@@ -250,7 +258,7 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 
 	if isLastAttempt {
 		w.recordOutcome(ctx, "failed_final", start)
-		slog.Error(cfg.name+": provider failed (final attempt)", "feedback_record_id", id, "error", err)
+		log.Error(cfg.name+": provider failed (final attempt)", "error", err)
 
 		return fmt.Errorf("%s (final attempt): %w", cfg.classifyErrVerb, err)
 	}
@@ -264,14 +272,14 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 // completes the job (nothing to write), a tenant write conflict retries (the post-purge attempt
 // finds the record gone), and anything else fails the job.
 func (w *enrichmentWorker[A, R]) handlePersistError(
-	ctx context.Context, err error, id uuid.UUID, start time.Time, isLastAttempt bool,
+	ctx context.Context, err error, log *slog.Logger, start time.Time, isLastAttempt bool,
 ) error {
 	cfg := w.cfg
 
 	switch {
 	case errors.Is(err, huberrors.ErrNotFound):
 		w.recordOutcome(ctx, "skipped", start)
-		slog.Info(cfg.name+": record gone before write, skipping", "feedback_record_id", id)
+		log.Info(cfg.name + ": record gone before write, skipping")
 
 		return nil
 	case cfg.isSuperseded != nil && cfg.isSuperseded(err):
@@ -280,7 +288,7 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 		}
 
 		w.recordOutcome(ctx, "skipped", start)
-		slog.Info(cfg.name+": result superseded, skipping", "feedback_record_id", id)
+		log.Info(cfg.name + ": result superseded, skipping")
 
 		return nil
 	case errors.Is(err, huberrors.ErrTenantWriteConflict):
@@ -288,8 +296,8 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 
 		cfg.metrics.workerError(ctx, "tenant_write_conflict")
 		w.recordOutcome(ctx, outcome, start)
-		slog.Warn(cfg.name+": tenant data purge in progress, deferring write",
-			"feedback_record_id", id, "final_attempt", isLastAttempt)
+		log.Warn(cfg.name+": tenant data purge in progress, deferring write",
+			"final_attempt", isLastAttempt)
 
 		return err // the persist hook (service Set*) already wraps this context
 	default:
@@ -302,8 +310,8 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 
 		cfg.metrics.workerError(ctx, "update_failed")
 		w.recordOutcome(ctx, outcome, start)
-		slog.Error(cfg.name+": set result failed",
-			"feedback_record_id", id, "final_attempt", isLastAttempt, "error", err)
+		log.Error(cfg.name+": set result failed",
+			"final_attempt", isLastAttempt, "error", err)
 
 		return err // the persist hook (service Set*) already wraps this context
 	}

--- a/internal/workers/feedback_embedding.go
+++ b/internal/workers/feedback_embedding.go
@@ -76,6 +76,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 
 			slog.Info("embedding: record gone before embed, skipping",
 				"feedback_record_id", args.FeedbackRecordID,
+				"event_id", args.EventID,
 			)
 
 			return nil
@@ -99,6 +100,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 
 		slog.Error("embedding: get record failed",
 			"feedback_record_id", args.FeedbackRecordID,
+			"event_id", args.EventID,
 			"final_attempt", isLastAttempt,
 			"error", err,
 		)
@@ -134,6 +136,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 
 	slog.Info("embedding: stored",
 		"feedback_record_id", args.FeedbackRecordID,
+		"event_id", args.EventID,
 	)
 
 	if w.metrics != nil {

--- a/internal/workers/feedback_embedding.go
+++ b/internal/workers/feedback_embedding.go
@@ -63,6 +63,8 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 	args := job.Args
 	start := time.Now()
 
+	log := slog.With("feedback_record_id", args.FeedbackRecordID, "event_id", args.EventID)
+
 	record, err := w.embeddingService.GetFeedbackRecord(ctx, args.FeedbackRecordID)
 	if err != nil {
 		// Not-found means the record was deleted or its tenant purged between enqueue and
@@ -74,10 +76,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 				w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "skipped")
 			}
 
-			slog.Info("embedding: record gone before embed, skipping",
-				"feedback_record_id", args.FeedbackRecordID,
-				"event_id", args.EventID,
-			)
+			log.Info("embedding: record gone before embed, skipping")
 
 			return nil
 		}
@@ -98,9 +97,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), outcome)
 		}
 
-		slog.Error("embedding: get record failed",
-			"feedback_record_id", args.FeedbackRecordID,
-			"event_id", args.EventID,
+		log.Error("embedding: get record failed",
 			"final_attempt", isLastAttempt,
 			"error", err,
 		)
@@ -119,25 +116,22 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 	}
 
 	if text == "" {
-		return w.handleEmptyText(ctx, job, record, start, stillCurrent)
+		return w.handleEmptyText(ctx, job, record, log, start, stillCurrent)
 	}
 
 	embedding, err := w.embeddingClient.CreateEmbedding(ctx, text)
 	if err != nil {
-		return w.handleEmbedError(ctx, err, job, start)
+		return w.handleEmbedError(ctx, err, job, log, start)
 	}
 
 	err = w.embeddingService.SetEmbedding(ctx, args.FeedbackRecordID, args.Model, embedding, stillCurrent)
 	if err != nil {
 		isLastAttempt := job.Attempt >= job.MaxAttempts
 
-		return w.handleSetEmbeddingError(ctx, err, args.FeedbackRecordID, start, isLastAttempt, "set feedback record embedding")
+		return w.handleSetEmbeddingError(ctx, err, log, start, isLastAttempt, "set feedback record embedding")
 	}
 
-	slog.Info("embedding: stored",
-		"feedback_record_id", args.FeedbackRecordID,
-		"event_id", args.EventID,
-	)
+	log.Info("embedding: stored")
 
 	if w.metrics != nil {
 		w.metrics.RecordEmbeddingOutcome(ctx, "success")
@@ -152,7 +146,7 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 // jobs than the provider's rate limit and would otherwise mass-discard them as failed_final
 // (mirrors the classify workers) — while anything else retries, failing on the last attempt.
 func (w *FeedbackEmbeddingWorker) handleEmbedError(
-	ctx context.Context, err error, job *river.Job[service.FeedbackEmbeddingArgs], start time.Time,
+	ctx context.Context, err error, job *river.Job[service.FeedbackEmbeddingArgs], log *slog.Logger, start time.Time,
 ) error {
 	if delay, ok := rateLimitSnoozeDelay(err, job.CreatedAt); ok {
 		if w.metrics != nil {
@@ -161,8 +155,7 @@ func (w *FeedbackEmbeddingWorker) handleEmbedError(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "retry")
 		}
 
-		slog.Warn("embedding: provider rate limited, snoozing",
-			"feedback_record_id", job.Args.FeedbackRecordID,
+		log.Warn("embedding: provider rate limited, snoozing",
 			"retry_after", delay,
 		)
 
@@ -185,8 +178,7 @@ func (w *FeedbackEmbeddingWorker) handleEmbedError(
 	}
 
 	if isLastAttempt {
-		slog.Error("embedding: API failed (final attempt)",
-			"feedback_record_id", job.Args.FeedbackRecordID,
+		log.Error("embedding: API failed (final attempt)",
 			"error", err,
 		)
 		// Return error so River marks the job as failed; otherwise these records never get embeddings and don't show as failed in River UI.
@@ -205,7 +197,7 @@ func (w *FeedbackEmbeddingWorker) handleEmbedError(
 func (w *FeedbackEmbeddingWorker) handleSetEmbeddingError(
 	ctx context.Context,
 	err error,
-	feedbackRecordID uuid.UUID,
+	log *slog.Logger,
 	start time.Time,
 	isLastAttempt bool,
 	action string,
@@ -217,9 +209,7 @@ func (w *FeedbackEmbeddingWorker) handleSetEmbeddingError(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "skipped")
 		}
 
-		slog.Info("embedding: record gone before write, skipping",
-			"feedback_record_id", feedbackRecordID,
-		)
+		log.Info("embedding: record gone before write, skipping")
 
 		return nil
 	case errors.Is(err, huberrors.ErrEmbeddingSuperseded):
@@ -232,9 +222,7 @@ func (w *FeedbackEmbeddingWorker) handleSetEmbeddingError(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "skipped")
 		}
 
-		slog.Info("embedding: content changed mid-job, superseded write skipped",
-			"feedback_record_id", feedbackRecordID,
-		)
+		log.Info("embedding: content changed mid-job, superseded write skipped")
 
 		return nil
 	case errors.Is(err, huberrors.ErrTenantWriteConflict):
@@ -249,9 +237,7 @@ func (w *FeedbackEmbeddingWorker) handleSetEmbeddingError(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), outcome)
 		}
 
-		slog.Warn("embedding: tenant data purge in progress, deferring write",
-			"feedback_record_id", feedbackRecordID,
-		)
+		log.Warn("embedding: tenant data purge in progress, deferring write")
 
 		return fmt.Errorf("%s: %w", action, err)
 	default:
@@ -268,8 +254,7 @@ func (w *FeedbackEmbeddingWorker) handleSetEmbeddingError(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), outcome)
 		}
 
-		slog.Error("embedding: "+action+" failed",
-			"feedback_record_id", feedbackRecordID,
+		log.Error("embedding: "+action+" failed",
 			"final_attempt", isLastAttempt,
 			"error", err,
 		)
@@ -283,6 +268,7 @@ func (w *FeedbackEmbeddingWorker) handleEmptyText(
 	ctx context.Context,
 	job *river.Job[service.FeedbackEmbeddingArgs],
 	record *models.FeedbackRecord,
+	log *slog.Logger,
 	start time.Time,
 	stillCurrent func(fieldLabel, valueText *string) bool,
 ) error {
@@ -293,7 +279,7 @@ func (w *FeedbackEmbeddingWorker) handleEmptyText(
 		if err != nil {
 			isLastAttempt := job.Attempt >= job.MaxAttempts
 
-			return w.handleSetEmbeddingError(ctx, err, feedbackRecordID, start, isLastAttempt, "clear feedback record embedding")
+			return w.handleSetEmbeddingError(ctx, err, log, start, isLastAttempt, "clear feedback record embedding")
 		}
 
 		if w.metrics != nil {
@@ -301,9 +287,7 @@ func (w *FeedbackEmbeddingWorker) handleEmptyText(
 			w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "success")
 		}
 
-		slog.Info("embedding: cleared (empty value_text)",
-			"feedback_record_id", feedbackRecordID,
-		)
+		log.Info("embedding: cleared (empty value_text)")
 
 		return nil
 	}
@@ -313,9 +297,7 @@ func (w *FeedbackEmbeddingWorker) handleEmptyText(
 		w.metrics.RecordEmbeddingDuration(ctx, time.Since(start), "skipped")
 	}
 
-	slog.Info("embedding: skipped (no value_text)",
-		"feedback_record_id", feedbackRecordID,
-	)
+	log.Info("embedding: skipped (no value_text)")
 
 	return nil
 }

--- a/internal/workers/feedback_emotions.go
+++ b/internal/workers/feedback_emotions.go
@@ -43,6 +43,7 @@ func NewFeedbackEmotionsWorker(
 		name:         "emotions",
 		timeout:      enrichmentJobTimeout,
 		recordID:     func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:      func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.EventID },
 		getRecord:    svc.GetFeedbackRecord,
 		eligible:     (*models.FeedbackRecord).IsTextField,
 		hasContent:   (*models.FeedbackRecord).HasOpenText,

--- a/internal/workers/feedback_sentiment.go
+++ b/internal/workers/feedback_sentiment.go
@@ -36,6 +36,7 @@ func NewFeedbackSentimentWorker(
 		name:         "sentiment",
 		timeout:      enrichmentJobTimeout,
 		recordID:     func(args service.FeedbackSentimentArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:      func(args service.FeedbackSentimentArgs) uuid.UUID { return args.EventID },
 		getRecord:    svc.GetFeedbackRecord,
 		eligible:     (*models.FeedbackRecord).IsTextField,
 		hasContent:   (*models.FeedbackRecord).HasOpenText,

--- a/internal/workers/feedback_translation.go
+++ b/internal/workers/feedback_translation.go
@@ -39,6 +39,7 @@ func NewFeedbackTranslationWorker(
 		name:       "translation",
 		timeout:    enrichmentJobTimeout,
 		recordID:   func(args service.FeedbackTranslationArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:    func(args service.FeedbackTranslationArgs) uuid.UUID { return args.EventID },
 		getRecord:  svc.GetFeedbackRecord,
 		eligible:   (*models.FeedbackRecord).IsTextField,
 		hasContent: (*models.FeedbackRecord).HasOpenText,

--- a/internal/workers/feedback_translation.go
+++ b/internal/workers/feedback_translation.go
@@ -44,7 +44,7 @@ func NewFeedbackTranslationWorker(
 		eligible:   (*models.FeedbackRecord).IsTextField,
 		hasContent: (*models.FeedbackRecord).HasOpenText,
 		classify: func(ctx context.Context, record *models.FeedbackRecord, args service.FeedbackTranslationArgs) (string, error) {
-			return translate(ctx, client, record, args.TargetLang)
+			return translate(ctx, client, record, args.TargetLang, args.EventID)
 		},
 		persist: func(ctx context.Context, record *models.FeedbackRecord, args service.FeedbackTranslationArgs, translated *string) error {
 			// Guard the write against content churn since the Work-time read: a stale job's
@@ -71,7 +71,7 @@ func NewFeedbackTranslationWorker(
 // translate returns the translated value_text, short-circuiting (copying the original) when the
 // record's source language already matches the target language.
 func translate(
-	ctx context.Context, client service.TranslationClient, record *models.FeedbackRecord, targetLang string,
+	ctx context.Context, client service.TranslationClient, record *models.FeedbackRecord, targetLang string, eventID uuid.UUID,
 ) (string, error) {
 	sourceLang := ""
 	if record.Language != nil {
@@ -80,7 +80,7 @@ func translate(
 
 	if sameLanguageAndScript(sourceLang, targetLang) {
 		slog.Info("translation: source already in target language, copying value_text",
-			"feedback_record_id", record.ID)
+			"feedback_record_id", record.ID, "event_id", eventID)
 
 		return *record.ValueText, nil
 	}


### PR DESCRIPTION
## What does this PR do?

Round-2 observability + free perf wins for the enrichment framework. Deliberately kept **out of #99** so that PR's review stays focused.

> **#99 has merged — this is now rebased onto `main` and ready for review.** It was stacked on #99 (`refactor/ENG-1613_enrichment-framework`) during review because it touches the classify job args/worker introduced there; those are in `main` now.

Relates to ENG-1644 (observability/perf) and ENG-1613 (the `AGENTS.md` refresh, folded in from the former #101 — not worth a standalone PR).

**Commits (9 total, grouped by theme; each self-contained):**

1. **`perf(embeddings)`** — the nearest/after-cursor search queries selected both `(e.embedding <=> $1) AS distance` *and* `(1 - …) AS score`, evaluating the cosine-distance operator twice per row; drop the score column and derive `score = 1 - distance` in Go. Also build `BuildEmbeddingInput` once on the embedding create path (it was computed twice). No behavior change.
2. **`feat: HNSW iterative-scan gauge`** — when the server rejects `hnsw.iterative_scan` (pgvector < 0.8) the repo latches the fallback and logs *once*, after which recall is silently capped at `ef_search` for the process lifetime. Expose it as `hub_hnsw_iterative_scan_degraded` (0/1), registered alongside the search handler.
3. **`feat: carry event id in job args`** — add `EventID` to all four enrichment job args, populated from `event.ID` at enqueue. Not part of the River unique key (correlation metadata, not a dedupe input); `uuid.Nil` for backfill jobs. Backward-compatible JSON.
4. **`feat: log event id in workers`** *(+ `refactor: complete event_id coverage on the embedding path`, + `fix: correlate the translation short-circuit log line`, + `test: lock event-id propagation and the iterative-scan gauge`)* — emit `event_id` on worker log lines so a job's logs correlate to its originating event. The generic worker binds a `slog.Logger` once (also removing `feedback_record_id` duplicated across ~12 sites); the standalone embedding worker gets its main lines, and the translation worker's same-language short-circuit line is correlated too. The test commit pins event-id propagation through the providers and the gauge's 0/1 behavior.
5. **`feat: counter for enrichment outputs cleared on edit`** — new `hub_enrichment_outputs_cleared_total` counter (label `output` ∈ {`sentiment`, `emotions`, `translation`, `other`}), incremented from the API's eager-clear path when a `value_text`/`language` edit NULLs a derived output. Counted from the actual pre-/post-update row (not every update), API-instance-only (worker/backfill leave it unset), nil-safe when metrics are disabled.
6. **`docs: refresh AGENTS.md`** — brings the repo's agent/contributor guide in line with the tree after the enrichment work (the shared classify scaffold, `cmd/backfill-*`, the new `internal/` packages). Docs-only.

**Scope notes (intentionally deferred):**
- The **taxonomy run-input truncation metric** (also on ENG-1644) is a separate subsystem living on `main`, unrelated to enrichment — it'll be its own small `main`-based PR, not stacked here.
- The embedding worker's *error-path* log lines get `event_id` when it moves onto the shared scaffold (**ENG-1643**); this PR covers its main lines and, more importantly, carries `EventID` in its args (visible in the River UI regardless).

## How should this be tested?

Requires the pgvector test DB (`DATABASE_URL` → `test_db`); providers can be dummy (this exercises wiring/enqueue/queries, not real inference).

- `make build && make lint` — clean (0 issues).
- `make test-unit` — includes the generic-worker and embedding-worker `Work` tests (exercise the new bound logger / `eventID` hook).
- `make tests` — the semantic-search integration test asserts `score ≈ 1 - distance` (`assert.InDelta`, 1e-9), covering the SQL→Go change end-to-end; the sentiment/emotions/translation integration tests drive the workers.
- **Event correlation, manual:** `POST` a text feedback record, then in the River UI (or `river_job.args`) confirm the enqueued jobs carry `event_id` matching the `PublishEvent` log line; worker logs for that job now include `event_id` + `feedback_record_id`.
- **Degradation gauge:** on pgvector ≥ 0.8 it reports `0`; it flips to `1` only if the server rejects the `hnsw.iterative_scan` GUC (the pgvector < 0.8 fallback).
- **Outputs-cleared counter:** unit `TestEnrichmentClearMetricsRecords` asserts one increment per cleared output and bounds the `output` label; end-to-end, `PATCH` a text record's `value_text` and confirm `hub_enrichment_outputs_cleared_total` increments for the affected outputs.

## Checklist

### Required
- [x] Filled out the "How to test" section in this PR
- [x] Read Repository Guidelines
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch — **rebased onto `main` after #99 merged**
- [ ] Database schema changed — **N/A: no migration**

### Appreciated
- [ ] API changed — **N/A: no API/OpenAPI change** (two new internal metrics only: the `hub_hnsw_iterative_scan_degraded` gauge and the `hub_enrichment_outputs_cleared_total` counter)
- [x] Updated docs — refreshes `AGENTS.md` (commit 6); the `hub_hnsw_iterative_scan_degraded` / correlation behavior is internal, so env-vars docs are unaffected
- [x] Ran `make tests-coverage` for meaningful logic changes




