### PR TITLE
feat: add translated taxonomy embeddings

### DIFF
--- a/.github/workflows/api-contract-tests.yml
+++ b/.github/workflows/api-contract-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/migrations-validate.yml
+++ b/.github/workflows/migrations-validate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Build
 # =============================================================================
 # TARGETOS/TARGETARCH are set by Docker Buildx for multi-platform builds (e.g. linux/arm64 on Mac M1).
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG GOOSE_VERSION=v3.27.1

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/formbricks/hub/internal/api/handlers"
 	"github.com/formbricks/hub/internal/api/middleware"
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/internal/repository"
 	"github.com/formbricks/hub/internal/service"
@@ -251,6 +252,13 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	tenantDataRepo := repository.NewTenantDataRepository(db, cfg.TenantData.PurgeLockTimeout.Duration())
 	embeddingProviderName, embeddingModel := embeddingProviderAndModel(cfg)
 	embeddingModelForDB := embeddingModel
+	taxonomyEmbeddingModel := service.TaxonomyEmbeddingModel(embeddingModelForDB, cfg.Taxonomy.EmbeddingModel)
+
+	taxonomyEmbeddingEnqueueModel := taxonomyEmbeddingModel
+
+	if embeddingProviderName == "" {
+		taxonomyEmbeddingEnqueueModel = ""
+	}
 
 	feedbackRecordsService := service.NewFeedbackRecordsService(
 		feedbackRecordsRepo,
@@ -262,6 +270,7 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 		cfg.Embedding.MaxAttempts,
 		cfg.Translation.DefaultLanguage,
 	)
+	feedbackRecordsService.SetTaxonomyEmbeddingModel(taxonomyEmbeddingEnqueueModel)
 
 	// The eager-clear (nulling stale enrichment outputs on a value_text edit) fires only on this
 	// API PATCH path, so wire its counter here; the worker/backfill service instances leave it unset.
@@ -428,6 +437,19 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 			embeddingMetrics,
 		)
 		messageManager.RegisterProvider(embeddingProv)
+
+		if taxonomyEmbeddingEnqueueModel != "" {
+			taxonomyEmbeddingProv := service.NewEmbeddingProviderForInputKind(
+				riverClient,
+				taxonomyEmbeddingEnqueueModel,
+				service.EmbeddingsQueueName,
+				cfg.Embedding.MaxAttempts,
+				docPrefix,
+				embeddingMetrics,
+				models.EmbeddingInputKindTaxonomyTranslated,
+			)
+			messageManager.RegisterProvider(taxonomyEmbeddingProv)
+		}
 	}
 
 	webhooksService := service.NewWebhooksService(webhooksRepo, messageManager, cfg.Webhook.MaxCount, cfg.Webhook.URLBlacklist)
@@ -516,7 +538,7 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	taxonomyService := service.NewTaxonomyService(service.NewTaxonomyServiceParams{
 		Repo:                  taxonomyRepo,
 		Starter:               taxonomyStarter,
-		EmbeddingModel:        embeddingModelForDB,
+		EmbeddingModel:        taxonomyEmbeddingModel,
 		MinimumEmbeddingCount: cfg.Taxonomy.MinimumEmbeddedRecords,
 	})
 	taxonomyHandler := handlers.NewTaxonomyHandler(taxonomyService)

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -115,11 +115,12 @@ func run() int {
 	}
 
 	embeddingModelForDB := embeddingModel
+	taxonomyEmbeddingModel := service.TaxonomyEmbeddingModel(embeddingModelForDB, cfg.Taxonomy.EmbeddingModel)
 	targetModel := embeddingModelForDB
 	inputKind := models.EmbeddingInputKindRaw
 
 	if *taxonomyMode {
-		targetModel = service.TaxonomyEmbeddingModel(embeddingModelForDB, cfg.Taxonomy.EmbeddingModel)
+		targetModel = taxonomyEmbeddingModel
 		inputKind = models.EmbeddingInputKindTaxonomyTranslated
 	}
 
@@ -133,15 +134,17 @@ func run() int {
 			return exitFailure
 		}
 
-		deleted, pruneErr := embeddingsRepo.DeleteEmbeddingsForOtherModels(ctx, embeddingModelForDB, pruneBatchSize)
+		deleted, pruneErr := embeddingsRepo.DeleteEmbeddingsForOtherModels(
+			ctx, embeddingModelForDB, pruneBatchSize, taxonomyEmbeddingModel)
 		if pruneErr != nil {
 			slog.Error("Prune failed", "error", pruneErr, "deleted_before_failure", deleted)
 
 			return exitFailure
 		}
 
-		slog.Info("Prune complete", "deleted", deleted, "kept_model", embeddingModelForDB)
-		fmt.Printf("Deleted %d stale-model embedding row(s); kept model %q.\n", deleted, embeddingModelForDB)
+		slog.Info("Prune complete", "deleted", deleted, "kept_models", []string{embeddingModelForDB, taxonomyEmbeddingModel})
+		fmt.Printf("Deleted %d stale-model embedding row(s); kept models %q and %q.\n",
+			deleted, embeddingModelForDB, taxonomyEmbeddingModel)
 
 		return exitSuccess
 	}

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/repository"
 	"github.com/formbricks/hub/internal/service"
 	"github.com/formbricks/hub/internal/workers"
