### PR TITLE
feat: support directory-scoped taxonomy runs

### DIFF
--- a/internal/api/handlers/taxonomy_handler.go
+++ b/internal/api/handlers/taxonomy_handler.go
@@ -275,6 +275,7 @@ func parseUUIDPathValue(w http.ResponseWriter, r *http.Request, name string) (uu
 
 func taxonomyScopeFromQuery(w http.ResponseWriter, r *http.Request) (models.TaxonomyScope, bool) {
 	scope := models.TaxonomyScope{
+		ScopeType:  models.TaxonomyScopeType(r.URL.Query().Get("scope_type")),
 		TenantID:   r.URL.Query().Get("tenant_id"),
 		SourceType: r.URL.Query().Get("source_type"),
 		SourceID:   r.URL.Query().Get("source_id"),

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -53,16 +53,26 @@ const (
 	TaxonomyNodeTypeLeaf   TaxonomyNodeType = "leaf"
 )
 
-// TaxonomyScope identifies the feedback field that a taxonomy run covers.
+// TaxonomyScopeType identifies how broadly a taxonomy run reads feedback input.
+type TaxonomyScopeType string
+
+// Taxonomy scope types.
+const (
+	TaxonomyScopeTypeField     TaxonomyScopeType = "field"
+	TaxonomyScopeTypeDirectory TaxonomyScopeType = "directory"
+)
+
+// TaxonomyScope identifies the feedback input that a taxonomy run covers.
 //
 // SourceID is optional: feedback_records.source_id is nullable, so feedback may have no
 // attributed source. An empty SourceID is the canonical "no source" bucket and matches
 // feedback records whose source_id is NULL or blank.
 type TaxonomyScope struct {
-	TenantID   string `json:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
-	SourceType string `json:"source_type" validate:"required,no_null_bytes,min=1,max=255"`
-	SourceID   string `json:"source_id"   validate:"omitempty,no_null_bytes,max=255"`
-	FieldID    string `json:"field_id"    validate:"required,no_null_bytes,min=1,max=255"`
+	ScopeType  TaxonomyScopeType `json:"scope_type,omitempty" validate:"omitempty,oneof=field directory"`
+	TenantID   string            `json:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
+	SourceType string            `json:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
+	SourceID   string            `json:"source_id"   validate:"omitempty,no_null_bytes,max=255"`
+	FieldID    string            `json:"field_id"    validate:"omitempty,no_null_bytes,min=1,max=255"`
 }
 
 // TaxonomyFieldOption describes a feedback field that can be used for taxonomy generation.
@@ -85,6 +95,7 @@ type TaxonomyFieldsResponse struct {
 // TaxonomyRun is a persisted taxonomy generation run.
 type TaxonomyRun struct {
 	ID             uuid.UUID               `json:"id"`
+	ScopeType      TaxonomyScopeType       `json:"scope_type"`
 	TenantID       string                  `json:"tenant_id"`
 	SourceType     string                  `json:"source_type"`
 	SourceID       string                  `json:"source_id"`
@@ -126,11 +137,12 @@ type CreateTaxonomyRunResponse struct {
 // scopes history to the canonical "no source" bucket — runs whose source_id is "" —
 // which a plain string filter cannot express (it cannot tell "unset" from "empty").
 type ListTaxonomyRunsFilters struct {
-	TenantID   string  `form:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
-	SourceType string  `form:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
-	SourceID   *string `form:"source_id"   validate:"omitempty,no_null_bytes,max=255"`
-	FieldID    string  `form:"field_id"    validate:"omitempty,no_null_bytes,min=1,max=255"`
-	Limit      int     `form:"limit"       validate:"omitempty,min=1,max=100"`
+	ScopeType  TaxonomyScopeType `form:"scope_type"  validate:"omitempty,oneof=field directory"`
+	TenantID   string            `form:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
+	SourceType string            `form:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
+	SourceID   *string           `form:"source_id"   validate:"omitempty,no_null_bytes,max=255"`
+	FieldID    string            `form:"field_id"    validate:"omitempty,no_null_bytes,min=1,max=255"`
+	Limit      int               `form:"limit"       validate:"omitempty,min=1,max=100"`
 }
 
 // ListTaxonomyRunsResponse contains taxonomy run history.
@@ -182,6 +194,9 @@ type TaxonomyTreeResponse struct {
 // TaxonomyRunInputRecord is a feedback record and embedding used by the taxonomy service.
 type TaxonomyRunInputRecord struct {
 	FeedbackRecordID uuid.UUID `json:"feedback_record_id"`
+	SourceType       string    `json:"source_type,omitempty"`
+	SourceID         string    `json:"source_id,omitempty"`
+	FieldID          string    `json:"field_id,omitempty"`
 	FieldLabel       string    `json:"field_label,omitempty"`
 	ValueText        string    `json:"value_text"`
 	Embedding        []float32 `json:"embedding"`

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -69,10 +69,10 @@ const (
 // feedback records whose source_id is NULL or blank.
 type TaxonomyScope struct {
 	ScopeType  TaxonomyScopeType `json:"scope_type,omitempty" validate:"omitempty,oneof=field directory"`
-	TenantID   string            `json:"tenant_id"   validate:"required,no_null_bytes,min=1,max=255"`
-	SourceType string            `json:"source_type" validate:"omitempty,no_null_bytes,min=1,max=255"`
-	SourceID   string            `json:"source_id"   validate:"omitempty,no_null_bytes,max=255"`
-	FieldID    string            `json:"field_id"    validate:"omitempty,no_null_bytes,min=1,max=255"`
+	TenantID   string            `json:"tenant_id"            validate:"required,no_null_bytes,min=1,max=255"`
+	SourceType string            `json:"source_type"          validate:"omitempty,no_null_bytes,min=1,max=255"`
+	SourceID   string            `json:"source_id"            validate:"omitempty,no_null_bytes,max=255"`
+	FieldID    string            `json:"field_id"             validate:"omitempty,no_null_bytes,min=1,max=255"`
 }
 
 // TaxonomyFieldOption describes a feedback field that can be used for taxonomy generation.

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -373,6 +373,7 @@ func (r *TaxonomyRepository) GetRunForTenant(
 // GetActiveRun returns the active taxonomy run for a scope.
 func (r *TaxonomyRepository) GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error) {
 	scopeType := taxonomyScopeType(scope)
+
 	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+`
 		FROM taxonomy_active_runs ar
 		INNER JOIN taxonomy_runs ON taxonomy_runs.id = ar.run_id
@@ -431,6 +432,7 @@ func (r *TaxonomyRepository) ListRuns(
 	if filters.ScopeType != "" {
 		addFilter("scope_type", string(filters.ScopeType))
 	}
+
 	addFilter("source_type", filters.SourceType)
 	addFilter("field_id", filters.FieldID)
 	addFilterPtr("source_id", filters.SourceID)
@@ -510,56 +512,6 @@ func (r *TaxonomyRepository) GetRunInput(
 	}
 
 	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
-}
-
-func (r *TaxonomyRepository) queryRunInputRows(
-	ctx context.Context,
-	run *models.TaxonomyRun,
-	limit int,
-	embeddingModel string,
-) (pgx.Rows, error) {
-	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
-		return r.db.Query(ctx, `
-			SELECT
-				fr.id,
-				fr.source_type,
-				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
-				fr.field_id,
-				COALESCE(fr.field_label, ''),
-				fr.value_text,
-				e.embedding
-			FROM feedback_records fr
-			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
-			WHERE fr.tenant_id = $1
-			  AND fr.value_text IS NOT NULL
-			  AND btrim(fr.value_text) <> ''
-			ORDER BY fr.collected_at DESC, fr.id ASC
-			LIMIT $2`,
-			run.TenantID, limit, embeddingModel,
-		)
-	}
-
-	return r.db.Query(ctx, `
-		SELECT
-			fr.id,
-			fr.source_type,
-			COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
-			fr.field_id,
-			COALESCE(fr.field_label, ''),
-			fr.value_text,
-			e.embedding
-		FROM feedback_records fr
-		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
-		WHERE fr.tenant_id = $1
-		  AND fr.source_type = $2
-		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
-		  AND fr.field_id = $4
-		  AND fr.value_text IS NOT NULL
-		  AND btrim(fr.value_text) <> ''
-		ORDER BY fr.collected_at DESC, fr.id ASC
-		LIMIT $5`,
-		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
-	)
 }
 
 // StoreResultAndActivate stores generated taxonomy artifacts and activates the run.
@@ -922,6 +874,66 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	}
 
 	return records, limit, nil
+}
+
+func (r *TaxonomyRepository) queryRunInputRows(
+	ctx context.Context,
+	run *models.TaxonomyRun,
+	limit int,
+	embeddingModel string,
+) (pgx.Rows, error) {
+	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
+		rows, err := r.db.Query(ctx, `
+			SELECT
+				fr.id,
+				fr.source_type,
+				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
+				fr.field_id,
+				COALESCE(fr.field_label, ''),
+				fr.value_text,
+				e.embedding
+			FROM feedback_records fr
+			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
+			WHERE fr.tenant_id = $1
+			  AND fr.value_text IS NOT NULL
+			  AND btrim(fr.value_text) <> ''
+			ORDER BY fr.collected_at DESC, fr.id ASC
+			LIMIT $2`,
+			run.TenantID, limit, embeddingModel,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("query directory taxonomy run input rows: %w", err)
+		}
+
+		return rows, nil
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT
+			fr.id,
+			fr.source_type,
+			COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
+			fr.field_id,
+			COALESCE(fr.field_label, ''),
+			fr.value_text,
+			e.embedding
+		FROM feedback_records fr
+		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
+		WHERE fr.tenant_id = $1
+		  AND fr.source_type = $2
+		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
+		  AND fr.field_id = $4
+		  AND fr.value_text IS NOT NULL
+		  AND btrim(fr.value_text) <> ''
+		ORDER BY fr.collected_at DESC, fr.id ASC
+		LIMIT $5`,
+		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query field taxonomy run input rows: %w", err)
+	}
+
+	return rows, nil
 }
 
 func (r *TaxonomyRepository) listVisibleNodes(ctx context.Context, runID uuid.UUID) ([]models.TaxonomyNode, error) {

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -117,6 +117,25 @@ func (r *TaxonomyRepository) CountScopeInput(
 		fieldLabel     *string
 	)
 
+	if taxonomyScopeType(scope) == models.TaxonomyScopeTypeDirectory {
+		err := r.db.QueryRow(ctx, `
+			SELECT
+				COUNT(*)::int,
+				COUNT(e.feedback_record_id)::int
+			FROM feedback_records fr
+			LEFT JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $2
+			WHERE fr.tenant_id = $1
+			  AND fr.value_text IS NOT NULL
+			  AND btrim(fr.value_text) <> ''`,
+			scope.TenantID, embeddingModel,
+		).Scan(&recordCount, &embeddingCount)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("count directory taxonomy input: %w", err)
+		}
+
+		return recordCount, embeddingCount, nil, nil
+	}
+
 	err := r.db.QueryRow(ctx, `
 		SELECT
 			COUNT(*)::int,
@@ -150,6 +169,7 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 	)
 
 	err := withTenantWritePoolTx(ctx, r.db, []string{params.TenantID}, func(dbTx tenantWriteTx) error {
+		scopeType := taxonomyScopeType(params.TaxonomyScope)
 		// Scope lock comes second, after the shared tenant write lock, per the
 		// tenant write lock-order convention (see tenant_write_lock.go). Scope
 		// waiters already hold the tenant lock in shared mode, so they never
@@ -162,13 +182,14 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 		existing, err := queryTaxonomyRun(ctx, dbTx, taxonomyRunSelect+`
 			FROM taxonomy_runs
 			WHERE tenant_id = $1
-			  AND source_type = $2
-			  AND source_id = $3
-			  AND field_id = $4
+			  AND scope_type = $2
+			  AND source_type = $3
+			  AND source_id = $4
+			  AND field_id = $5
 			  AND status IN ('pending', 'running')
 			ORDER BY created_at DESC, id DESC
 			LIMIT 1`,
-			params.TenantID, params.SourceType, params.SourceID, params.FieldID,
+			params.TenantID, scopeType, params.SourceType, params.SourceID, params.FieldID,
 		)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("find in-progress taxonomy run: %w", err)
@@ -183,13 +204,14 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 		inserted, err := queryTaxonomyRun(ctx, dbTx, `
 			WITH taxonomy_runs AS (
 				INSERT INTO taxonomy_runs (
-					tenant_id, source_type, source_id, field_id, field_label,
+					tenant_id, scope_type, source_type, source_id, field_id, field_label,
 					status, params, record_count, embedding_count
 				)
-				VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7, $8)
+				VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8, $9)
 				RETURNING *
 			)`+taxonomyRunSelect+` FROM taxonomy_runs`,
 			params.TenantID,
+			scopeType,
 			params.SourceType,
 			params.SourceID,
 			params.FieldID,
@@ -216,12 +238,21 @@ func (r *TaxonomyRepository) CreateRunIfAvailable(
 
 func taxonomyScopeLockKey(scope models.TaxonomyScope) string {
 	return fmt.Sprintf(
-		"%d:%s|%d:%s|%d:%s|%d:%s",
+		"%d:%s|%d:%s|%d:%s|%d:%s|%d:%s",
+		len(taxonomyScopeType(scope)), taxonomyScopeType(scope),
 		len(scope.TenantID), scope.TenantID,
 		len(scope.SourceType), scope.SourceType,
 		len(scope.SourceID), scope.SourceID,
 		len(scope.FieldID), scope.FieldID,
 	)
+}
+
+func taxonomyScopeType(scope models.TaxonomyScope) models.TaxonomyScopeType {
+	if scope.ScopeType == "" {
+		return models.TaxonomyScopeTypeField
+	}
+
+	return scope.ScopeType
 }
 
 // MarkRunRunning transitions a taxonomy run to running.
@@ -341,14 +372,16 @@ func (r *TaxonomyRepository) GetRunForTenant(
 
 // GetActiveRun returns the active taxonomy run for a scope.
 func (r *TaxonomyRepository) GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error) {
+	scopeType := taxonomyScopeType(scope)
 	run, err := queryTaxonomyRun(ctx, r.db, taxonomyRunSelect+`
 		FROM taxonomy_active_runs ar
 		INNER JOIN taxonomy_runs ON taxonomy_runs.id = ar.run_id
 		WHERE ar.tenant_id = $1
-		  AND ar.source_type = $2
-		  AND ar.source_id = $3
-		  AND ar.field_id = $4`,
-		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID,
+		  AND ar.scope_type = $2
+		  AND ar.source_type = $3
+		  AND ar.source_id = $4
+		  AND ar.field_id = $5`,
+		scope.TenantID, scopeType, scope.SourceType, scope.SourceID, scope.FieldID,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -395,6 +428,9 @@ func (r *TaxonomyRepository) ListRuns(
 		query += fmt.Sprintf(" AND %s = $%d", column, len(args))
 	}
 
+	if filters.ScopeType != "" {
+		addFilter("scope_type", string(filters.ScopeType))
+	}
 	addFilter("source_type", filters.SourceType)
 	addFilter("field_id", filters.FieldID)
 	addFilterPtr("source_id", filters.SourceID)
@@ -440,20 +476,7 @@ func (r *TaxonomyRepository) GetRunInput(
 		limit = maxTaxonomyRunInputRows
 	}
 
-	rows, err := r.db.Query(ctx, `
-		SELECT fr.id, COALESCE(fr.field_label, ''), fr.value_text, e.embedding
-		FROM feedback_records fr
-		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
-		WHERE fr.tenant_id = $1
-		  AND fr.source_type = $2
-		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
-		  AND fr.field_id = $4
-		  AND fr.value_text IS NOT NULL
-		  AND btrim(fr.value_text) <> ''
-		ORDER BY fr.collected_at DESC, fr.id ASC
-		LIMIT $5`,
-		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
-	)
+	rows, err := r.queryRunInputRows(ctx, run, limit, embeddingModel)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run input: %w", err)
 	}
@@ -466,7 +489,15 @@ func (r *TaxonomyRepository) GetRunInput(
 			record models.TaxonomyRunInputRecord
 			vec    pgvector.HalfVector
 		)
-		if err := rows.Scan(&record.FeedbackRecordID, &record.FieldLabel, &record.ValueText, &vec); err != nil {
+		if err := rows.Scan(
+			&record.FeedbackRecordID,
+			&record.SourceType,
+			&record.SourceID,
+			&record.FieldID,
+			&record.FieldLabel,
+			&record.ValueText,
+			&vec,
+		); err != nil {
 			return nil, fmt.Errorf("scan taxonomy run input record: %w", err)
 		}
 
@@ -479,6 +510,56 @@ func (r *TaxonomyRepository) GetRunInput(
 	}
 
 	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
+}
+
+func (r *TaxonomyRepository) queryRunInputRows(
+	ctx context.Context,
+	run *models.TaxonomyRun,
+	limit int,
+	embeddingModel string,
+) (pgx.Rows, error) {
+	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
+		return r.db.Query(ctx, `
+			SELECT
+				fr.id,
+				fr.source_type,
+				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
+				fr.field_id,
+				COALESCE(fr.field_label, ''),
+				fr.value_text,
+				e.embedding
+			FROM feedback_records fr
+			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
+			WHERE fr.tenant_id = $1
+			  AND fr.value_text IS NOT NULL
+			  AND btrim(fr.value_text) <> ''
+			ORDER BY fr.collected_at DESC, fr.id ASC
+			LIMIT $2`,
+			run.TenantID, limit, embeddingModel,
+		)
+	}
+
+	return r.db.Query(ctx, `
+		SELECT
+			fr.id,
+			fr.source_type,
+			COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
+			fr.field_id,
+			COALESCE(fr.field_label, ''),
+			fr.value_text,
+			e.embedding
+		FROM feedback_records fr
+		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
+		WHERE fr.tenant_id = $1
+		  AND fr.source_type = $2
+		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
+		  AND fr.field_id = $4
+		  AND fr.value_text IS NOT NULL
+		  AND btrim(fr.value_text) <> ''
+		ORDER BY fr.collected_at DESC, fr.id ASC
+		LIMIT $5`,
+		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
+	)
 }
 
 // StoreResultAndActivate stores generated taxonomy artifacts and activates the run.
@@ -635,16 +716,17 @@ func storeResultAndActivateInTx(
 
 	activatedBy := taxonomyRunRequestedBy(run.Params)
 	if _, err := transaction.Exec(ctx, `
-		INSERT INTO taxonomy_active_runs (
-			tenant_id, source_type, source_id, field_id, run_id, activated_by
-		)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (tenant_id, source_type, source_id, field_id)
-		DO UPDATE SET
-			run_id = EXCLUDED.run_id,
-			activated_by = EXCLUDED.activated_by,
-			activated_at = NOW()`,
+			INSERT INTO taxonomy_active_runs (
+				tenant_id, scope_type, source_type, source_id, field_id, run_id, activated_by
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (tenant_id, scope_type, source_type, source_id, field_id)
+			DO UPDATE SET
+				run_id = EXCLUDED.run_id,
+				activated_by = EXCLUDED.activated_by,
+				activated_at = NOW()`,
 		run.TenantID,
+		run.ScopeType,
 		run.SourceType,
 		run.SourceID,
 		run.FieldID,
@@ -924,10 +1006,10 @@ type queryer interface {
 }
 
 const taxonomyRunSelect = `
-		SELECT taxonomy_runs.id, taxonomy_runs.tenant_id, taxonomy_runs.source_type,
-			taxonomy_runs.source_id, taxonomy_runs.field_id, taxonomy_runs.field_label,
-			taxonomy_runs.status, taxonomy_runs.params, taxonomy_runs.metrics,
-			taxonomy_runs.record_count, taxonomy_runs.embedding_count,
+			SELECT taxonomy_runs.id, taxonomy_runs.scope_type, taxonomy_runs.tenant_id, taxonomy_runs.source_type,
+				taxonomy_runs.source_id, taxonomy_runs.field_id, taxonomy_runs.field_label,
+				taxonomy_runs.status, taxonomy_runs.params, taxonomy_runs.metrics,
+				taxonomy_runs.record_count, taxonomy_runs.embedding_count,
 			taxonomy_runs.cluster_count, taxonomy_runs.node_count, taxonomy_runs.error, taxonomy_runs.error_code,
 			taxonomy_runs.started_at, taxonomy_runs.finished_at,
 			taxonomy_runs.created_at, taxonomy_runs.updated_at`
@@ -944,6 +1026,7 @@ func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
 
 	if err := row.Scan(
 		&run.ID,
+		&run.ScopeType,
 		&run.TenantID,
 		&run.SourceType,
 		&run.SourceID,
@@ -1093,11 +1176,12 @@ func insertNodeEvent(
 
 	if _, err := transaction.Exec(ctx, `
 		INSERT INTO taxonomy_node_events (
-			tenant_id, source_type, source_id, field_id, run_id, node_id,
+			tenant_id, scope_type, source_type, source_id, field_id, run_id, node_id,
 			event_type, actor_id, old_value, new_value
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		run.TenantID,
+		run.ScopeType,
 		run.SourceType,
 		run.SourceID,
 		run.FieldID,

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -25,6 +25,8 @@ var (
 
 const defaultMinimumTaxonomyEmbeddingCount = 20
 
+const directoryTaxonomyFieldLabel = "All feedback"
+
 // TaxonomyRepository persists taxonomy run state and generated artifacts.
 type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service coordinates one cohesive repository boundary.
 	ListFieldOptions(ctx context.Context, tenantID, embeddingModel string) ([]models.TaxonomyFieldOption, error)
@@ -142,17 +144,25 @@ func (s *TaxonomyService) StartManualRun(
 	}
 
 	if recordCount == 0 {
-		return nil, huberrors.NewValidationError("field_id", "no text feedback records found for this field scope")
+		return nil, huberrors.NewValidationError(scopeValidationField(scope), "no text feedback records found for this taxonomy scope")
 	}
 
 	if embeddingCount < s.minimumEmbeddingCount {
 		return nil, huberrors.NewValidationError(
-			"field_id",
+			scopeValidationField(scope),
 			fmt.Sprintf("at least %d embedded text feedback records are required; found %d", s.minimumEmbeddingCount, embeddingCount),
 		)
 	}
 
 	fieldLabel := req.FieldLabel
+	if fieldLabel != nil {
+		trimmed := strings.TrimSpace(*fieldLabel)
+		fieldLabel = &trimmed
+	}
+	if (fieldLabel == nil || *fieldLabel == "") && scope.ScopeType == models.TaxonomyScopeTypeDirectory {
+		label := directoryTaxonomyFieldLabel
+		fieldLabel = &label
+	}
 	if fieldLabel == nil {
 		fieldLabel = discoveredFieldLabel
 	}
@@ -448,6 +458,28 @@ func normalizeTaxonomyScope(scope models.TaxonomyScope) (models.TaxonomyScope, e
 		return models.TaxonomyScope{}, err
 	}
 
+	scopeType := scope.ScopeType
+	if scopeType == "" {
+		scopeType = models.TaxonomyScopeTypeField
+	}
+
+	if scopeType == models.TaxonomyScopeTypeDirectory {
+		if strings.TrimSpace(scope.SourceType) != "" {
+			return models.TaxonomyScope{}, huberrors.NewValidationError("source_type", "must be empty for directory taxonomy scope")
+		}
+		if strings.TrimSpace(scope.SourceID) != "" {
+			return models.TaxonomyScope{}, huberrors.NewValidationError("source_id", "must be empty for directory taxonomy scope")
+		}
+		if strings.TrimSpace(scope.FieldID) != "" {
+			return models.TaxonomyScope{}, huberrors.NewValidationError("field_id", "must be empty for directory taxonomy scope")
+		}
+
+		return models.TaxonomyScope{
+			ScopeType: models.TaxonomyScopeTypeDirectory,
+			TenantID:  tenantID,
+		}, nil
+	}
+
 	sourceType, err := normalizeRequiredIdentifier("source_type", scope.SourceType)
 	if err != nil {
 		return models.TaxonomyScope{}, err
@@ -465,11 +497,20 @@ func normalizeTaxonomyScope(scope models.TaxonomyScope) (models.TaxonomyScope, e
 	}
 
 	return models.TaxonomyScope{
+		ScopeType:  models.TaxonomyScopeTypeField,
 		TenantID:   tenantID,
 		SourceType: sourceType,
 		SourceID:   sourceID,
 		FieldID:    fieldID,
 	}, nil
+}
+
+func scopeValidationField(scope models.TaxonomyScope) string {
+	if scope.ScopeType == models.TaxonomyScopeTypeDirectory {
+		return "tenant_id"
+	}
+
+	return "field_id"
 }
 
 func taxonomyRunParams(actorID *string, embeddingModel string) json.RawMessage {

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -159,10 +159,12 @@ func (s *TaxonomyService) StartManualRun(
 		trimmed := strings.TrimSpace(*fieldLabel)
 		fieldLabel = &trimmed
 	}
+
 	if (fieldLabel == nil || *fieldLabel == "") && scope.ScopeType == models.TaxonomyScopeTypeDirectory {
 		label := directoryTaxonomyFieldLabel
 		fieldLabel = &label
 	}
+
 	if fieldLabel == nil {
 		fieldLabel = discoveredFieldLabel
 	}
@@ -467,9 +469,11 @@ func normalizeTaxonomyScope(scope models.TaxonomyScope) (models.TaxonomyScope, e
 		if strings.TrimSpace(scope.SourceType) != "" {
 			return models.TaxonomyScope{}, huberrors.NewValidationError("source_type", "must be empty for directory taxonomy scope")
 		}
+
 		if strings.TrimSpace(scope.SourceID) != "" {
 			return models.TaxonomyScope{}, huberrors.NewValidationError("source_id", "must be empty for directory taxonomy scope")
 		}
+
 		if strings.TrimSpace(scope.FieldID) != "" {
 			return models.TaxonomyScope{}, huberrors.NewValidationError("field_id", "must be empty for directory taxonomy scope")
 		}

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -14,6 +14,7 @@ import (
 type mockTaxonomyRepo struct {
 	countRecordCount     int
 	countEmbeddingCount  int
+	createRunParams      repository.CreateTaxonomyRunParams
 	createRun            *models.TaxonomyRun
 	createRunCreated     bool
 	internalRun          *models.TaxonomyRun
@@ -41,8 +42,10 @@ func (m *mockTaxonomyRepo) CountScopeInput(
 
 func (m *mockTaxonomyRepo) CreateRunIfAvailable(
 	_ context.Context,
-	_ repository.CreateTaxonomyRunParams,
+	params repository.CreateTaxonomyRunParams,
 ) (*models.TaxonomyRun, bool, error) {
+	m.createRunParams = params
+
 	return m.createRun, m.createRunCreated, nil
 }
 
@@ -163,6 +166,43 @@ type failingTaxonomyStarter struct{}
 
 func (f failingTaxonomyStarter) StartRun(_ context.Context, _ string) error {
 	return errors.New("taxonomy service unavailable")
+}
+
+type successfulTaxonomyStarter struct{}
+
+func (s successfulTaxonomyStarter) StartRun(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestTaxonomyService_StartManualRunUsesDirectoryFallbackLabel(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-333333333333")
+	blankLabel := "   "
+	repo := &mockTaxonomyRepo{
+		countRecordCount:    20,
+		countEmbeddingCount: 20,
+		createRun:           &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusPending},
+		createRunCreated:    true,
+	}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{
+		Repo:           repo,
+		Starter:        successfulTaxonomyStarter{},
+		EmbeddingModel: "text-embedding-004",
+	})
+
+	_, err := svc.StartManualRun(context.Background(), models.CreateTaxonomyRunRequest{
+		TaxonomyScope: models.TaxonomyScope{
+			ScopeType: models.TaxonomyScopeTypeDirectory,
+			TenantID:  "tenant-1",
+		},
+		FieldLabel: &blankLabel,
+	})
+	if err != nil {
+		t.Fatalf("StartManualRun() error = %v", err)
+	}
+
+	if repo.createRunParams.FieldLabel == nil || *repo.createRunParams.FieldLabel != directoryTaxonomyFieldLabel {
+		t.Fatalf("FieldLabel = %v, want %q", repo.createRunParams.FieldLabel, directoryTaxonomyFieldLabel)
+	}
 }
 
 func TestTaxonomyService_StartManualRunMarksServiceUnavailableFailure(t *testing.T) {

--- a/migrations/017_taxonomy_directory_scope.sql
+++ b/migrations/017_taxonomy_directory_scope.sql
@@ -1,0 +1,155 @@
+-- +goose up
+CREATE TYPE taxonomy_scope_type_enum AS ENUM (
+  'field',
+  'directory'
+);
+
+ALTER TABLE taxonomy_runs
+  ADD COLUMN scope_type taxonomy_scope_type_enum NOT NULL DEFAULT 'field';
+ALTER TABLE taxonomy_active_runs
+  ADD COLUMN scope_type taxonomy_scope_type_enum NOT NULL DEFAULT 'field';
+ALTER TABLE taxonomy_node_events
+  ADD COLUMN scope_type taxonomy_scope_type_enum NOT NULL DEFAULT 'field';
+
+ALTER TABLE taxonomy_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_runs_source_type_required,
+  DROP CONSTRAINT IF EXISTS taxonomy_runs_field_id_required,
+  ADD CONSTRAINT taxonomy_runs_scope_identity_unique
+    UNIQUE (id, tenant_id, scope_type, source_type, source_id, field_id),
+  ADD CONSTRAINT taxonomy_runs_scope_shape CHECK (
+    (
+      scope_type = 'field'
+      AND btrim(source_type) <> ''
+      AND btrim(field_id) <> ''
+    )
+    OR (
+      scope_type = 'directory'
+      AND source_type = ''
+      AND source_id = ''
+      AND field_id = ''
+    )
+  );
+
+CREATE INDEX idx_taxonomy_runs_tenant_scope_created_at
+  ON taxonomy_runs (tenant_id, scope_type, source_type, source_id, field_id, created_at DESC, id);
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+  constraint_name text;
+BEGIN
+  SELECT c.conname INTO constraint_name
+  FROM pg_constraint c
+  WHERE c.conrelid = 'taxonomy_active_runs'::regclass
+    AND c.contype = 'f'
+    AND c.confrelid = 'taxonomy_runs'::regclass;
+
+  IF constraint_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE taxonomy_active_runs DROP CONSTRAINT %I', constraint_name);
+  END IF;
+END $$;
+-- +goose StatementEnd
+
+ALTER TABLE taxonomy_active_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_pkey,
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_source_type_required,
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_field_id_required,
+  ADD CONSTRAINT taxonomy_active_runs_pkey
+    PRIMARY KEY (tenant_id, scope_type, source_type, source_id, field_id),
+  ADD CONSTRAINT taxonomy_active_runs_scope_shape CHECK (
+    (
+      scope_type = 'field'
+      AND btrim(source_type) <> ''
+      AND btrim(field_id) <> ''
+    )
+    OR (
+      scope_type = 'directory'
+      AND source_type = ''
+      AND source_id = ''
+      AND field_id = ''
+    )
+  ),
+  ADD CONSTRAINT taxonomy_active_runs_scope_fkey
+    FOREIGN KEY (run_id, tenant_id, scope_type, source_type, source_id, field_id)
+    REFERENCES taxonomy_runs(id, tenant_id, scope_type, source_type, source_id, field_id)
+    ON DELETE CASCADE;
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+  constraint_name text;
+BEGIN
+  SELECT c.conname INTO constraint_name
+  FROM pg_constraint c
+  WHERE c.conrelid = 'taxonomy_node_events'::regclass
+    AND c.contype = 'f'
+    AND c.confrelid = 'taxonomy_runs'::regclass;
+
+  IF constraint_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE taxonomy_node_events DROP CONSTRAINT %I', constraint_name);
+  END IF;
+END $$;
+-- +goose StatementEnd
+
+ALTER TABLE taxonomy_node_events
+  DROP CONSTRAINT IF EXISTS taxonomy_node_events_source_type_required,
+  DROP CONSTRAINT IF EXISTS taxonomy_node_events_field_id_required,
+  ADD CONSTRAINT taxonomy_node_events_scope_shape CHECK (
+    (
+      scope_type = 'field'
+      AND btrim(source_type) <> ''
+      AND btrim(field_id) <> ''
+    )
+    OR (
+      scope_type = 'directory'
+      AND source_type = ''
+      AND source_id = ''
+      AND field_id = ''
+    )
+  ),
+  ADD CONSTRAINT taxonomy_node_events_scope_fkey
+    FOREIGN KEY (run_id, tenant_id, scope_type, source_type, source_id, field_id)
+    REFERENCES taxonomy_runs(id, tenant_id, scope_type, source_type, source_id, field_id)
+    ON DELETE CASCADE;
+
+-- +goose down
+DELETE FROM taxonomy_runs WHERE scope_type = 'directory';
+
+ALTER TABLE taxonomy_active_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_scope_fkey;
+ALTER TABLE taxonomy_node_events
+  DROP CONSTRAINT IF EXISTS taxonomy_node_events_scope_fkey;
+
+ALTER TABLE taxonomy_active_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_pkey,
+  DROP CONSTRAINT IF EXISTS taxonomy_active_runs_scope_shape,
+  ADD CONSTRAINT taxonomy_active_runs_pkey
+    PRIMARY KEY (tenant_id, source_type, source_id, field_id),
+  ADD CONSTRAINT taxonomy_active_runs_source_type_required CHECK (btrim(source_type) <> ''),
+  ADD CONSTRAINT taxonomy_active_runs_field_id_required CHECK (btrim(field_id) <> ''),
+  DROP COLUMN IF EXISTS scope_type,
+  ADD CONSTRAINT taxonomy_active_runs_run_scope_fkey
+    FOREIGN KEY (run_id, tenant_id, source_type, source_id, field_id)
+    REFERENCES taxonomy_runs(id, tenant_id, source_type, source_id, field_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE taxonomy_node_events
+  DROP CONSTRAINT IF EXISTS taxonomy_node_events_scope_shape,
+  ADD CONSTRAINT taxonomy_node_events_source_type_required CHECK (btrim(source_type) <> ''),
+  ADD CONSTRAINT taxonomy_node_events_field_id_required CHECK (btrim(field_id) <> ''),
+  DROP COLUMN IF EXISTS scope_type,
+  ADD CONSTRAINT taxonomy_node_events_run_scope_fkey
+    FOREIGN KEY (run_id, tenant_id, source_type, source_id, field_id)
+    REFERENCES taxonomy_runs(id, tenant_id, source_type, source_id, field_id)
+    ON DELETE CASCADE;
+
+DROP INDEX IF EXISTS idx_taxonomy_runs_tenant_scope_created_at;
+
+ALTER TABLE taxonomy_runs
+  DROP CONSTRAINT IF EXISTS taxonomy_runs_scope_shape,
+  DROP CONSTRAINT IF EXISTS taxonomy_runs_scope_identity_unique,
+  ADD CONSTRAINT taxonomy_runs_source_type_required CHECK (btrim(source_type) <> ''),
+  ADD CONSTRAINT taxonomy_runs_field_id_required CHECK (btrim(field_id) <> ''),
+  DROP COLUMN IF EXISTS scope_type;
+
+DROP TYPE IF EXISTS taxonomy_scope_type_enum;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1483,10 +1483,10 @@ paths:
                 - Taxonomy
             summary: List taxonomy runs
             description: |
-                Returns taxonomy run history for a tenant, most recent first. Optionally filter by source_type,
-                field_id, and source_id. source_id is a tri-state filter: omit it for no source filter, pass an
-                empty string to scope to the canonical "no source" bucket, or pass a concrete value to match that
-                source.
+                Returns taxonomy run history for a tenant, most recent first. Optionally filter by scope_type,
+                source_type, field_id, and source_id. source_id is a tri-state filter: omit it for no source
+                filter, pass an empty string to scope to the canonical "no source" bucket, or pass a concrete
+                value to match that source.
             operationId: list-taxonomy-runs
             parameters:
                 - name: tenant_id
@@ -1499,6 +1499,12 @@ paths:
                     maxLength: 255
                     pattern: '^[^\x00]*$'
                     example: "org-123"
+                - name: scope_type
+                  in: query
+                  required: false
+                  description: Optional scope type filter. Omitted means no scope type filter.
+                  schema:
+                    $ref: '#/components/schemas/TaxonomyScopeType'
                 - name: source_type
                   in: query
                   required: false
@@ -1564,9 +1570,11 @@ paths:
                 - Taxonomy
             summary: Start a taxonomy run
             description: |
-                Starts a manual taxonomy generation run for a field scope. Hub validates that the field has enough
-                embedded text feedback (below the configured minimum returns 400 with an "insufficient data"
-                validation error), creates the run, and hands it to the taxonomy compute service.
+                Starts a manual taxonomy generation run for a field or directory scope. Hub validates that the
+                scope has enough embedded text feedback (below the configured minimum returns 400 with an
+                "insufficient data" validation error), creates the run, and hands it to the taxonomy compute
+                service. Omit scope_type for the existing field scope behavior; use scope_type=directory with
+                tenant_id only to generate one taxonomy over all text feedback in the directory.
 
                 Idempotent per scope: if a run is already pending or running for the same scope, the existing run
                 is returned with `in_progress: true` (HTTP 200) instead of starting a new one; a newly created run
@@ -1585,9 +1593,16 @@ paths:
                                 summary: Start a run for a survey field
                                 value:
                                     tenant_id: "org-123"
+                                    scope_type: "field"
                                     source_type: "formbricks"
                                     source_id: "survey-abc"
                                     field_id: "feedback"
+                                    actor_id: "user-42"
+                            directory:
+                                summary: Start a run for all text feedback in a directory
+                                value:
+                                    tenant_id: "org-123"
+                                    scope_type: "directory"
                                     actor_id: "user-42"
             responses:
                 "202":
@@ -1604,8 +1619,8 @@ paths:
                                 $ref: '#/components/schemas/CreateTaxonomyRunOutputBody'
                 "400":
                     description: |
-                        Bad Request – invalid scope, or insufficient input (no text feedback for the field, or
-                        fewer embedded records than the configured minimum).
+                            Bad Request – invalid scope, or insufficient input (no text feedback for the scope, or
+                            fewer embedded records than the configured minimum).
                     content:
                         application/problem+json:
                             schema:
@@ -1644,7 +1659,7 @@ paths:
                 - Taxonomy
             summary: Get the active taxonomy tree for a scope
             description: |
-                Returns the currently active taxonomy run and its tree for a field scope. Exactly one run is
+                Returns the currently active taxonomy run and its tree for a field or directory scope. Exactly one run is
                 active per scope at a time. Returns 404 when no run has been activated for the scope.
             operationId: get-active-taxonomy-tree
             parameters:
@@ -1658,10 +1673,16 @@ paths:
                     maxLength: 255
                     pattern: '^[^\x00]*$'
                     example: "org-123"
+                - name: scope_type
+                  in: query
+                  required: false
+                  description: Scope type. Omit for field scope; use directory with tenant_id only for directory taxonomy.
+                  schema:
+                    $ref: '#/components/schemas/TaxonomyScopeType'
                 - name: source_type
                   in: query
-                  required: true
-                  description: Source type of the scope.
+                  required: false
+                  description: Source type of a field scope. Must be omitted for directory scope.
                   schema:
                     type: string
                     minLength: 1
@@ -1677,8 +1698,8 @@ paths:
                     pattern: '^[^\x00]*$'
                 - name: field_id
                   in: query
-                  required: true
-                  description: Field ID of the scope.
+                  required: false
+                  description: Field ID of a field scope. Must be omitted for directory scope.
                   schema:
                     type: string
                     minLength: 1
@@ -2982,6 +3003,15 @@ components:
                 - generation_failed
                 - invalid_output
                 - internal_error
+        TaxonomyScopeType:
+            type: string
+            description: |
+                Taxonomy input scope. `field` covers one (source_type, source_id, field_id) field scope.
+                `directory` covers all text feedback records for the tenant/directory and must not include
+                source_type, source_id, or field_id.
+            enum:
+                - field
+                - directory
         TaxonomyNodeType:
             type: string
             description: Position of a node within the taxonomy tree.
@@ -3000,6 +3030,8 @@ components:
                 id:
                     type: string
                     format: uuid
+                scope_type:
+                    $ref: '#/components/schemas/TaxonomyScopeType'
                 tenant_id:
                     type: string
                 source_type:
@@ -3053,6 +3085,7 @@ components:
                     format: date-time
             required:
                 - id
+                - scope_type
                 - tenant_id
                 - source_type
                 - source_id
@@ -3178,8 +3211,13 @@ components:
         CreateTaxonomyRunInputBody:
             type: object
             additionalProperties: false
-            description: Request to start a manual taxonomy run for a field scope.
+            description: |
+                Request to start a manual taxonomy run. Omit scope_type or set it to `field` for the existing
+                field-scoped behavior. Set scope_type to `directory` with only tenant_id to generate one
+                taxonomy over all text feedback in the directory.
             properties:
+                scope_type:
+                    $ref: '#/components/schemas/TaxonomyScopeType'
                 tenant_id:
                     type: string
                     minLength: 1
@@ -3190,16 +3228,18 @@ components:
                     minLength: 1
                     maxLength: 255
                     pattern: '^[^\x00]*$'
+                    description: Required for field scope; omit for directory scope.
                 source_id:
                     type: string
                     maxLength: 255
                     pattern: '^[^\x00]*$'
-                    description: Optional; empty or omitted is the canonical "no source" bucket.
+                    description: Optional for field scope; empty or omitted is the canonical "no source" bucket. Omit for directory scope.
                 field_id:
                     type: string
                     minLength: 1
                     maxLength: 255
                     pattern: '^[^\x00]*$'
+                    description: Required for field scope; omit for directory scope.
                 field_label:
                     type: string
                     pattern: '^[^\x00]*$'
@@ -3212,8 +3252,6 @@ components:
                     description: Optional identifier of the actor starting the run.
             required:
                 - tenant_id
-                - source_type
-                - field_id
         CreateTaxonomyRunOutputBody:
             type: object
             additionalProperties: false

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -254,6 +254,14 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusBadRequest, nil)
 	})
 
+	t.Run("directory scope rejects field selectors", func(t *testing.T) {
+		scope := uniqueDirectoryTaxonomyScope("tax-api-create-directory-invalid")
+		scope.SourceType = "formbricks"
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusBadRequest, nil)
+	})
+
 	t.Run("accepts a new run and reuses an in-progress one", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-api-create-ok")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
@@ -268,6 +276,45 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 		assert.Contains(t, harness.starter.startedRunIDs(), first.Run.ID.String())
 
 		// A second request for the same scope reuses the running run (200, in_progress).
+		var second models.CreateTaxonomyRunResponse
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusOK, &second)
+		require.True(t, second.InProgress)
+		assert.Equal(t, first.Run.ID, second.Run.ID)
+	})
+
+	t.Run("accepts a directory run across sources and fields", func(t *testing.T) {
+		directoryScope := uniqueDirectoryTaxonomyScope("tax-api-create-directory")
+		cleanupTaxonomyTenant(ctx, t, harness.db, directoryScope.TenantID)
+
+		firstFieldScope := models.TaxonomyScope{
+			TenantID:   directoryScope.TenantID,
+			SourceType: "formbricks",
+			SourceID:   "survey-" + uuid.NewString(),
+			FieldID:    "ces_comment",
+		}
+		secondFieldScope := models.TaxonomyScope{
+			TenantID:   directoryScope.TenantID,
+			SourceType: "support",
+			SourceID:   "ticket-" + uuid.NewString(),
+			FieldID:    "support_comment",
+		}
+		seedEmbeddedFeedback(ctx, t, harness, firstFieldScope, taxonomyMinEmbeddedRecords)
+		seedEmbeddedFeedback(ctx, t, harness, secondFieldScope, taxonomyMinEmbeddedRecords+1)
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: directoryScope}
+
+		var first models.CreateTaxonomyRunResponse
+		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusAccepted, &first)
+		require.False(t, first.InProgress)
+		assert.Equal(t, models.TaxonomyScopeTypeDirectory, first.Run.ScopeType)
+		assert.Empty(t, first.Run.SourceType)
+		assert.Empty(t, first.Run.SourceID)
+		assert.Empty(t, first.Run.FieldID)
+		require.NotNil(t, first.Run.FieldLabel)
+		assert.Equal(t, "All feedback", *first.Run.FieldLabel)
+		assert.Equal(t, taxonomyMinEmbeddedRecords*2+1, first.Run.RecordCount)
+		assert.Equal(t, taxonomyMinEmbeddedRecords*2+1, first.Run.EmbeddingCount)
+
 		var second models.CreateTaxonomyRunResponse
 		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusOK, &second)
 		require.True(t, second.InProgress)
@@ -299,6 +346,47 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		require.NotEmpty(t, input.Records)
 		assert.NotEmpty(t, input.Records[0].Embedding)
 		assert.NotEmpty(t, input.Records[0].ValueText)
+	})
+
+	t.Run("directory run input spans sources and fields", func(t *testing.T) {
+		directoryScope := uniqueDirectoryTaxonomyScope("tax-internal-directory-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, directoryScope.TenantID)
+
+		firstFieldScope := models.TaxonomyScope{
+			TenantID:   directoryScope.TenantID,
+			SourceType: "formbricks",
+			SourceID:   "survey-" + uuid.NewString(),
+			FieldID:    "ces_comment",
+		}
+		secondFieldScope := models.TaxonomyScope{
+			TenantID:   directoryScope.TenantID,
+			SourceType: "support",
+			SourceID:   "ticket-" + uuid.NewString(),
+			FieldID:    "support_comment",
+		}
+		seedEmbeddedFeedback(ctx, t, harness, firstFieldScope, taxonomyMinEmbeddedRecords)
+		seedEmbeddedFeedback(ctx, t, harness, secondFieldScope, taxonomyMinEmbeddedRecords+1)
+
+		runID := startRunForScope(ctx, t, harness, directoryScope)
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+		assert.Equal(t, models.TaxonomyScopeTypeDirectory, input.Run.ScopeType)
+		require.Len(t, input.Records, taxonomyMinEmbeddedRecords*2+1)
+
+		fieldIDs := map[string]bool{}
+		sourceTypes := map[string]bool{}
+		for _, record := range input.Records {
+			fieldIDs[record.FieldID] = true
+			sourceTypes[record.SourceType] = true
+			assert.NotEmpty(t, record.Embedding)
+			assert.NotEmpty(t, record.ValueText)
+		}
+		assert.True(t, fieldIDs["ces_comment"])
+		assert.True(t, fieldIDs["support_comment"])
+		assert.True(t, sourceTypes["formbricks"])
+		assert.True(t, sourceTypes["support"])
 	})
 
 	t.Run("complete run stores artifacts and activates", func(t *testing.T) {

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -298,6 +298,7 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 			SourceID:   "ticket-" + uuid.NewString(),
 			FieldID:    "support_comment",
 		}
+
 		seedEmbeddedFeedback(ctx, t, harness, firstFieldScope, taxonomyMinEmbeddedRecords)
 		seedEmbeddedFeedback(ctx, t, harness, secondFieldScope, taxonomyMinEmbeddedRecords+1)
 
@@ -364,6 +365,7 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 			SourceID:   "ticket-" + uuid.NewString(),
 			FieldID:    "support_comment",
 		}
+
 		seedEmbeddedFeedback(ctx, t, harness, firstFieldScope, taxonomyMinEmbeddedRecords)
 		seedEmbeddedFeedback(ctx, t, harness, secondFieldScope, taxonomyMinEmbeddedRecords+1)
 
@@ -377,12 +379,14 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 
 		fieldIDs := map[string]bool{}
 		sourceTypes := map[string]bool{}
+
 		for _, record := range input.Records {
 			fieldIDs[record.FieldID] = true
 			sourceTypes[record.SourceType] = true
 			assert.NotEmpty(t, record.Embedding)
 			assert.NotEmpty(t, record.ValueText)
 		}
+
 		assert.True(t, fieldIDs["ces_comment"])
 		assert.True(t, fieldIDs["support_comment"])
 		assert.True(t, sourceTypes["formbricks"])

--- a/tests/taxonomy_support_test.go
+++ b/tests/taxonomy_support_test.go
@@ -371,3 +371,10 @@ func uniqueTaxonomyScope(prefix string) models.TaxonomyScope {
 		FieldID:    "feedback",
 	}
 }
+
+func uniqueDirectoryTaxonomyScope(prefix string) models.TaxonomyScope {
+	return models.TaxonomyScope{
+		ScopeType: models.TaxonomyScopeTypeDirectory,
+		TenantID:  prefix + "-" + uuid.NewString(),
+	}
+}


### PR DESCRIPTION
## Summary

- Add `scope_type` to taxonomy scopes and runs, with existing field-scoped behavior as the default.
- Add a directory scope that generates one taxonomy across all text feedback records for a tenant.
- Persist directory-scoped active runs and node events with scope-aware keys and constraints.
- Return mixed-source/mixed-field run input records to the taxonomy service with per-record `source_type`, `source_id`, and `field_id` metadata.
- Update OpenAPI plus service/API coverage for directory runs.

## Why

The app should be able to offer one simple "Generate taxonomy" action for a directory, without requiring users to pick a dataset/source/field. The previous Hub contract required `source_type` and `field_id`, so the only possible run scope was one feedback field.

## Companion PR

- Taxonomy service: https://github.com/formbricks/taxonomy/pull/6

## Validation

- `go test ./internal/service ./internal/models ./internal/repository ./internal/api/handlers`
- `make migrate-validate`
- Ruby YAML parse for `openapi.yaml`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5433/codex_taxonomy_test?sslmode=disable go test ./tests -run 'TestTaxonomyAPI_(CreateRun|InternalServiceEndpoints)' -count=1 -v`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5433/codex_taxonomy_test?sslmode=disable make tests`
- Local smoke with Hub API on `127.0.0.1:8080` and taxonomy service on `127.0.0.1:8001`: Hub `/health`, Hub `/openapi.yaml`, taxonomy `/health`, and Hub internal taxonomy `auth-check`