### PR TITLE
chore: bump Go to 1.26.5

### DIFF
--- a/.github/workflows/api-contract-tests.yml
+++ b/.github/workflows/api-contract-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/migrations-validate.yml
+++ b/.github/workflows/migrations-validate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ run:
   timeout: 5m
   concurrency: 4
   modules-download-mode: readonly
-  go: "1.26.4"
+  go: "1.26.5"
   # Allow linting test files but suppress specific strict rules via exclusion below
   tests: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Build
 # =============================================================================
 # TARGETOS/TARGETARCH are set by Docker Buildx for multi-platform builds (e.g. linux/arm64 on Mac M1).
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG GOOSE_VERSION=v3.27.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/formbricks/hub
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-playground/form/v4 v4.3.0


### PR DESCRIPTION
## What does this PR do?

Bumps Go from `1.26.4` to `1.26.5` across the repo to resolve the govulncheck failure now breaking the **Code Quality** gate on open PRs (e.g. #105).

The affecting advisory is [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) — a `crypto/tls` vulnerability in the **Go standard library** (`Found in: crypto/tls@go1.26.4`, `Fixed in: crypto/tls@go1.26.5`). It's not introduced by any single PR; it affects every branch built with go1.26.4, so the fix is a toolchain bump rather than a code change. 1.26.5 is also the current latest stable release.

Version pins updated:

- `go.mod` — `go` directive
- `Dockerfile` — `golang:1.26.5-alpine` builder base image
- `.golangci.yml` — linter target `go` version
- `.github/workflows/` — all `actions/setup-go` pins (`tests.yml` ×3, `code-quality.yml`, `api-contract-tests.yml`, `migrations-validate.yml`)

The `code-quality.yml` cache key already derives the Go version dynamically from the `setup-go` output, so it updates automatically.

**Note on remaining advisory:** govulncheck still reports [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) (`golang.org/x/crypto/openpgp` is unmaintained). It is a transitive dependency our code never calls (`Fixed in: N/A`), so it is non-affecting, does not fail the gate, and is not fixable by a version bump. Out of scope here.

## How should this be tested?

Verified locally with the go1.26.5 toolchain (auto-downloaded via `GOTOOLCHAIN=auto`):

- `go build ./...` — clean.
- `govulncheck ./...` (v1.3.0, matching CI) — **"Your code is affected by 0 vulnerabilities"**, exit 0. Before the bump it reported GO-2026-5856 as affecting (exit 3).
- Pre-commit hook ran `make fmt` + `make lint` (**0 issues**) and unit tests (pass).

CI runs the full suite (unit + integration pg16/17/18 + coverage + migrate-validate + the Code Quality/govulncheck gate) — the previously red Code Quality check should now pass.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits — n/a (version-string bump)
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`) — deferred to CI (needs a DB); unit tests ran green via the pre-commit hook
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging — n/a
- [x] Merged the latest changes from main onto my branch (branched off current `origin/main`)
- [ ] If database schema changed — n/a (no schema change)

### Appreciated

- [ ] If API changed — n/a (no API change)
- [ ] If API behavior changed — n/a
- [ ] Updated docs in `docs/` if changes were necessary — n/a
- [ ] Ran `make tests-coverage` for meaningful logic changes — n/a (no logic change)