@@ -48,6 +49,8 @@ func run() int {
 	pruneStaleModels := flag.Bool("prune-stale-models", false,
 		"delete embedding rows whose model differs from EMBEDDING_MODEL instead of backfilling "+
 			"(run only after a model migration's backfill has completed)")
+	taxonomyMode := flag.Bool("taxonomy", false,
+		"backfill taxonomy embeddings from translated text using TAXONOMY_EMBEDDING_MODEL or taxonomy:<EMBEDDING_MODEL>:translated-v1")
 
 	flag.Parse()
 
@@ -112,11 +115,24 @@ func run() int {
 	}
 
 	embeddingModelForDB := embeddingModel
+	targetModel := embeddingModelForDB
+	inputKind := models.EmbeddingInputKindRaw
+
+	if *taxonomyMode {
+		targetModel = service.TaxonomyEmbeddingModel(embeddingModelForDB, cfg.Taxonomy.EmbeddingModel)
+		inputKind = models.EmbeddingInputKindTaxonomyTranslated
+	}
 
 	repo := repository.NewFeedbackRecordsRepository(db)
 	embeddingsRepo := repository.NewEmbeddingsRepository(db)
 
 	if *pruneStaleModels {
+		if *taxonomyMode {
+			slog.Error("-taxonomy cannot be combined with -prune-stale-models")
+
+			return exitFailure
+		}
+
 		deleted, pruneErr := embeddingsRepo.DeleteEmbeddingsForOtherModels(ctx, embeddingModelForDB, pruneBatchSize)
 		if pruneErr != nil {
 			slog.Error("Prune failed", "error", pruneErr, "deleted_before_failure", deleted)
@@ -169,16 +185,20 @@ func run() int {
 
 	feedbackRecordsService.SetEmbeddingInserter(riverClient)
 
-	enqueued, err := feedbackRecordsService.BackfillEmbeddings(ctx, embeddingModelForDB)
+	enqueued, err := feedbackRecordsService.BackfillEmbeddingsWithInputKind(ctx, targetModel, inputKind)
 	if err != nil {
 		slog.Error("Backfill failed", "error", err)
 
 		return exitFailure
 	}
 
-	slog.Info("Backfill complete", "enqueued", enqueued) // #nosec G706 -- enqueued is an int, not user input
+	slog.Info("Backfill complete",
+		"enqueued", enqueued,
+		"model", targetModel,
+		"input_kind", inputKind,
+	) // #nosec G706 -- enqueued is an int, not user input
 
-	fmt.Printf("Enqueued %d embedding job(s).\n", enqueued)
+	fmt.Printf("Enqueued %d embedding job(s) for model %q.\n", enqueued, targetModel)
 
 	return exitSuccess
 }

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -94,6 +94,16 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 	}
 
 	providerName, embeddingModel := embeddingProviderAndModel(cfg)
+	taxonomyEmbeddingModel := service.TaxonomyEmbeddingModel(embeddingModel, cfg.Taxonomy.EmbeddingModel)
+
+	taxonomyEmbeddingEnqueueModel := taxonomyEmbeddingModel
+
+	if providerName == "" {
+		taxonomyEmbeddingEnqueueModel = ""
+	}
+
+	var translationRecordsService *service.FeedbackRecordsService
+
 	if providerName != "" {
 		embeddingCfg := service.EmbeddingClientConfig{
 			Provider:            providerName,
@@ -155,10 +165,20 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		}
 
 		// The translation worker only reads the record and writes the translation, so
-		// the embedding-specific service params are unused here.
+		// the raw embedding params are unused here. The taxonomy embedding params let
+		// successful translation writes enqueue translated taxonomy re-embedding.
 		translationRecordsRepo := repository.NewFeedbackRecordsRepository(db)
-		translationRecordsService := service.NewFeedbackRecordsService(
-			translationRecordsRepo, nil, "", nil, nil, "", 0, cfg.Translation.DefaultLanguage)
+		translationRecordsService = service.NewFeedbackRecordsService(
+			translationRecordsRepo,
+			nil,
+			"",
+			nil,
+			nil,
+			service.EmbeddingsQueueName,
+			cfg.Embedding.MaxAttempts,
+			cfg.Translation.DefaultLanguage,
+		)
+		translationRecordsService.SetTaxonomyEmbeddingModel(taxonomyEmbeddingEnqueueModel)
 
 		deps.TranslationService = translationRecordsService
 		deps.TranslationClient = translationClient
@@ -262,6 +282,10 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		shutdownObservability(context.Background(), meterProvider, tracerProvider)
 
 		return nil, fmt.Errorf("create River client: %w", err)
+	}
+
+	if translationRecordsService != nil {
+		translationRecordsService.SetEmbeddingInserter(riverClient)
 	}
 
 	return &WorkerApp{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/formbricks/hub
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-playground/form/v4 v4.3.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,7 @@ type TaxonomyConfig struct {
 	ServiceURL             string `env:"TAXONOMY_SERVICE_URL"`
 	ServiceToken           string `env:"TAXONOMY_SERVICE_TOKEN"`
 	HubInternalAPIToken    string `env:"HUB_INTERNAL_API_TOKEN"`
+	EmbeddingModel         string `env:"TAXONOMY_EMBEDDING_MODEL"`
 	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -420,6 +420,7 @@ func TestLoad_TaxonomyConfig(t *testing.T) {
 	t.Setenv("TAXONOMY_SERVICE_URL", "https://taxonomy.example.com/root/")
 	t.Setenv("TAXONOMY_SERVICE_TOKEN", "taxonomy-service-token")
 	t.Setenv("HUB_INTERNAL_API_TOKEN", "hub-internal-token")
+	t.Setenv("TAXONOMY_EMBEDDING_MODEL", "taxonomy:test-model:translated-v1")
 
 	cfg, err := Load()
 	if err != nil {
@@ -436,6 +437,10 @@ func TestLoad_TaxonomyConfig(t *testing.T) {
 
 	if cfg.Taxonomy.HubInternalAPIToken != "hub-internal-token" {
 		t.Errorf("Taxonomy.HubInternalAPIToken = %q, want hub-internal-token", cfg.Taxonomy.HubInternalAPIToken)
+	}
+
+	if cfg.Taxonomy.EmbeddingModel != "taxonomy:test-model:translated-v1" {
+		t.Errorf("Taxonomy.EmbeddingModel = %q, want taxonomy:test-model:translated-v1", cfg.Taxonomy.EmbeddingModel)
 	}
 }
 

--- a/internal/models/embeddings.go
+++ b/internal/models/embeddings.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,6 +18,28 @@ type Embedding struct {
 	Model            string    `json:"model"`
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// EmbeddingInputKind identifies which record text was embedded.
+type EmbeddingInputKind string
+
+const (
+	// EmbeddingInputKindRaw embeds the original feedback value_text.
+	EmbeddingInputKindRaw EmbeddingInputKind = "raw"
+	// EmbeddingInputKindTaxonomyTranslated embeds translated text when present, falling back to value_text.
+	EmbeddingInputKindTaxonomyTranslated EmbeddingInputKind = "taxonomy_translated"
+)
+
+// NormalizeEmbeddingInputKind maps empty/unknown job values to raw for backward-compatible queued jobs.
+func NormalizeEmbeddingInputKind(kind EmbeddingInputKind) EmbeddingInputKind {
+	switch EmbeddingInputKind(strings.TrimSpace(string(kind))) {
+	case EmbeddingInputKindRaw:
+		return EmbeddingInputKindRaw
+	case EmbeddingInputKindTaxonomyTranslated:
+		return EmbeddingInputKindTaxonomyTranslated
+	default:
+		return EmbeddingInputKindRaw
+	}
 }
 
 // FeedbackRecordWithScore is a feedback record ID, similarity score, and the record's field_label and value_text for display.

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,8 +36,12 @@ const (
 	maxNearestFetchLimit = 2000
 )
 
-// ErrEmbeddingDimensionMismatch is returned when an embedding slice length does not match EmbeddingVectorDimensions.
-var ErrEmbeddingDimensionMismatch = errors.New("embedding dimension mismatch")
+var (
+	// ErrEmbeddingDimensionMismatch is returned when an embedding slice length does not match EmbeddingVectorDimensions.
+	ErrEmbeddingDimensionMismatch = errors.New("embedding dimension mismatch")
+
+	errNoCurrentEmbeddingModels = errors.New("at least one current embedding model is required")
+)
 
 // EmbeddingsRepository handles data access for the embeddings table.
 type EmbeddingsRepository struct {
@@ -186,23 +191,27 @@ func guardEmbeddingSourceCurrent(
 	return nil
 }
 
-// DeleteEmbeddingsForOtherModels batch-deletes embedding rows whose model differs from
-// currentModel. Reads only ever join on the current model, so such rows are dead weight — but
-// they sit inside the single shared HNSW index, where every stale vector consumes candidate
-// budget on every search (worsening recall) and storage grows with each model migration. Batched
-// (batchSize rows per DELETE) so a large prune never holds long row locks or produces one giant
-// WAL burst. Returns the total deleted. Run only after a model migration's backfill has
-// completed, or search goes dark until the new model's vectors exist.
+// DeleteEmbeddingsForOtherModels batch-deletes embedding rows whose model is not in the
+// current model set. Reads only ever join on active models, so such rows are dead weight.
+// Batched (batchSize rows per DELETE) so a large prune never holds long row locks or
+// produces one giant WAL burst. Returns the total deleted. Run only after a model
+// migration's backfill has completed, or reads using that model go dark until the new
+// model's vectors exist.
 func (r *EmbeddingsRepository) DeleteEmbeddingsForOtherModels(
-	ctx context.Context, currentModel string, batchSize int,
+	ctx context.Context, currentModel string, batchSize int, additionalCurrentModels ...string,
 ) (int64, error) {
+	currentModels := normalizeEmbeddingModels(append([]string{currentModel}, additionalCurrentModels...))
+	if len(currentModels) == 0 {
+		return 0, errNoCurrentEmbeddingModels
+	}
+
 	var total int64
 
 	for {
 		tag, err := r.db.Exec(ctx, `
 			DELETE FROM embeddings WHERE id IN (
-				SELECT id FROM embeddings WHERE model <> $1 LIMIT $2
-			)`, currentModel, batchSize)
+				SELECT id FROM embeddings WHERE NOT (model = ANY($1::text[])) LIMIT $2
+			)`, currentModels, batchSize)
 		if err != nil {
 			return total, fmt.Errorf("delete stale-model embeddings: %w", err)
 		}
@@ -214,6 +223,27 @@ func (r *EmbeddingsRepository) DeleteEmbeddingsForOtherModels(
 			return total, nil
 		}
 	}
+}
+
+func normalizeEmbeddingModels(models []string) []string {
+	seen := make(map[string]struct{}, len(models))
+	out := make([]string, 0, len(models))
+
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+
+		if _, ok := seen[model]; ok {
+			continue
+		}
+
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+
+	return out
 }
 
 // ListFeedbackRecordIDsForBackfill returns one keyset page (fr.id > afterID, ordered by id,
@@ -362,6 +392,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbedding(
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3
+			  AND e.model NOT LIKE 'taxonomy:%'
 			ORDER BY (e.embedding <=> $1), e.feedback_record_id
 			LIMIT $4`, queryVec, model, tenantID, fetchLimit)
 	} else {
@@ -371,6 +402,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbedding(
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3 AND e.feedback_record_id != $4
+			  AND e.model NOT LIKE 'taxonomy:%'
 			ORDER BY (e.embedding <=> $1), e.feedback_record_id
 			LIMIT $5`, queryVec, model, tenantID, *excludeID, fetchLimit)
 	}
@@ -467,6 +499,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbeddingAfterCursor(
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3
+			  AND e.model NOT LIKE 'taxonomy:%'
 			  AND ((e.embedding <=> $1), e.feedback_record_id) > ($4, $5)
 			ORDER BY (e.embedding <=> $1), e.feedback_record_id
 			LIMIT $6`, queryVec, model, tenantID, lastDistance, lastFeedbackRecordID, fetchLimit)
@@ -477,6 +510,7 @@ func (r *EmbeddingsRepository) NearestFeedbackRecordsByEmbeddingAfterCursor(
 			FROM embeddings e
 			INNER JOIN feedback_records fr ON fr.id = e.feedback_record_id
 			WHERE e.model = $2 AND fr.tenant_id = $3 AND e.feedback_record_id != $4
+			  AND e.model NOT LIKE 'taxonomy:%'
 			  AND ((e.embedding <=> $1), e.feedback_record_id) > ($5, $6)
 			ORDER BY (e.embedding <=> $1), e.feedback_record_id
 			LIMIT $7`, queryVec, model, tenantID, *excludeID, lastDistance, lastFeedbackRecordID, fetchLimit)

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -79,7 +79,7 @@ func rollbackQuietly(ctx context.Context, tx pgx.Tx, msg string) {
 // writes the row.
 func (r *EmbeddingsRepository) Upsert(
 	ctx context.Context, feedbackRecordID uuid.UUID, model string, embedding []float32,
-	stillCurrent func(fieldLabel, valueText *string) bool,
+	stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	if len(embedding) != models.EmbeddingVectorDimensions {
 		return fmt.Errorf("%w: got %d, want %d", ErrEmbeddingDimensionMismatch, len(embedding), models.EmbeddingVectorDimensions)
@@ -120,7 +120,7 @@ func (r *EmbeddingsRepository) Upsert(
 // since-changed content must not delete the vector a newer job wrote.
 func (r *EmbeddingsRepository) DeleteByFeedbackRecordAndModel(
 	ctx context.Context, feedbackRecordID uuid.UUID, model string,
-	stillCurrent func(fieldLabel, valueText *string) bool,
+	stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	return withTenantWritePoolTx(ctx, r.db, nil, func(dbTx tenantWriteTx) error {
 		if _, err := lockFeedbackRecordTenantShared(ctx, dbTx, feedbackRecordID); err != nil {
@@ -148,7 +148,8 @@ func (r *EmbeddingsRepository) DeleteByFeedbackRecordAndModel(
 // content for the stillCurrent check. Returns ErrEmbeddingSuperseded when the content moved on,
 // NotFound when the record vanished mid-transaction, and nil (no-op) when stillCurrent is nil.
 func guardEmbeddingSourceCurrent(
-	ctx context.Context, dbTx tenantWriteTx, feedbackRecordID uuid.UUID, stillCurrent func(fieldLabel, valueText *string) bool,
+	ctx context.Context, dbTx tenantWriteTx, feedbackRecordID uuid.UUID,
+	stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	if stillCurrent == nil {
 		return nil
@@ -160,7 +161,7 @@ func guardEmbeddingSourceCurrent(
 		return fmt.Errorf("lock feedback record for embedding write: %w", err)
 	}
 
-	var fieldLabel, valueText *string
+	var fieldLabel, valueText, valueTextTranslated *string
 
 	// FOR UPDATE row-locks the record until this write commits, so a concurrent PATCH Update
 	// (which does not take the per-record advisory lock) cannot change the content between this
@@ -168,8 +169,8 @@ func guardEmbeddingSourceCurrent(
 	// sibling guardValueTextCurrent. Crucial here: embeddings have no eager-clear or NULL-rows
 	// backfill, so a stale vector that lands last is otherwise permanent.
 	err := dbTx.QueryRow(ctx,
-		`SELECT field_label, value_text FROM feedback_records WHERE id = $1 FOR UPDATE`, feedbackRecordID,
-	).Scan(&fieldLabel, &valueText)
+		`SELECT field_label, value_text, value_text_translated FROM feedback_records WHERE id = $1 FOR UPDATE`, feedbackRecordID,
+	).Scan(&fieldLabel, &valueText, &valueTextTranslated)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return huberrors.NewNotFoundError("feedback record", "feedback record not found")
@@ -178,7 +179,7 @@ func guardEmbeddingSourceCurrent(
 		return fmt.Errorf("read feedback record content for embedding write: %w", err)
 	}
 
-	if !stillCurrent(fieldLabel, valueText) {
+	if !stillCurrent(fieldLabel, valueText, valueTextTranslated) {
 		return huberrors.ErrEmbeddingSuperseded
 	}
 
@@ -222,7 +223,19 @@ func (r *EmbeddingsRepository) DeleteEmbeddingsForOtherModels(
 func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfill(
 	ctx context.Context, model string, afterID uuid.UUID, limit int,
 ) ([]uuid.UUID, error) {
-	rows, err := r.db.Query(ctx, `
+	return r.ListFeedbackRecordIDsForBackfillByInputKind(ctx, model, models.EmbeddingInputKindRaw, afterID, limit)
+}
+
+// ListFeedbackRecordIDsForBackfillByInputKind returns feedback-record IDs missing an embedding
+// for model and eligible for the requested embedding input kind.
+func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfillByInputKind(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	afterID uuid.UUID,
+	limit int,
+) ([]uuid.UUID, error) {
+	query := `
 		SELECT fr.id FROM feedback_records fr
 		WHERE fr.value_text IS NOT NULL AND trim(fr.value_text) != ''
 		  AND fr.id > $2
@@ -232,7 +245,22 @@ func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfill(
 		  )
 		ORDER BY fr.id
 		LIMIT $3
-	`, model, afterID, limit)
+	`
+	if models.NormalizeEmbeddingInputKind(inputKind) == models.EmbeddingInputKindTaxonomyTranslated {
+		query = `
+			SELECT fr.id FROM feedback_records fr
+			WHERE COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
+			  AND fr.id > $2
+			  AND NOT EXISTS (
+			    SELECT 1 FROM embeddings e
+			    WHERE e.feedback_record_id = fr.id AND e.model = $1
+			  )
+			ORDER BY fr.id
+			LIMIT $3
+		`
+	}
+
+	rows, err := r.db.Query(ctx, query, model, afterID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list feedback record ids for backfill: %w", err)
 	}

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -125,8 +125,7 @@ func (r *TaxonomyRepository) CountScopeInput(
 			FROM feedback_records fr
 			LEFT JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $2
 			WHERE fr.tenant_id = $1
-			  AND fr.value_text IS NOT NULL
-			  AND btrim(fr.value_text) <> ''`,
+			  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL`,
 			scope.TenantID, embeddingModel,
 		).Scan(&recordCount, &embeddingCount)
 		if err != nil {
@@ -147,8 +146,7 @@ func (r *TaxonomyRepository) CountScopeInput(
 		  AND fr.source_type = $2
 		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
 		  AND fr.field_id = $4
-		  AND fr.value_text IS NOT NULL
-		  AND btrim(fr.value_text) <> ''`,
+		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL`,
 		scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID, embeddingModel,
 	).Scan(&recordCount, &embeddingCount, &fieldLabel)
 	if err != nil {
@@ -890,13 +888,12 @@ func (r *TaxonomyRepository) queryRunInputRows(
 				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
 				fr.field_id,
 				COALESCE(fr.field_label, ''),
-				fr.value_text,
+				COALESCE(NULLIF(btrim(fr.value_text_translated), ''), fr.value_text),
 				e.embedding
 			FROM feedback_records fr
 			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
 			WHERE fr.tenant_id = $1
-			  AND fr.value_text IS NOT NULL
-			  AND btrim(fr.value_text) <> ''
+			  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
 			ORDER BY fr.collected_at DESC, fr.id ASC
 			LIMIT $2`,
 			run.TenantID, limit, embeddingModel,
@@ -915,7 +912,7 @@ func (r *TaxonomyRepository) queryRunInputRows(
 			COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
 			fr.field_id,
 			COALESCE(fr.field_label, ''),
-			fr.value_text,
+			COALESCE(NULLIF(btrim(fr.value_text_translated), ''), fr.value_text),
 			e.embedding
 		FROM feedback_records fr
 		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
@@ -923,8 +920,7 @@ func (r *TaxonomyRepository) queryRunInputRows(
 		  AND fr.source_type = $2
 		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
 		  AND fr.field_id = $4
-		  AND fr.value_text IS NOT NULL
-		  AND btrim(fr.value_text) <> ''
+		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
 		ORDER BY fr.collected_at DESC, fr.id ASC
 		LIMIT $5`,
 		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -67,8 +67,7 @@ func (r *TaxonomyRepository) ListFieldOptions(
 		FROM feedback_records fr
 		LEFT JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $2
 		WHERE fr.tenant_id = $1
-		  AND fr.value_text IS NOT NULL
-		  AND btrim(fr.value_text) <> ''
+		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
 		GROUP BY fr.tenant_id, fr.source_type, COALESCE(NULLIF(btrim(fr.source_id), ''), ''), fr.field_id
 		ORDER BY fr.source_type, COALESCE(NULLIF(btrim(fr.source_id), ''), ''), fr.field_id`,
 		tenantID, embeddingModel,
@@ -888,7 +887,7 @@ func (r *TaxonomyRepository) queryRunInputRows(
 				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
 				fr.field_id,
 				COALESCE(fr.field_label, ''),
-				COALESCE(NULLIF(btrim(fr.value_text_translated), ''), fr.value_text),
+				COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')),
 				e.embedding
 			FROM feedback_records fr
 			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
@@ -912,7 +911,7 @@ func (r *TaxonomyRepository) queryRunInputRows(
 			COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
 			fr.field_id,
 			COALESCE(fr.field_label, ''),
-			COALESCE(NULLIF(btrim(fr.value_text_translated), ''), fr.value_text),
+			COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')),
 			e.embedding
 		FROM feedback_records fr
 		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6

--- a/internal/service/embedding_job_args.go
+++ b/internal/service/embedding_job_args.go
@@ -3,6 +3,8 @@ package service
 import (
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
+
+	"github.com/formbricks/hub/internal/models"
 )
 
 const (
@@ -22,6 +24,8 @@ type FeedbackEmbeddingArgs struct {
 	EventID uuid.UUID `json:"event_id"`
 	// Model is the embedding model name; stored in embeddings.model.
 	Model string `json:"model" river:"unique"`
+	// InputKind selects which feedback text is embedded. Empty is treated as raw for legacy queued jobs.
+	InputKind models.EmbeddingInputKind `json:"input_kind,omitempty"`
 	// ValueTextHash is a hash of the input (trimmed value_text, or "empty"/"backfill") for dedupe semantics.
 	ValueTextHash string `json:"value_text_hash" river:"unique"`
 }

--- a/internal/service/embedding_provider.go
+++ b/internal/service/embedding_provider.go
@@ -25,6 +25,7 @@ type EmbeddingProvider struct {
 	maxAttempts int
 	docPrefix   string // model-specific prefix for document embedding; OpenAI and Google use ""
 	metrics     observability.EmbeddingMetrics
+	inputKind   models.EmbeddingInputKind
 }
 
 // NewEmbeddingProvider creates a provider that enqueues feedback_embedding jobs.
@@ -39,6 +40,20 @@ func NewEmbeddingProvider(
 	docPrefix string,
 	metrics observability.EmbeddingMetrics,
 ) *EmbeddingProvider {
+	return NewEmbeddingProviderForInputKind(
+		inserter, model, queueName, maxAttempts, docPrefix, metrics, models.EmbeddingInputKindRaw)
+}
+
+// NewEmbeddingProviderForInputKind creates a provider for a specific embedding input kind.
+func NewEmbeddingProviderForInputKind(
+	inserter RiverJobInserter,
+	model string,
+	queueName string,
+	maxAttempts int,
+	docPrefix string,
+	metrics observability.EmbeddingMetrics,
+	inputKind models.EmbeddingInputKind,
+) *EmbeddingProvider {
 	return &EmbeddingProvider{
 		inserter:    inserter,
 		model:       model,
@@ -46,6 +61,7 @@ func NewEmbeddingProvider(
 		maxAttempts: maxAttempts,
 		docPrefix:   docPrefix,
 		metrics:     metrics,
+		inputKind:   models.NormalizeEmbeddingInputKind(inputKind),
 	}
 }
 
@@ -55,8 +71,8 @@ func NewEmbeddingProvider(
 // API key is required for openai and google (validated at startup).
 func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 	if event.Type == datatypes.FeedbackRecordUpdated {
-		if !slices.Contains(event.ChangedFields, "value_text") && !slices.Contains(event.ChangedFields, "field_label") {
-			slog.Debug("embedding: skip, value_text/field_label not in changed fields",
+		if !p.hasEmbeddingRelevantChange(event.ChangedFields) {
+			slog.Debug("embedding: skip, embedding input fields not in changed fields",
 				"event_id", event.ID,
 				"feedback_record_id", recordIDFromEventData(event.Data),
 			)
@@ -76,7 +92,7 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 
 	// Build the embedding input once and reuse it for both the create-time empty check and the
 	// dedupe hash; it was otherwise computed twice on the create path.
-	input := BuildEmbeddingInput(record.FieldLabel, record.ValueText, p.docPrefix)
+	input := BuildEmbeddingInputForKind(record, p.inputKind, p.docPrefix)
 
 	// On create, only enqueue when there is embeddable text. On update we enqueue regardless so the worker can clear.
 	if event.Type == datatypes.FeedbackRecordCreated && input == "" {
@@ -101,6 +117,7 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 		FeedbackRecordID: record.ID,
 		EventID:          event.ID,
 		Model:            p.model,
+		InputKind:        p.inputKind,
 		ValueTextHash:    valueTextHash,
 	}, opts)
 	if err != nil {
@@ -125,6 +142,15 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 	if p.metrics != nil {
 		p.metrics.RecordJobsEnqueued(ctx, 1)
 	}
+}
+
+func (p *EmbeddingProvider) hasEmbeddingRelevantChange(changedFields []string) bool {
+	if slices.Contains(changedFields, "value_text") || slices.Contains(changedFields, "field_label") {
+		return true
+	}
+
+	return p.inputKind == models.EmbeddingInputKindTaxonomyTranslated &&
+		slices.Contains(changedFields, "value_text_translated")
 }
 
 func recordIDFromEventData(data any) uuid.UUID {
@@ -153,6 +179,35 @@ const (
 //
 // Returns formatted string: "[prefix]Question: [label]\nAnswer: [value]" (or "[prefix][value]" when label is empty).
 func BuildEmbeddingInput(fieldLabel, valueText *string, prefix string) string {
+	return BuildEmbeddingInputFromValues(fieldLabel, valueText, nil, models.EmbeddingInputKindRaw, prefix)
+}
+
+// BuildEmbeddingInputForKind prepares text for a specific embedding input kind.
+func BuildEmbeddingInputForKind(record *models.FeedbackRecord, kind models.EmbeddingInputKind, prefix string) string {
+	if record == nil {
+		return ""
+	}
+
+	return BuildEmbeddingInputFromValues(record.FieldLabel, record.ValueText, record.ValueTextTranslated, kind, prefix)
+}
+
+// BuildEmbeddingInputFromValues prepares text for vector embedding from raw record values.
+// Taxonomy embeddings prefer translated text when present, falling back to original value_text.
+func BuildEmbeddingInputFromValues(
+	fieldLabel, valueText, valueTextTranslated *string,
+	kind models.EmbeddingInputKind,
+	prefix string,
+) string {
+	if models.NormalizeEmbeddingInputKind(kind) == models.EmbeddingInputKindTaxonomyTranslated {
+		if normalizedText(valueTextTranslated) != "" {
+			return buildEmbeddingInput(fieldLabel, valueTextTranslated, prefix)
+		}
+	}
+
+	return buildEmbeddingInput(fieldLabel, valueText, prefix)
+}
+
+func buildEmbeddingInput(fieldLabel, valueText *string, prefix string) string {
 	if valueText == nil {
 		return ""
 	}

--- a/internal/service/embedding_provider.go
+++ b/internal/service/embedding_provider.go
@@ -145,12 +145,7 @@ func (p *EmbeddingProvider) PublishEvent(ctx context.Context, event Event) {
 }
 
 func (p *EmbeddingProvider) hasEmbeddingRelevantChange(changedFields []string) bool {
-	if slices.Contains(changedFields, "value_text") || slices.Contains(changedFields, "field_label") {
-		return true
-	}
-
-	return p.inputKind == models.EmbeddingInputKindTaxonomyTranslated &&
-		slices.Contains(changedFields, "value_text_translated")
+	return slices.Contains(changedFields, "value_text") || slices.Contains(changedFields, "field_label")
 }
 
 func recordIDFromEventData(data any) uuid.UUID {

--- a/internal/service/embedding_provider_test.go
+++ b/internal/service/embedding_provider_test.go
@@ -68,6 +68,7 @@ func TestEmbeddingProvider_PublishEvent_FeedbackRecordCreated_withValueText_enqu
 	assert.Equal(t, recordID, inserter.insertCalls[0].args.FeedbackRecordID)
 	assert.Equal(t, event.ID, inserter.insertCalls[0].args.EventID, "event id is carried into the job args")
 	assert.Equal(t, "model-name", inserter.insertCalls[0].args.Model)
+	assert.Equal(t, models.EmbeddingInputKindRaw, inserter.insertCalls[0].args.InputKind)
 	assert.NotEmpty(t, inserter.insertCalls[0].args.ValueTextHash, "dedupe key should include input hash")
 	assert.NotNil(t, inserter.insertCalls[0].opts)
 	assert.Equal(t, "embeddings", inserter.insertCalls[0].opts.Queue)
@@ -165,6 +166,45 @@ func TestEmbeddingProvider_PublishEvent_FeedbackRecordUpdated_fieldLabelInChange
 	assert.NotEmpty(t, inserter.insertCalls[0].args.ValueTextHash)
 }
 
+func TestEmbeddingProvider_PublishEvent_TaxonomyTranslatedPrefersTranslatedText(t *testing.T) {
+	inserter := &mockEmbeddingInserter{}
+	p := NewEmbeddingProviderForInputKind(
+		inserter,
+		"taxonomy:model:translated-v1",
+		"embeddings",
+		3,
+		"",
+		nil,
+		models.EmbeddingInputKindTaxonomyTranslated,
+	)
+
+	recordID := uuid.Must(uuid.NewV7())
+	fieldLabel := "What went wrong?"
+	valueText := "La machine ne demarre pas"
+	translated := "The washing machine does not start"
+	event := Event{
+		ID:        uuid.Must(uuid.NewV7()),
+		Type:      datatypes.FeedbackRecordCreated,
+		Timestamp: time.Now(),
+		Data: &models.FeedbackRecord{
+			ID:                  recordID,
+			FieldType:           models.FieldTypeText,
+			FieldLabel:          &fieldLabel,
+			ValueText:           &valueText,
+			ValueTextTranslated: &translated,
+		},
+	}
+
+	p.PublishEvent(context.Background(), event)
+
+	require.Len(t, inserter.insertCalls, 1)
+	assert.Equal(t, recordID, inserter.insertCalls[0].args.FeedbackRecordID)
+	assert.Equal(t, "taxonomy:model:translated-v1", inserter.insertCalls[0].args.Model)
+	assert.Equal(t, models.EmbeddingInputKindTaxonomyTranslated, inserter.insertCalls[0].args.InputKind)
+	assert.Equal(t, hashContent("Question: What went wrong?\nAnswer: The washing machine does not start"),
+		inserter.insertCalls[0].args.ValueTextHash)
+}
+
 func TestBuildEmbeddingInput(t *testing.T) {
 	t.Run("label and value produces Question/Answer format", func(t *testing.T) {
 		out := BuildEmbeddingInput(
@@ -188,4 +228,35 @@ func TestBuildEmbeddingInput(t *testing.T) {
 		out := BuildEmbeddingInput(new("Q"), new("A"), "search_document: ")
 		assert.Equal(t, "search_document: Question: Q\nAnswer: A", out)
 	})
+}
+
+func TestBuildEmbeddingInputForKind(t *testing.T) {
+	fieldLabel := "Open feedback"
+	valueText := "Original text"
+	translated := "Translated text"
+
+	out := BuildEmbeddingInputFromValues(
+		&fieldLabel,
+		&valueText,
+		&translated,
+		models.EmbeddingInputKindTaxonomyTranslated,
+		"",
+	)
+	assert.Equal(t, "Question: Open feedback\nAnswer: Translated text", out)
+
+	blankTranslated := "  "
+	out = BuildEmbeddingInputFromValues(
+		&fieldLabel,
+		&valueText,
+		&blankTranslated,
+		models.EmbeddingInputKindTaxonomyTranslated,
+		"",
+	)
+	assert.Equal(t, "Question: Open feedback\nAnswer: Original text", out)
+}
+
+func TestTaxonomyEmbeddingModel(t *testing.T) {
+	assert.Equal(t, "taxonomy:text-embedding:translated-v1", TaxonomyEmbeddingModel("text-embedding", ""))
+	assert.Equal(t, "custom-taxonomy-model", TaxonomyEmbeddingModel("text-embedding", " custom-taxonomy-model "))
+	assert.Empty(t, TaxonomyEmbeddingModel(" ", ""))
 }

--- a/internal/service/feedback_records_service.go
+++ b/internal/service/feedback_records_service.go
@@ -74,14 +74,17 @@ type FeedbackRecordsRepository interface { //nolint:interfacebloat // one cohesi
 type EmbeddingsRepository interface {
 	Upsert(
 		ctx context.Context, feedbackRecordID uuid.UUID, model string, embedding []float32,
-		stillCurrent func(fieldLabel, valueText *string) bool,
+		stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 	) error
 	DeleteByFeedbackRecordAndModel(
 		ctx context.Context, feedbackRecordID uuid.UUID, model string,
-		stillCurrent func(fieldLabel, valueText *string) bool,
+		stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 	) error
 	ListFeedbackRecordIDsForBackfill(
 		ctx context.Context, model string, afterID uuid.UUID, limit int,
+	) ([]uuid.UUID, error)
+	ListFeedbackRecordIDsForBackfillByInputKind(
+		ctx context.Context, model string, inputKind models.EmbeddingInputKind, afterID uuid.UUID, limit int,
 	) ([]uuid.UUID, error)
 }
 
@@ -97,6 +100,7 @@ type FeedbackRecordsService struct {
 	repo                   FeedbackRecordsRepository
 	embeddingsRepo         EmbeddingsRepository
 	embeddingModel         string
+	taxonomyEmbeddingModel string
 	publisher              MessagePublisher
 	embeddingInserter      RiverJobInserter
 	embeddingQueueName     string
@@ -139,6 +143,11 @@ func NewFeedbackRecordsService(
 // This allows a single service instance to be used by both handlers and the embedding worker.
 func (s *FeedbackRecordsService) SetEmbeddingInserter(inserter RiverJobInserter) {
 	s.embeddingInserter = inserter
+}
+
+// SetTaxonomyEmbeddingModel sets the model key used for taxonomy-specific translated embeddings.
+func (s *FeedbackRecordsService) SetTaxonomyEmbeddingModel(model string) {
+	s.taxonomyEmbeddingModel = strings.TrimSpace(model)
 }
 
 // SetEnrichmentClearMetrics enables the eager-clear counter. Wire it on the API service instance
@@ -201,6 +210,10 @@ func (s *FeedbackRecordsService) SetTranslation(
 		ctx, feedbackRecordID, translated, langKey, s.translationDefaultLang, stillCurrent,
 	); err != nil {
 		return fmt.Errorf("set feedback record translation: %w", err)
+	}
+
+	if err := s.enqueueTaxonomyEmbedding(ctx, feedbackRecordID); err != nil {
+		return err
 	}
 
 	return nil
@@ -477,7 +490,7 @@ func (s *FeedbackRecordsService) DeleteFeedbackRecordsByUser(
 // It does not publish an event.
 func (s *FeedbackRecordsService) SetEmbedding(
 	ctx context.Context, feedbackRecordID uuid.UUID, model string, embedding []float32,
-	stillCurrent func(fieldLabel, valueText *string) bool,
+	stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	if embedding == nil {
 		if err := s.embeddingsRepo.DeleteByFeedbackRecordAndModel(ctx, feedbackRecordID, model, stillCurrent); err != nil {
@@ -503,9 +516,20 @@ const embeddingBackfillPageSize = 500
 // It streams the records in keyset pages. Returns the number of jobs enqueued. Requires embeddingInserter
 // and embeddingQueueName to be set.
 func (s *FeedbackRecordsService) BackfillEmbeddings(ctx context.Context, model string) (int, error) {
+	return s.BackfillEmbeddingsWithInputKind(ctx, model, models.EmbeddingInputKindRaw)
+}
+
+// BackfillEmbeddingsWithInputKind enqueues embedding jobs for the given input kind.
+func (s *FeedbackRecordsService) BackfillEmbeddingsWithInputKind(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+) (int, error) {
 	if s.embeddingInserter == nil || s.embeddingQueueName == "" {
 		return 0, ErrEmbeddingBackfillNotConfigured
 	}
+
+	inputKind = models.NormalizeEmbeddingInputKind(inputKind)
 
 	opts := &river.InsertOpts{
 		Queue:       s.embeddingQueueName,
@@ -518,7 +542,8 @@ func (s *FeedbackRecordsService) BackfillEmbeddings(ctx context.Context, model s
 	afterID := uuid.Nil
 
 	for {
-		ids, err := s.embeddingsRepo.ListFeedbackRecordIDsForBackfill(ctx, model, afterID, embeddingBackfillPageSize)
+		ids, err := s.embeddingsRepo.ListFeedbackRecordIDsForBackfillByInputKind(
+			ctx, model, inputKind, afterID, embeddingBackfillPageSize)
 		if err != nil {
 			return enqueued, fmt.Errorf("list ids for embedding backfill: %w", err)
 		}
@@ -531,7 +556,8 @@ func (s *FeedbackRecordsService) BackfillEmbeddings(ctx context.Context, model s
 			res, err := s.embeddingInserter.Insert(ctx, FeedbackEmbeddingArgs{
 				FeedbackRecordID: id,
 				Model:            model,
-				ValueTextHash:    "backfill",
+				InputKind:        inputKind,
+				ValueTextHash:    "backfill:" + string(inputKind),
 			}, opts)
 			if err != nil {
 				return enqueued, fmt.Errorf("enqueue embedding job for %s: %w", id, err)
@@ -613,6 +639,27 @@ func (s *FeedbackRecordsService) BackfillTranslationsForTenant(
 
 			return targets, nil
 		})
+}
+
+func (s *FeedbackRecordsService) enqueueTaxonomyEmbedding(ctx context.Context, feedbackRecordID uuid.UUID) error {
+	if s.embeddingInserter == nil || s.embeddingQueueName == "" || s.taxonomyEmbeddingModel == "" {
+		return nil
+	}
+
+	_, err := s.embeddingInserter.Insert(ctx, FeedbackEmbeddingArgs{
+		FeedbackRecordID: feedbackRecordID,
+		Model:            s.taxonomyEmbeddingModel,
+		InputKind:        models.EmbeddingInputKindTaxonomyTranslated,
+		ValueTextHash:    "translation",
+	}, &river.InsertOpts{
+		Queue:       s.embeddingQueueName,
+		MaxAttempts: s.embeddingMaxAttempts,
+	})
+	if err != nil {
+		return fmt.Errorf("enqueue taxonomy embedding after translation write: %w", err)
+	}
+
+	return nil
 }
 
 // backfillTranslationsPaged enqueues a translation job for every target produced by

--- a/internal/service/feedback_records_service_test.go
+++ b/internal/service/feedback_records_service_test.go
@@ -403,6 +403,45 @@ func TestFeedbackRecordsService_SetTranslation_RequiresLangKey(t *testing.T) {
 	}
 }
 
+func TestFeedbackRecordsService_SetTranslation_EnqueuesTaxonomyEmbedding(t *testing.T) {
+	inserter := &mockEmbeddingInserter{}
+	svc := NewFeedbackRecordsService(
+		&mockFeedbackRecordsRepo{},
+		nil,
+		"",
+		nil,
+		inserter,
+		"embeddings",
+		3,
+		"",
+	)
+	svc.SetTaxonomyEmbeddingModel("taxonomy:embedding-model:translated-v1")
+
+	recordID := uuid.New()
+
+	translated := "Hello"
+	if err := svc.SetTranslation(context.Background(), recordID, &translated, "en-US", nil); err != nil {
+		t.Fatalf("SetTranslation() error = %v", err)
+	}
+
+	if len(inserter.insertCalls) != 1 {
+		t.Fatalf("insert calls = %d, want 1", len(inserter.insertCalls))
+	}
+
+	got := inserter.insertCalls[0]
+	if got.args.FeedbackRecordID != recordID {
+		t.Fatalf("FeedbackRecordID = %s, want %s", got.args.FeedbackRecordID, recordID)
+	}
+
+	if got.args.Model != "taxonomy:embedding-model:translated-v1" {
+		t.Fatalf("Model = %q, want taxonomy model", got.args.Model)
+	}
+
+	if got.args.InputKind != models.EmbeddingInputKindTaxonomyTranslated {
+		t.Fatalf("InputKind = %q, want taxonomy_translated", got.args.InputKind)
+	}
+}
+
 func TestFeedbackRecordsService_SetSentiment_Persists(t *testing.T) {
 	repo := &mockFeedbackRecordsRepo{}
 	svc := NewFeedbackRecordsService(repo, nil, "", nil, nil, "", 0, "")

--- a/internal/service/taxonomy_embedding_model.go
+++ b/internal/service/taxonomy_embedding_model.go
@@ -1,0 +1,17 @@
+package service
+
+import "strings"
+
+// TaxonomyEmbeddingModel returns the embeddings.model key used for taxonomy-specific embeddings.
+func TaxonomyEmbeddingModel(embeddingModel, override string) string {
+	if trimmed := strings.TrimSpace(override); trimmed != "" {
+		return trimmed
+	}
+
+	trimmed := strings.TrimSpace(embeddingModel)
+	if trimmed == "" {
+		return ""
+	}
+
+	return "taxonomy:" + trimmed + ":translated-v1"
+}

--- a/internal/workers/feedback_embedding.go
+++ b/internal/workers/feedback_embedding.go
@@ -32,7 +32,7 @@ type feedbackEmbeddingService interface {
 	GetFeedbackRecord(ctx context.Context, id uuid.UUID) (*models.FeedbackRecord, error)
 	SetEmbedding(
 		ctx context.Context, feedbackRecordID uuid.UUID, model string, embedding []float32,
-		stillCurrent func(fieldLabel, valueText *string) bool,
+		stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 	) error
 }
 
@@ -105,14 +105,15 @@ func (w *FeedbackEmbeddingWorker) Work(ctx context.Context, job *river.Job[servi
 		return fmt.Errorf("get feedback record: %w", err)
 	}
 
-	text := service.BuildEmbeddingInput(record.FieldLabel, record.ValueText, w.docPrefix)
+	inputKind := models.NormalizeEmbeddingInputKind(args.InputKind)
+	text := service.BuildEmbeddingInputForKind(record, inputKind, w.docPrefix)
 
 	// stillCurrent lets the repository verify, atomically with the write, that the content this
 	// job embedded is still the record's content — so of two concurrent jobs for one record, the
 	// stale one skips instead of clobbering the newer vector (last-write-wins would attach an old
 	// text's embedding forever; the missing-rows-only backfill cannot repair that).
-	stillCurrent := func(fieldLabel, valueText *string) bool {
-		return service.BuildEmbeddingInput(fieldLabel, valueText, w.docPrefix) == text
+	stillCurrent := func(fieldLabel, valueText, valueTextTranslated *string) bool {
+		return service.BuildEmbeddingInputFromValues(fieldLabel, valueText, valueTextTranslated, inputKind, w.docPrefix) == text
 	}
 
 	if text == "" {
@@ -270,7 +271,7 @@ func (w *FeedbackEmbeddingWorker) handleEmptyText(
 	record *models.FeedbackRecord,
 	log *slog.Logger,
 	start time.Time,
-	stillCurrent func(fieldLabel, valueText *string) bool,
+	stillCurrent func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	feedbackRecordID := job.Args.FeedbackRecordID
 

--- a/internal/workers/feedback_embedding_test.go
+++ b/internal/workers/feedback_embedding_test.go
@@ -55,7 +55,7 @@ func (m *mockEmbeddingService) GetFeedbackRecord(_ context.Context, _ uuid.UUID)
 
 func (m *mockEmbeddingService) SetEmbedding(
 	_ context.Context, _ uuid.UUID, _ string, embedding []float32,
-	_ func(fieldLabel, valueText *string) bool,
+	_ func(fieldLabel, valueText, valueTextTranslated *string) bool,
 ) error {
 	m.setCalls++
 	m.setEmbeddingNil = embedding == nil
@@ -66,9 +66,12 @@ func (m *mockEmbeddingService) SetEmbedding(
 type mockEmbeddingClient struct {
 	embedding []float32
 	err       error
+	input     string
 }
 
-func (m *mockEmbeddingClient) CreateEmbedding(_ context.Context, _ string) ([]float32, error) {
+func (m *mockEmbeddingClient) CreateEmbedding(_ context.Context, input string) ([]float32, error) {
+	m.input = input
+
 	return m.embedding, m.err
 }
 
@@ -93,6 +96,13 @@ func textRecord(valueText string) *models.FeedbackRecord {
 	if valueText != "" {
 		record.ValueText = &valueText
 	}
+
+	return record
+}
+
+func translatedTextRecord(valueText, valueTextTranslated string) *models.FeedbackRecord {
+	record := textRecord(valueText)
+	record.ValueTextTranslated = &valueTextTranslated
 
 	return record
 }
@@ -195,6 +205,22 @@ func TestFeedbackEmbeddingWorker_Work_SetEmbeddingConflict(t *testing.T) {
 			t.Fatalf("Work() error = %v, must not be a tenant write conflict", err)
 		}
 	})
+}
+
+func TestFeedbackEmbeddingWorker_Work_TaxonomyInputUsesTranslatedText(t *testing.T) {
+	svc := &mockEmbeddingService{record: translatedTextRecord("La machine ne demarre pas", "The machine does not start")}
+	client := &mockEmbeddingClient{embedding: []float32{0.1}}
+	worker := NewFeedbackEmbeddingWorker(svc, client, "", nil)
+	job := embeddingJob()
+	job.Args.InputKind = models.EmbeddingInputKindTaxonomyTranslated
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error = %v, want nil", err)
+	}
+
+	if client.input != "Question: How was it?\nAnswer: The machine does not start" {
+		t.Fatalf("embedding input = %q, want translated taxonomy text", client.input)
+	}
 }
 
 func TestFeedbackEmbeddingWorker_Work_EmptyTextConflict(t *testing.T) {

--- a/migrations/019_raw_embedding_hnsw_index.sql
+++ b/migrations/019_raw_embedding_hnsw_index.sql
@@ -1,0 +1,16 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Keep the semantic-search HNSW graph limited to raw/search embeddings. Taxonomy embeddings
+-- live in the same table under model keys prefixed with "taxonomy:", but they are fetched by
+-- exact model/id joins for taxonomy runs and should not consume HNSW candidate budget.
+DROP INDEX CONCURRENTLY IF EXISTS idx_embeddings;
+CREATE INDEX CONCURRENTLY idx_embeddings
+  ON embeddings USING hnsw (embedding halfvec_cosine_ops)
+  WITH (m = 24, ef_construction = 200)
+  WHERE model NOT LIKE 'taxonomy:%';
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_embeddings;
+CREATE INDEX CONCURRENTLY idx_embeddings
+  ON embeddings USING hnsw (embedding halfvec_cosine_ops)
+  WITH (m = 24, ef_construction = 200);

--- a/tests/embedding_backfill_test.go
+++ b/tests/embedding_backfill_test.go
@@ -254,13 +254,14 @@ func TestEmbeddingsUpsert_StaleWriteGuard(t *testing.T) {
 }
 
 // TestDeleteEmbeddingsForOtherModels locks the stale-model prune: rows for other models are
-// batch-deleted, rows for the current model survive.
+// batch-deleted, rows for the current models survive.
 func TestDeleteEmbeddingsForOtherModels(t *testing.T) {
 	ctx := context.Background()
 	feedbackRepo, embeddingsRepo := embeddingBackfillRepos(t)
 
 	// Unique per-run model names so the assertion is immune to leftover rows from other tests.
 	currentModel := "prune-current-" + uuid.NewString()
+	currentTaxonomyModel := "taxonomy:" + currentModel + ":translated-v1"
 	staleModel := "prune-stale-" + uuid.NewString()
 	text := "prune me"
 
@@ -281,6 +282,7 @@ func TestDeleteEmbeddingsForOtherModels(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, embeddingsRepo.Upsert(ctx, rec.ID, currentModel, embedding, nil))
+		require.NoError(t, embeddingsRepo.Upsert(ctx, rec.ID, currentTaxonomyModel, embedding, nil))
 		require.NoError(t, embeddingsRepo.Upsert(ctx, rec.ID, staleModel, embedding, nil))
 
 		keep = append(keep, rec.ID)
@@ -288,13 +290,16 @@ func TestDeleteEmbeddingsForOtherModels(t *testing.T) {
 	}
 
 	// batchSize 2 forces multiple delete rounds over the 3 stale rows.
-	deleted, err := embeddingsRepo.DeleteEmbeddingsForOtherModels(ctx, currentModel, 2)
+	deleted, err := embeddingsRepo.DeleteEmbeddingsForOtherModels(ctx, currentModel, 2, currentTaxonomyModel)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, deleted, int64(3), "at least this test's stale rows are pruned")
 
 	for _, id := range keep {
 		_, err := embeddingsRepo.GetEmbeddingByFeedbackRecordAndModel(ctx, id, currentModel)
 		require.NoError(t, err, "current-model rows must survive the prune")
+
+		_, err = embeddingsRepo.GetEmbeddingByFeedbackRecordAndModel(ctx, id, currentTaxonomyModel)
+		require.NoError(t, err, "current taxonomy-model rows must survive the prune")
 	}
 
 	for _, id := range drop {

--- a/tests/embedding_backfill_test.go
+++ b/tests/embedding_backfill_test.go
@@ -21,7 +21,8 @@ import (
 
 // countingEmbeddingInserter records the FeedbackEmbeddingArgs jobs enqueued.
 type countingEmbeddingInserter struct {
-	ids []uuid.UUID
+	ids  []uuid.UUID
+	args []service.FeedbackEmbeddingArgs
 }
 
 func (c *countingEmbeddingInserter) Insert(
@@ -29,6 +30,7 @@ func (c *countingEmbeddingInserter) Insert(
 ) (*rivertype.JobInsertResult, error) {
 	if a, ok := args.(service.FeedbackEmbeddingArgs); ok {
 		c.ids = append(c.ids, a.FeedbackRecordID)
+		c.args = append(c.args, a)
 	}
 
 	return &rivertype.JobInsertResult{}, nil
@@ -162,6 +164,45 @@ func TestBackfillEmbeddings_StreamsAllEligible(t *testing.T) {
 	}
 }
 
+func TestBackfillEmbeddings_TaxonomyInputKind(t *testing.T) {
+	ctx := context.Background()
+	feedbackRepo, embeddingsRepo := embeddingBackfillRepos(t)
+
+	model := "taxonomy-backfill-stream-" + uuid.NewString()
+	tenant := uuid.NewString()
+	value := "Bonjour"
+
+	rec, err := feedbackRepo.Create(ctx, &models.CreateFeedbackRecordRequest{
+		SourceType:   "formbricks",
+		SubmissionID: uuid.NewString(),
+		TenantID:     tenant,
+		FieldID:      "q1",
+		FieldType:    models.FieldTypeText,
+		ValueText:    &value,
+	})
+	require.NoError(t, err)
+
+	inserter := &countingEmbeddingInserter{}
+	svc := service.NewFeedbackRecordsService(feedbackRepo, embeddingsRepo, model, nil, inserter, "embeddings", 3, "")
+
+	enqueued, err := svc.BackfillEmbeddingsWithInputKind(ctx, model, models.EmbeddingInputKindTaxonomyTranslated)
+	require.NoError(t, err)
+	require.Positive(t, enqueued)
+
+	found := false
+
+	for _, args := range inserter.args {
+		if args.FeedbackRecordID == rec.ID {
+			found = true
+
+			assert.Equal(t, models.EmbeddingInputKindTaxonomyTranslated, args.InputKind)
+			assert.Equal(t, model, args.Model)
+		}
+	}
+
+	assert.True(t, found, "taxonomy backfill should enqueue the created record")
+}
+
 // TestEmbeddingsUpsert_StaleWriteGuard locks the concurrent-jobs guard: an upsert (or clear)
 // whose stillCurrent check fails against the record's current content is skipped with
 // ErrEmbeddingSuperseded, so a slower job that read older content can never clobber the vector
@@ -188,7 +229,7 @@ func TestEmbeddingsUpsert_StaleWriteGuard(t *testing.T) {
 
 	// A stale job (its content no longer matches the row) is skipped and writes nothing.
 	staleErr := embeddingsRepo.Upsert(ctx, rec.ID, model, embedding,
-		func(_, valueText *string) bool { return valueText != nil && *valueText == "older text" })
+		func(_, valueText, _ *string) bool { return valueText != nil && *valueText == "older text" })
 	require.ErrorIs(t, staleErr, huberrors.ErrEmbeddingSuperseded)
 
 	_, getErr := embeddingsRepo.GetEmbeddingByFeedbackRecordAndModel(ctx, rec.ID, model)
@@ -196,7 +237,7 @@ func TestEmbeddingsUpsert_StaleWriteGuard(t *testing.T) {
 
 	// The job holding the current content writes normally.
 	require.NoError(t, embeddingsRepo.Upsert(ctx, rec.ID, model, embedding,
-		func(_, valueText *string) bool { return valueText != nil && *valueText == text }))
+		func(_, valueText, _ *string) bool { return valueText != nil && *valueText == text }))
 
 	stored, err := embeddingsRepo.GetEmbeddingByFeedbackRecordAndModel(ctx, rec.ID, model)
 	require.NoError(t, err)
@@ -205,7 +246,7 @@ func TestEmbeddingsUpsert_StaleWriteGuard(t *testing.T) {
 	// A stale clear must not delete the current vector either.
 	require.ErrorIs(t,
 		embeddingsRepo.DeleteByFeedbackRecordAndModel(ctx, rec.ID, model,
-			func(_, valueText *string) bool { return valueText == nil }),
+			func(_, valueText, _ *string) bool { return valueText == nil }),
 		huberrors.ErrEmbeddingSuperseded)
 
 	_, err = embeddingsRepo.GetEmbeddingByFeedbackRecordAndModel(ctx, rec.ID, model)

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -382,6 +382,43 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		assert.Equal(t, translated, input.Records[0].ValueText)
 	})
 
+	t.Run("run input includes translated-only records", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-translated-only-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+
+		translated := "The machine does not start"
+
+		var recordID uuid.UUID
+
+		err := harness.db.QueryRow(ctx, `
+			INSERT INTO feedback_records (
+				source_type, source_id, field_id, field_label, field_type,
+				value_text, value_text_translated, translation_lang_key, tenant_id, submission_id
+			)
+			VALUES ($1, $2, $3, 'Feedback', 'text'::field_type_enum, NULL, $4, 'en-US', $5, $6)
+			RETURNING id`,
+			scope.SourceType, scope.SourceID, scope.FieldID, translated, scope.TenantID, "submission-"+uuid.NewString(),
+		).Scan(&recordID)
+		require.NoError(t, err)
+
+		embedding := make([]float32, models.EmbeddingVectorDimensions)
+		embedding[0] = 0.25
+		require.NoError(t, harness.embeddingsRepo.Upsert(ctx, recordID, taxonomyEmbeddingModel, embedding, nil))
+
+		recordCount, embeddingCount, _, err := harness.repo.CountScopeInput(ctx, scope, taxonomyEmbeddingModel)
+		require.NoError(t, err)
+		assert.Equal(t, 1, recordCount)
+		assert.Equal(t, 1, embeddingCount)
+
+		runID := startRunForScope(ctx, t, harness, scope)
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+		require.Len(t, input.Records, 1)
+		assert.Equal(t, translated, input.Records[0].ValueText)
+	})
+
 	t.Run("directory run input spans sources and fields", func(t *testing.T) {
 		directoryScope := uniqueDirectoryTaxonomyScope("tax-internal-directory-input")
 		cleanupTaxonomyTenant(ctx, t, harness.db, directoryScope.TenantID)

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -349,6 +349,39 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		assert.NotEmpty(t, input.Records[0].ValueText)
 	})
 
+	t.Run("run input returns translated text when present", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-translated-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+
+		original := "La machine ne demarre pas"
+		translated := "The machine does not start"
+
+		var recordID uuid.UUID
+
+		err := harness.db.QueryRow(ctx, `
+			INSERT INTO feedback_records (
+				source_type, source_id, field_id, field_label, field_type,
+				value_text, value_text_translated, translation_lang_key, tenant_id, submission_id
+			)
+			VALUES ($1, $2, $3, 'Feedback', 'text'::field_type_enum, $4, $5, 'en-US', $6, $7)
+			RETURNING id`,
+			scope.SourceType, scope.SourceID, scope.FieldID, original, translated, scope.TenantID, "submission-"+uuid.NewString(),
+		).Scan(&recordID)
+		require.NoError(t, err)
+
+		embedding := make([]float32, models.EmbeddingVectorDimensions)
+		embedding[0] = 0.25
+		require.NoError(t, harness.embeddingsRepo.Upsert(ctx, recordID, taxonomyEmbeddingModel, embedding, nil))
+
+		runID := startRunForScope(ctx, t, harness, scope)
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+		require.Len(t, input.Records, 1)
+		assert.Equal(t, translated, input.Records[0].ValueText)
+	})
+
 	t.Run("directory run input spans sources and fields", func(t *testing.T) {
 		directoryScope := uniqueDirectoryTaxonomyScope("tax-internal-directory-input")
 		cleanupTaxonomyTenant(ctx, t, harness.db, directoryScope.TenantID)


### PR DESCRIPTION
## Summary
- add taxonomy-specific embedding jobs keyed separately from raw search embeddings
- embed taxonomy records from `value_text_translated` when present, falling back to `value_text`
- route taxonomy run counts/input through the taxonomy embedding model key and return canonical translated text to the taxonomy service
- enqueue taxonomy re-embedding after translation writes and add a `-taxonomy` backfill mode
- keep semantic search on raw embeddings by excluding taxonomy model rows from the raw HNSW index/search path
- bump the Go toolchain pins to `1.26.5` so Code Quality runs `govulncheck` against the patched stdlib

## Why
Multilingual directories were clustering by language because taxonomy embeddings were built from raw mixed-language text. This keeps normal semantic search embeddings unchanged while giving taxonomy generation a canonicalized embedding space.

## Rollout
- After deploy, run `backfill-embeddings -taxonomy` for existing records before relying on taxonomy generation for pre-existing directories. New/updated/translated records enqueue taxonomy embeddings automatically.
- If `backfill-embeddings -prune-stale-models` is used during rollout, it now preserves both the active raw embedding model and the active taxonomy embedding model.

## Validation
- `go test ./internal/repository ./internal/service ./cmd/backfill-embeddings`
- `DATABASE_URL='postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable' go test ./tests -run 'TestDeleteEmbeddingsForOtherModels|TestTaxonomyAPI_InternalServiceEndpoints|TestTaxonomyNoSource' -timeout 120s`
- `DATABASE_URL='postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable' go test ./tests/... -timeout 120s`
- `make test-unit`
- `make build`
- `PATH='/Users/bhagya/work/bin:'"$PATH" make migrate-validate`
- `GOLANGCI_LINT=/Users/bhagya/work/bin/golangci-lint PATH='/Users/bhagya/work/bin:'"$PATH" make lint-new`
- `GOLANGCI_LINT=/Users/bhagya/work/bin/golangci-lint make fmt`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
