### PR TITLE
fix(translation): skip translation when source language is unset

### DIFF
--- a/internal/workers/feedback_translation.go
+++ b/internal/workers/feedback_translation.go
@@ -69,13 +69,27 @@ func NewFeedbackTranslationWorker(
 }
 
 // translate returns the translated value_text, short-circuiting (copying the original) when the
-// record's source language already matches the target language.
+// record has no usable source language, or its source language already matches the target.
 func translate(
 	ctx context.Context, client service.TranslationClient, record *models.FeedbackRecord, targetLang string, eventID uuid.UUID,
 ) (string, error) {
 	sourceLang := ""
 	if record.Language != nil {
 		sourceLang = *record.Language
+	}
+
+	// An unset source language means the caller isn't tracking languages for this record. For
+	// Formbricks surveys specifically, a response in the survey's default language arrives with no
+	// language at all (the "default" sentinel is dropped before send), so the common single-language
+	// case has no source. Treat "unknown" as "already in the target" and copy through rather than
+	// round-tripping identical text through the LLM — which is what produced e.g. English feedback
+	// being "translated" to English. A present-but-different (or undetermined "und") tag still
+	// translates via sameLanguageAndScript below.
+	if strings.TrimSpace(sourceLang) == "" {
+		slog.Info("translation: source language unset, copying value_text",
+			"feedback_record_id", record.ID, "event_id", eventID)
+
+		return *record.ValueText, nil
 	}
 
 	if sameLanguageAndScript(sourceLang, targetLang) {

--- a/internal/workers/feedback_translation_test.go
+++ b/internal/workers/feedback_translation_test.go
@@ -172,6 +172,28 @@ func TestFeedbackTranslationWorker_ClearsWhenValueTextEmpty(t *testing.T) {
 	}
 }
 
+func TestFeedbackTranslationWorker_UnsetSourceLanguageCopies(t *testing.T) {
+	// No source language (record.Language == nil) — the common Formbricks single-language case,
+	// where a default-language response reaches the Hub with no language at all. Copy through
+	// instead of round-tripping identical text through the LLM (e.g. English -> English).
+	svc := &mockTranslationWorkerService{record: translationRecord("Hello world", "")}
+	client := &stubTranslationClient{out: "should-not-be-used"}
+	worker := NewFeedbackTranslationWorker(svc, client, nil)
+
+	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
+		t.Fatalf("Work() error = %v", err)
+	}
+
+	if len(client.calls) != 0 {
+		t.Fatalf("client called %d times, want 0 (unset source must copy, not translate)", len(client.calls))
+	}
+
+	if len(svc.setCalls) != 1 || svc.setCalls[0].translated == nil ||
+		*svc.setCalls[0].translated != "Hello world" || svc.setCalls[0].langKey != "en-US" {
+		t.Fatalf("set calls = %+v, want copied 'Hello world' / en-US", svc.setCalls)
+	}
+}
+
 func TestFeedbackTranslationWorker_UndeterminedSourceTranslates(t *testing.T) {
 	// "und" (undetermined) must not be treated as matching the target — translate, not copy.
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "und")}


### PR DESCRIPTION
## What does this PR do?

Fixes feedback records whose open text is already in the tenant's target language being needlessly sent to the translation LLM — most visibly **English text getting "translated" to English**, where the round-trip can subtly rewrite the original.

### Root cause

The translation worker uses `record.Language` as the source language and copies `value_text` through only when `sameLanguageAndScript(source, target)` matches. That comparison already ignores region (`en-US` vs `en-GB` match) and correctly distinguishes scripts (`zh-Hans` vs `zh-Hant` translate), so it was never the problem.

The problem is an **unset** source language. `record.Language` is client-supplied and frequently absent. For Formbricks surveys this is the *common* case: a response submitted in the survey's **default** language is stored as the `"default"` sentinel, and the Formbricks → Hub transform drops the field entirely before sending (`...(response.language && response.language !== "default" ? { language } : {})`). So single-language tenants send **no** source language on every record → `sameLanguageAndScript("", target)` returns false → every record was translated, including content already in the target language.

### Change

In `translate()`, when the source language is unset (nil/empty), treat it as "already in the target language" and copy `value_text` through instead of calling the LLM. A present-but-different tag — including undetermined `"und"` — still translates via `sameLanguageAndScript`. `sameLanguageAndScript` itself is unchanged.

### Trade-off / follow-up

If a tenant's target differs from their surveys' **default** language (e.g. target English, default-language responses in German), those default-language records arrive with no source and will now be copied through untranslated rather than translated. The complete fix is on the Formbricks side: resolve the `"default"` sentinel back to the survey's real default `language.code` before sending, so the Hub always receives a genuine tag. Worth a follow-up in the Formbricks repo (`apps/web/lib/feedback-source/transform.ts`).

## How should this be tested?

- `make tests` / unit tests in `internal/workers/`.
- New test `TestFeedbackTranslationWorker_UnsetSourceLanguageCopies`: a record with `Language == nil` and target `en-US` copies `value_text` through and makes **0** LLM calls.
- Existing tests still green: `..._SourceEqualsTargetCopies` (`en-US`/`en-GB`), `..._UndeterminedSourceTranslates` (`und` still translates), `..._DifferentScriptTranslates` (`zh-Hans`/`zh-Hant`), and the `TestSameLanguageAndScript` table.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read Repository Guidelines
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`) — ran unit tests via pre-commit; no logic in `tests/` affected
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: N/A — no schema change

### Appreciated

- [ ] If API changed: N/A — no API/OpenAPI change
- [ ] If API behavior changed: N/A
- [ ] Updated docs in `docs/` if changes were necessary — N/A
- [x] Ran `make tests-coverage` for meaningful logic changes — worker unit tests cover the new branch
