### PR TITLE
feat: add value_id to feedback records for stable option identity

### DIFF
--- a/internal/api/handlers/feedback_records_handler_test.go
+++ b/internal/api/handlers/feedback_records_handler_test.go
@@ -450,6 +450,7 @@ func TestFeedbackRecordsHandler_BodyBounds(t *testing.T) {
 			"source_id":         `"source_id":"` + over256 + `"`,
 			"source_name":       `"source_name":"` + over256 + `"`,
 			"user_id":           `"user_id":"` + over256 + `"`,
+			"value_id":          `"value_id":"` + over256 + `"`,
 			"field_label":       `"field_label":"` + over2049 + `"`,
 			"field_group_label": `"field_group_label":"` + over2049 + `"`,
 		}

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -254,27 +254,31 @@ func (e EmotionValue) IsValid() bool {
 
 // FeedbackRecord represents a single feedback record.
 type FeedbackRecord struct {
-	ID              uuid.UUID       `json:"id"`
-	CollectedAt     time.Time       `json:"collected_at"`
-	CreatedAt       time.Time       `json:"created_at"`
-	UpdatedAt       time.Time       `json:"updated_at"`
-	SourceType      string          `json:"source_type"`
-	SourceID        *string         `json:"source_id,omitempty"`
-	SourceName      *string         `json:"source_name,omitempty"`
-	FieldID         string          `json:"field_id"`
-	FieldLabel      *string         `json:"field_label,omitempty"`
-	FieldType       FieldType       `json:"field_type"`
-	FieldGroupID    *string         `json:"field_group_id,omitempty"`
-	FieldGroupLabel *string         `json:"field_group_label,omitempty"`
-	ValueText       *string         `json:"value_text,omitempty"`
-	ValueNumber     *float64        `json:"value_number,omitempty"`
-	ValueBoolean    *bool           `json:"value_boolean,omitempty"`
-	ValueDate       *time.Time      `json:"value_date,omitempty"`
-	Metadata        json.RawMessage `json:"metadata,omitempty"`
-	Language        *string         `json:"language,omitempty"`
-	UserID          *string         `json:"user_id,omitempty"`
-	TenantID        string          `json:"tenant_id"`
-	SubmissionID    string          `json:"submission_id"` // mandatory; never null
+	ID              uuid.UUID `json:"id"`
+	CollectedAt     time.Time `json:"collected_at"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	SourceType      string    `json:"source_type"`
+	SourceID        *string   `json:"source_id,omitempty"`
+	SourceName      *string   `json:"source_name,omitempty"`
+	FieldID         string    `json:"field_id"`
+	FieldLabel      *string   `json:"field_label,omitempty"`
+	FieldType       FieldType `json:"field_type"`
+	FieldGroupID    *string   `json:"field_group_id,omitempty"`
+	FieldGroupLabel *string   `json:"field_group_label,omitempty"`
+	ValueText       *string   `json:"value_text,omitempty"`
+	// ValueID is the source system's stable id for a selected option (e.g. a survey choice id),
+	// stored alongside ValueText's display label so selected-choice answers keep a durable identity
+	// across label edits and languages. Opaque to Hub; nil for free-text/non-choice answers.
+	ValueID      *string         `json:"value_id,omitempty"`
+	ValueNumber  *float64        `json:"value_number,omitempty"`
+	ValueBoolean *bool           `json:"value_boolean,omitempty"`
+	ValueDate    *time.Time      `json:"value_date,omitempty"`
+	Metadata     json.RawMessage `json:"metadata,omitempty"`
+	Language     *string         `json:"language,omitempty"`
+	UserID       *string         `json:"user_id,omitempty"`
+	TenantID     string          `json:"tenant_id"`
+	SubmissionID string          `json:"submission_id"` // mandatory; never null
 	// Language-enrichment outputs (ENG-1255): server-generated, read-only. NULL until
 	// the record is translated into the tenant's configured target language.
 	ValueTextTranslated *string `json:"value_text_translated,omitempty"`
@@ -313,6 +317,7 @@ type CreateFeedbackRecordRequest struct {
 	FieldGroupID    *string         `json:"field_group_id,omitempty"    validate:"omitempty,no_null_bytes,max=255"`
 	FieldGroupLabel *string         `json:"field_group_label,omitempty" validate:"omitempty,no_null_bytes,max=2048"`
 	ValueText       *string         `json:"value_text,omitempty"        validate:"omitempty,no_null_bytes,max=30000"`
+	ValueID         *string         `json:"value_id,omitempty"          validate:"omitempty,no_null_bytes,max=255"`
 	ValueNumber     *float64        `json:"value_number,omitempty"`
 	ValueBoolean    *bool           `json:"value_boolean,omitempty"`
 	ValueDate       *time.Time      `json:"value_date,omitempty"`
@@ -334,6 +339,7 @@ type TranslationBackfillTarget struct {
 // Only value fields, metadata, language, and user_id can be updated.
 type UpdateFeedbackRecordRequest struct {
 	ValueText    *string         `json:"value_text,omitempty"    validate:"omitempty,no_null_bytes,max=30000"`
+	ValueID      *string         `json:"value_id,omitempty"      validate:"omitempty,no_null_bytes,max=255"`
 	ValueNumber  *float64        `json:"value_number,omitempty"`
 	ValueBoolean *bool           `json:"value_boolean,omitempty"`
 	ValueDate    *time.Time      `json:"value_date,omitempty"`
@@ -352,6 +358,10 @@ func (r *UpdateFeedbackRecordRequest) FieldsChangedFrom(old *FeedbackRecord) []s
 
 	if r.ValueText != nil && !stringPtrEqual(old.ValueText, r.ValueText) {
 		fields = append(fields, "value_text")
+	}
+
+	if r.ValueID != nil && !stringPtrEqual(old.ValueID, r.ValueID) {
+		fields = append(fields, "value_id")
 	}
 
 	if r.ValueNumber != nil && (old.ValueNumber == nil || *old.ValueNumber != *r.ValueNumber) {
@@ -399,6 +409,10 @@ func (r *UpdateFeedbackRecordRequest) ChangedFields() []string {
 		fields = append(fields, "value_text")
 	}
 
+	if r.ValueID != nil {
+		fields = append(fields, "value_id")
+	}
+
 	if r.ValueNumber != nil {
 		fields = append(fields, "value_number")
 	}
@@ -435,6 +449,7 @@ type ListFeedbackRecordsFilters struct {
 	FieldID      *string    `form:"field_id"       validate:"omitempty,no_null_bytes"`
 	FieldGroupID *string    `form:"field_group_id" validate:"omitempty,no_null_bytes"`
 	FieldType    *FieldType `form:"field_type"     validate:"omitempty,field_type"`
+	ValueID      *string    `form:"value_id"       validate:"omitempty,no_null_bytes"`
 	UserID       *string    `form:"user_id"        validate:"omitempty,no_null_bytes"`
 	Since        *time.Time `form:"since"          validate:"omitempty"`
 	Until        *time.Time `form:"until"          validate:"omitempty"`

--- a/internal/models/feedback_records_change_test.go
+++ b/internal/models/feedback_records_change_test.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestUpdateFeedbackRecordRequest_ChangedFields verifies presence-based change detection includes
+// value_id when set and omits it when nil.
+func TestUpdateFeedbackRecordRequest_ChangedFields(t *testing.T) {
+	valueID := "opt_a"
+
+	t.Run("value_id set is reported", func(t *testing.T) {
+		got := (&UpdateFeedbackRecordRequest{ValueID: &valueID}).ChangedFields()
+		if !slices.Contains(got, "value_id") {
+			t.Fatalf("ChangedFields() = %v, want it to contain value_id", got)
+		}
+	})
+
+	t.Run("value_id nil is omitted", func(t *testing.T) {
+		text := "hi"
+
+		got := (&UpdateFeedbackRecordRequest{ValueText: &text}).ChangedFields()
+		if slices.Contains(got, "value_id") {
+			t.Fatalf("ChangedFields() = %v, want it to omit value_id", got)
+		}
+	})
+}
+
+// TestUpdateFeedbackRecordRequest_FieldsChangedFrom verifies comparison-based change detection for
+// value_id: a differing value is reported, an idempotent re-send of the same value is not.
+func TestUpdateFeedbackRecordRequest_FieldsChangedFrom(t *testing.T) {
+	oldID := "opt_a"
+	newID := "opt_b"
+
+	t.Run("changed value is reported", func(t *testing.T) {
+		old := &FeedbackRecord{ValueID: &oldID}
+
+		got := (&UpdateFeedbackRecordRequest{ValueID: &newID}).FieldsChangedFrom(old)
+		if !slices.Contains(got, "value_id") {
+			t.Fatalf("FieldsChangedFrom() = %v, want it to contain value_id", got)
+		}
+	})
+
+	t.Run("unchanged value is not reported", func(t *testing.T) {
+		old := &FeedbackRecord{ValueID: &oldID}
+		sameID := "opt_a"
+
+		got := (&UpdateFeedbackRecordRequest{ValueID: &sameID}).FieldsChangedFrom(old)
+		if slices.Contains(got, "value_id") {
+			t.Fatalf("FieldsChangedFrom() = %v, want it to omit value_id (idempotent re-send)", got)
+		}
+	})
+
+	t.Run("newly set from nil is reported", func(t *testing.T) {
+		old := &FeedbackRecord{}
+
+		got := (&UpdateFeedbackRecordRequest{ValueID: &newID}).FieldsChangedFrom(old)
+		if !slices.Contains(got, "value_id") {
+			t.Fatalf("FieldsChangedFrom() = %v, want it to contain value_id", got)
+		}
+	})
+}

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -43,7 +43,7 @@ func NewFeedbackRecordsRepository(db *pgxpool.Pool) *FeedbackRecordsRepository {
 const feedbackRecordColumns = `id, collected_at, created_at, updated_at,
 	source_type, source_id, source_name,
 	field_id, field_label, field_type, field_group_id, field_group_label,
-	value_text, value_number, value_boolean, value_date,
+	value_text, value_id, value_number, value_boolean, value_date,
 	metadata, language, user_id, tenant_id, submission_id,
 	value_text_translated, translation_lang_key,
 	sentiment, sentiment_score,
@@ -72,6 +72,7 @@ func scanFeedbackRecord(row scanner) (*models.FeedbackRecord, error) {
 		&record.FieldGroupID,
 		&record.FieldGroupLabel,
 		&record.ValueText,
+		&record.ValueID,
 		&record.ValueNumber,
 		&record.ValueBoolean,
 		&record.ValueDate,
@@ -112,16 +113,16 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 	// write lock in a single statement (held for this statement's implicit
 	// transaction): one round trip, same isolation against a tenant data purge.
 	// Zero rows means the lock was refused (purge in progress).
-	const lockKeyParam = 19 // $19, after the 18 inserted columns
+	const lockKeyParam = 20 // $20, after the 19 inserted columns
 
 	query := `
 		INSERT INTO feedback_records (
 			collected_at, source_type, source_id, source_name,
 			field_id, field_label, field_type, field_group_id, field_group_label,
 			value_text, value_number, value_boolean, value_date,
-			metadata, language, user_id, tenant_id, submission_id
+			metadata, language, user_id, tenant_id, submission_id, value_id
 		)
-		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
 		WHERE ` + tenantWriteLockGate(lockKeyParam) + `
 		RETURNING ` + feedbackRecordColumns
 
@@ -129,7 +130,7 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 		collectedAt, req.SourceType, req.SourceID, req.SourceName,
 		req.FieldID, req.FieldLabel, req.FieldType, req.FieldGroupID, req.FieldGroupLabel,
 		req.ValueText, req.ValueNumber, req.ValueBoolean, req.ValueDate,
-		req.Metadata, req.Language, req.UserID, req.TenantID, req.SubmissionID,
+		req.Metadata, req.Language, req.UserID, req.TenantID, req.SubmissionID, req.ValueID,
 		TenantWriteLockKey(req.TenantID),
 	))
 	if err != nil {
@@ -660,6 +661,12 @@ func buildFilterConditions(filters *models.ListFeedbackRecordsFilters) (whereCla
 		argCount++
 	}
 
+	if filters.ValueID != nil {
+		conditions = append(conditions, fmt.Sprintf("value_id = $%d", argCount))
+		args = append(args, *filters.ValueID)
+		argCount++
+	}
+
 	if filters.UserID != nil {
 		conditions = append(conditions, fmt.Sprintf("user_id = $%d", argCount))
 		args = append(args, *filters.UserID)
@@ -789,6 +796,14 @@ func buildUpdateQuery(
 		valueTextArg = argCount
 		updates = append(updates, fmt.Sprintf("value_text = $%d", argCount))
 		args = append(args, *req.ValueText)
+		argCount++
+	}
+
+	// value_id is a plain caller-supplied field (not an enrichment source), so it is set
+	// directly and does not participate in the stale-enrichment clears below.
+	if req.ValueID != nil {
+		updates = append(updates, fmt.Sprintf("value_id = $%d", argCount))
+		args = append(args, *req.ValueID)
 		argCount++
 	}
 

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -617,70 +617,62 @@ func scanBackfillTargetIDs(rows pgx.Rows, name string) ([]uuid.UUID, error) {
 func buildFilterConditions(filters *models.ListFeedbackRecordsFilters) (whereClause string, args []any) {
 	var conditions []string
 
-	argCount := 1
-
+	// Each placeholder is len(args)+1, evaluated before that condition's arg is appended, so $N
+	// always equals the argument's 1-based position. Deriving it from the slice length (rather than
+	// a manual counter) means conditions stay correct in any order and a new filter can be added
+	// anywhere without desyncing a counter.
 	if filters.TenantID != nil {
-		conditions = append(conditions, fmt.Sprintf("tenant_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("tenant_id = $%d", len(args)+1))
 		args = append(args, *filters.TenantID)
-		argCount++
 	}
 
 	if filters.SubmissionID != nil {
-		conditions = append(conditions, fmt.Sprintf("submission_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("submission_id = $%d", len(args)+1))
 		args = append(args, *filters.SubmissionID)
-		argCount++
 	}
 
 	if filters.SourceType != nil {
-		conditions = append(conditions, fmt.Sprintf("source_type = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("source_type = $%d", len(args)+1))
 		args = append(args, *filters.SourceType)
-		argCount++
 	}
 
 	if filters.SourceID != nil {
-		conditions = append(conditions, fmt.Sprintf("source_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("source_id = $%d", len(args)+1))
 		args = append(args, *filters.SourceID)
-		argCount++
 	}
 
 	if filters.FieldID != nil {
-		conditions = append(conditions, fmt.Sprintf("field_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("field_id = $%d", len(args)+1))
 		args = append(args, *filters.FieldID)
-		argCount++
 	}
 
 	if filters.FieldGroupID != nil {
-		conditions = append(conditions, fmt.Sprintf("field_group_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("field_group_id = $%d", len(args)+1))
 		args = append(args, *filters.FieldGroupID)
-		argCount++
 	}
 
 	if filters.FieldType != nil {
-		conditions = append(conditions, fmt.Sprintf("field_type = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("field_type = $%d", len(args)+1))
 		args = append(args, *filters.FieldType)
-		argCount++
 	}
 
 	if filters.ValueID != nil {
-		conditions = append(conditions, fmt.Sprintf("value_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("value_id = $%d", len(args)+1))
 		args = append(args, *filters.ValueID)
-		argCount++
 	}
 
 	if filters.UserID != nil {
-		conditions = append(conditions, fmt.Sprintf("user_id = $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("user_id = $%d", len(args)+1))
 		args = append(args, *filters.UserID)
-		argCount++
 	}
 
 	if filters.Since != nil {
-		conditions = append(conditions, fmt.Sprintf("collected_at >= $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("collected_at >= $%d", len(args)+1))
 		args = append(args, *filters.Since)
-		argCount++
 	}
 
 	if filters.Until != nil {
-		conditions = append(conditions, fmt.Sprintf("collected_at <= $%d", argCount))
+		conditions = append(conditions, fmt.Sprintf("collected_at <= $%d", len(args)+1))
 		args = append(args, *filters.Until)
 	}
 

--- a/internal/repository/feedback_records_repository_test.go
+++ b/internal/repository/feedback_records_repository_test.go
@@ -29,6 +29,7 @@ func TestBuildUpdateQuery_ClearsStaleEnrichmentOnContentChange(t *testing.T) {
 	text := "updated text"
 	lang := "de-DE"
 	user := "user-1"
+	valueID := "opt_a"
 	meta := json.RawMessage(`{"k":"v"}`)
 
 	// Enrichment output columns, grouped by what invalidates them.
@@ -58,6 +59,11 @@ func TestBuildUpdateQuery_ClearsStaleEnrichmentOnContentChange(t *testing.T) {
 		},
 		{"metadata-only change clears nothing", &models.UpdateFeedbackRecordRequest{Metadata: meta}, nil},
 		{"user_id-only change clears nothing", &models.UpdateFeedbackRecordRequest{UserID: &user}, nil},
+		{
+			"value_id-only change clears nothing",
+			&models.UpdateFeedbackRecordRequest{ValueID: &valueID},
+			nil,
+		},
 	}
 
 	for _, testCase := range cases {
@@ -85,4 +91,29 @@ func TestBuildUpdateQuery_ClearsStaleEnrichmentOnContentChange(t *testing.T) {
 // clearColumnWhen. The " = CASE WHEN" suffix makes "sentiment" not match "sentiment_score".
 func clearsColumn(query, col string) bool {
 	return strings.Contains(query, col+" = CASE WHEN")
+}
+
+// TestBuildUpdateQuery_ValueID verifies value_id is a plain assignable column: an
+// update carrying it emits a direct "value_id = $N" SET clause (not an eager-clear CASE),
+// since it is caller-supplied data rather than a derived enrichment.
+func TestBuildUpdateQuery_ValueID(t *testing.T) {
+	valueID := "opt_very_satisfied"
+	req := &models.UpdateFeedbackRecordRequest{ValueID: &valueID}
+
+	query, args, hasUpdates := buildUpdateQuery(req, uuid.New(), time.Now())
+	if !hasUpdates {
+		t.Fatal("buildUpdateQuery hasUpdates = false, want true")
+	}
+
+	if !strings.Contains(query, "value_id = $1") {
+		t.Fatalf("query missing direct value_id assignment\nquery: %s", query)
+	}
+
+	if clearsColumn(query, "value_id") {
+		t.Fatalf("value_id must not be an eager-clear column\nquery: %s", query)
+	}
+
+	if len(args) == 0 || args[0] != valueID {
+		t.Fatalf("args = %v, want first arg %q", args, valueID)
+	}
 }

--- a/internal/repository/feedback_records_repository_test.go
+++ b/internal/repository/feedback_records_repository_test.go
@@ -117,3 +117,61 @@ func TestBuildUpdateQuery_ValueID(t *testing.T) {
 		t.Fatalf("args = %v, want first arg %q", args, valueID)
 	}
 }
+
+// TestBuildFilterConditions_PlaceholdersMatchArgs locks that every generated $N placeholder maps to
+// its argument's 1-based position for any combination of filters. The placeholder is derived from
+// len(args)+1 at each append precisely so the order of filters can't desync it — this guards
+// against a regression to a manual counter (a trailing filter that forgot to advance it would bind
+// the wrong value). Every filter is set here, so the conditions appear in the function's fixed
+// order and each column's placeholder must equal its position.
+func TestBuildFilterConditions_PlaceholdersMatchArgs(t *testing.T) {
+	tenant := "t1"
+	submission := "s1"
+	sourceType := "survey"
+	sourceID := "src1"
+	fieldID := "q1"
+	fieldGroupID := "g1"
+	fieldType := models.FieldTypeCategorical
+	valueID := "opt_a"
+	userID := "u1"
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	where, args := buildFilterConditions(&models.ListFeedbackRecordsFilters{
+		TenantID: &tenant, SubmissionID: &submission, SourceType: &sourceType,
+		SourceID: &sourceID, FieldID: &fieldID, FieldGroupID: &fieldGroupID,
+		FieldType: &fieldType, ValueID: &valueID, UserID: &userID,
+		Since: &since, Until: &until,
+	})
+
+	expected := []struct {
+		clause string
+		value  any
+	}{
+		{"tenant_id = $1", tenant},
+		{"submission_id = $2", submission},
+		{"source_type = $3", sourceType},
+		{"source_id = $4", sourceID},
+		{"field_id = $5", fieldID},
+		{"field_group_id = $6", fieldGroupID},
+		{"field_type = $7", fieldType},
+		{"value_id = $8", valueID},
+		{"user_id = $9", userID},
+		{"collected_at >= $10", since},
+		{"collected_at <= $11", until},
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("args len = %d, want %d\nwhere: %s", len(args), len(expected), where)
+	}
+
+	for i, exp := range expected {
+		if !strings.Contains(where, exp.clause) {
+			t.Fatalf("where clause missing %q\ngot: %s", exp.clause, where)
+		}
+
+		if args[i] != exp.value {
+			t.Fatalf("args[%d] = %v, want %v (placeholder in %q must bind that arg)", i, args[i], exp.value, exp.clause)
+		}
+	}
+}

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -839,7 +839,7 @@ func (r *TaxonomyRepository) ListNodeRecords(
 		SELECT fr.id, fr.collected_at, fr.created_at, fr.updated_at,
 			fr.source_type, fr.source_id, fr.source_name,
 			fr.field_id, fr.field_label, fr.field_type, fr.field_group_id, fr.field_group_label,
-			fr.value_text, fr.value_number, fr.value_boolean, fr.value_date,
+			fr.value_text, fr.value_id, fr.value_number, fr.value_boolean, fr.value_date,
 			fr.metadata, fr.language, fr.user_id, fr.tenant_id, fr.submission_id,
 			fr.value_text_translated, fr.translation_lang_key,
 			fr.sentiment, fr.sentiment_score,

--- a/migrations/018_add_feedback_record_value_id.sql
+++ b/migrations/018_add_feedback_record_value_id.sql
@@ -1,0 +1,32 @@
+-- +goose NO TRANSACTION
+-- +goose up
+-- value_id is the stable id of the selected option in the source system (a Formbricks survey choice
+-- id, a matrix column id, etc.), stored alongside the human-readable value_text so selected-choice
+-- answers keep a durable identity across label edits and response-language differences (ENG-1671).
+-- Hub treats it as an opaque string (no validation against any source registry); it is NULL for
+-- non-choice fields, free-text/"other" answers, and non-Formbricks sources (CSV, integrations),
+-- where value_text remains the fallback identity.
+--
+-- Runs without a transaction (like the other index migrations) so it never holds a long lock on
+-- feedback_records (the primary, high-write table):
+--   * ADD COLUMN of a nullable column with no default is metadata-only (instant).
+--   * the index is built CONCURRENTLY (no ACCESS EXCLUSIVE / write block).
+-- Every statement is also RE-RUNNABLE: under NO TRANSACTION each statement auto-commits while goose
+-- records the version only at the end, so an interrupted deploy (e.g. pod eviction mid CREATE INDEX
+-- CONCURRENTLY, which additionally leaves an INVALID index) re-runs the whole file cleanly.
+ALTER TABLE feedback_records ADD COLUMN IF NOT EXISTS value_id VARCHAR(255);
+
+-- Targeted lookups are "all records for option X of field F in tenant T" (the label-edit update
+-- flow) and the value_id list filter, i.e. equality on (tenant_id, field_id, value_id). value_id is
+-- sparse (NULL for text/CSV/non-choice rows), so a PARTIAL index over the non-NULL rows keeps it
+-- small and off the ingestion write path for the common text-only record — mirroring the table's
+-- other sparse-column partial indexes (sentiment, emotions). The composite is left-prefix usable
+-- for (tenant_id, field_id) too. DROP-then-CREATE (not IF NOT EXISTS) so a re-run after an
+-- interrupted build replaces the INVALID leftover instead of keeping it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_feedback_records_tenant_field_value_id;
+CREATE INDEX CONCURRENTLY idx_feedback_records_tenant_field_value_id
+  ON feedback_records (tenant_id, field_id, value_id) WHERE value_id IS NOT NULL;
+
+-- +goose down
+DROP INDEX CONCURRENTLY IF EXISTS idx_feedback_records_tenant_field_value_id;
+ALTER TABLE feedback_records DROP COLUMN IF EXISTS value_id;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,6 +148,15 @@ paths:
                         - boolean
                         - date
                     pattern: '^[^\x00]*$'
+                - name: value_id
+                  in: query
+                  description: Filter by the source system's stable option id (e.g. all records for one survey choice). NULL bytes not allowed.
+                  schema:
+                    type: string
+                    description: Filter by the source system's stable option id. NULL bytes not allowed.
+                    pattern: '^[^\x00]*$'
+                    maxLength: 255
+                    example: "opt_very_satisfied"
                 - name: user_id
                   in: query
                   description: Filter by user ID. NULL bytes not allowed.
@@ -2435,6 +2444,13 @@ components:
                         - Great service!
                     pattern: '^[^\x00]*$'
                     maxLength: 30000
+                value_id:
+                    type: [string, "null"]
+                    description: Stable id of the selected option in the source system (e.g. a survey choice id or matrix column id), stored alongside value_text so selected-choice answers keep a durable identity across label edits and languages. Opaque to Hub (not validated). Null for free-text/"other" answers, non-choice fields, and sources without option ids. NULL bytes not allowed when present.
+                    examples:
+                        - opt_very_satisfied
+                    pattern: '^[^\x00]*$'
+                    maxLength: 255
             required:
                 - source_type
                 - field_id
@@ -2654,6 +2670,10 @@ components:
                 value_text:
                     type: string
                     description: Text response. NULL bytes not allowed.
+                    pattern: '^[^\x00]*$'
+                value_id:
+                    type: string
+                    description: Stable id of the selected option in the source system (e.g. a survey choice id), stored alongside value_text for durable option identity. Opaque to Hub. Absent for free-text/non-choice answers. NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
                 value_text_translated:
                     type: string
@@ -2985,6 +3005,11 @@ components:
                     description: Update text response. NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
                     maxLength: 30000
+                value_id:
+                    type: string
+                    description: Update the stable id of the selected option in the source system (e.g. a survey choice id), stored alongside value_text for durable option identity. Opaque to Hub. NULL bytes not allowed.
+                    pattern: '^[^\x00]*$'
+                    maxLength: 255
         TaxonomyRunStatus:
             type: string
             description: Lifecycle state of a taxonomy run. Allowed transitions are pending -> running|failed|canceled and running -> succeeded|failed|canceled.

--- a/tests/feedback_value_id_test.go
+++ b/tests/feedback_value_id_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+	"github.com/formbricks/hub/pkg/database"
+)
+
+// TestFeedbackRecords_ValueIDRoundTrip locks the create/read/update paths for
+// value_id: a categorical answer can carry both value_text (display label) and
+// value_id (stable key), both round-trip through the shared scanFeedbackRecord, an update
+// changes value_id, and an unrelated update leaves it intact.
+func TestFeedbackRecords_ValueIDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	repo := repository.NewFeedbackRecordsRepository(db)
+
+	tenantID := testTenantID("value-id")
+	valueText := "Very satisfied"
+	valueID := "opt_very_satisfied"
+
+	created, err := repo.Create(ctx, &models.CreateFeedbackRecordRequest{
+		SourceType:   "formbricks",
+		FieldID:      "csat",
+		FieldType:    models.FieldTypeCategorical,
+		ValueText:    &valueText,
+		ValueID:      &valueID,
+		TenantID:     tenantID,
+		SubmissionID: testTenantID("submission"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created.ValueID)
+	assert.Equal(t, valueID, *created.ValueID)
+	require.NotNil(t, created.ValueText)
+	assert.Equal(t, valueText, *created.ValueText)
+
+	// Round-trips via GetByID (shared scan path).
+	got, err := repo.GetByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ValueID)
+	assert.Equal(t, valueID, *got.ValueID)
+
+	// Update changes value_id.
+	newID := "opt_neutral"
+	updated, _, err := repo.Update(ctx, created.ID, &models.UpdateFeedbackRecordRequest{ValueID: &newID})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ValueID)
+	assert.Equal(t, newID, *updated.ValueID)
+
+	// An unrelated update leaves value_id intact.
+	newLabel := "Neutral"
+	afterUnrelated, _, err := repo.Update(ctx, created.ID, &models.UpdateFeedbackRecordRequest{ValueText: &newLabel})
+	require.NoError(t, err)
+	require.NotNil(t, afterUnrelated.ValueID)
+	assert.Equal(t, newID, *afterUnrelated.ValueID, "value_id survives an unrelated update")
+}
+
+// TestFeedbackRecords_ListFilterByValueID locks the value_id list filter (the "update all records
+// for option X" flow): listing a tenant filtered by value_id returns only the records carrying that
+// option id, across submissions.
+func TestFeedbackRecords_ListFilterByValueID(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	repo := repository.NewFeedbackRecordsRepository(db)
+
+	tenantID := testTenantID("value-id-filter")
+	label := "Very satisfied"
+	wantID := "opt_very_satisfied"
+	otherID := "opt_neutral"
+
+	// Two records for the target option (distinct submissions) and one for another option.
+	createOption := func(submission, optionID string) {
+		_, createErr := repo.Create(ctx, &models.CreateFeedbackRecordRequest{
+			SourceType:   "formbricks",
+			FieldID:      "csat",
+			FieldType:    models.FieldTypeCategorical,
+			ValueText:    &label,
+			ValueID:      &optionID,
+			TenantID:     tenantID,
+			SubmissionID: submission,
+		})
+		require.NoError(t, createErr)
+	}
+	createOption(testTenantID("sub-a"), wantID)
+	createOption(testTenantID("sub-b"), wantID)
+	createOption(testTenantID("sub-c"), otherID)
+
+	records, _, err := repo.List(ctx, &models.ListFeedbackRecordsFilters{TenantID: &tenantID, ValueID: &wantID})
+	require.NoError(t, err)
+	assert.Len(t, records, 2, "only the two records with the target value_id are returned")
+
+	for _, rec := range records {
+		require.NotNil(t, rec.ValueID)
+		assert.Equal(t, wantID, *rec.ValueID)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `value_id` column to `feedback_records` so selected-choice answers have a stable, durable identity alongside their display label.

Today a chosen option is stored only as `value_text` (the human-readable label), which is fragile in two ways: labels arrive localized to the response language (splitting one option into several analytics categories, see ENG-1566), and renaming a choice forks historical rows from new ones. The agreed direction is a hybrid model — keep `value_text` for display (charts/Cube stay zero-touch) and additionally store the source system's stable option id (`value_id`) as the durable identity.

This is the **Hub side only**. The app-side work (populating `value_id` at ingestion, backfilling history, updating it on label edits) is separate.

What's included:

- **Schema** — nullable `value_id VARCHAR(255)` + a partial composite index `(tenant_id, field_id, value_id) WHERE value_id IS NOT NULL`. Nullable because non-choice fields, free-text/"other" answers, and non-Formbricks sources (CSV, integrations) have no option id — `value_text` stays the fallback identity there. The index is partial (value_id is sparse) and built `CONCURRENTLY` under `-- +goose NO TRANSACTION`, since `feedback_records` is the high-write primary table and a plain `CREATE INDEX` would block writes; it mirrors the table's existing sparse-column partial indexes (sentiment, emotions).
- **API** — `value_id` is accepted and returned on create, update, and retrieve/list, and is usable as a **list filter** (the "update all records for option X" flow). Hub treats it as an opaque string (max 255, no null bytes); it's never validated against any source registry.
- **Also here (small, related)** — `buildFilterConditions` now derives each SQL placeholder from `len(args)+1` instead of a manual counter. The counter's trailing `Until` branch never advanced it — harmless today only because `Until` is appended last, but a latent trap if any filter were ever added after it. The new derivation is order-independent and locked by a test.

No bulk-create: Hub has no bulk-create endpoint today, and this ticket's acceptance criteria don't gate on one, so it's tracked separately in ENG-1672.

### API example

```
# Create a categorical answer carrying both the label and the option id
POST /v1/feedback-records
{ "source_type": "formbricks", "field_id": "csat", "field_type": "categorical",
  "value_text": "Very satisfied", "value_id": "opt_very_satisfied",
  "tenant_id": "t1", "submission_id": "sub-1" }
→ 201 { "id": "019f…", "value_text": "Very satisfied", "value_id": "opt_very_satisfied", … }

# Filter a tenant's records by option id
GET /v1/feedback-records?tenant_id=t1&value_id=opt_very_satisfied
→ 200 { "data": [ … only records with that value_id … ] }
```

Linear: https://linear.app/formbricks/issue/ENG-1671/hub-add-value-id-to-feedback-records-for-stable-option-identity

Follow-up (SDK): the `@formbricks/hub` types regenerate from `openapi.yaml` via Stainless once this merges; the release is cut in `hub-typescript` after that.

## How should this be tested?

Config: a local `test_db` migrated to the tip of `migrations/` (`DATABASE_URL`, `API_KEY` from `.env`).

Automated:

- `make build`
- `make migrate-validate` — validates the goose annotations on migration `018`.
- `make tests` — integration suite, including the new `value_id` round-trip and list-filter tests (`tests/feedback_value_id_test.go`) and the placeholder-alignment unit test (`TestBuildFilterConditions_PlaceholdersMatchArgs`).
- `make fmt` and `make lint` — no new warnings.

Manual (against a running API), smoke-tested end to end:

1. `POST /v1/feedback-records` with `field_type: categorical`, `value_text` + `value_id` → `201`, both echoed.
2. `GET /v1/feedback-records/{id}` → both fields present.
3. `GET /v1/feedback-records?tenant_id=…&value_id=…` → only matching rows.
4. `PATCH /v1/feedback-records/{id}` with a new `value_id` → `200`; `value_text` untouched.
5. Edge: omit `value_id` (open-text) → absent from response; `value_id` of 256 chars → `400` (`invalid_params: [value_id]`); exactly 255 → `201`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes
