### PR TITLE
fix(translation): preserve original line breaks in translated text

### DIFF
--- a/internal/service/translation_client_factory.go
+++ b/internal/service/translation_client_factory.go
@@ -63,8 +63,10 @@ func buildTranslationPrompt(req TranslateRequest) (systemPrompt, userText string
 
 	systemPrompt = fmt.Sprintf(
 		"You are a professional translator. Translate the user's message from %s into %s. "+
-			"Preserve the original meaning, tone, and formatting, and keep any {{variable}} placeholders "+
-			"and HTML tags unchanged. Respond with only the translated text — no preamble, notes, or quotation marks.",
+			"Preserve the original meaning and tone. Reproduce the original formatting exactly: keep the "+
+			"same line breaks, blank lines, and leading/trailing whitespace, and do not add, remove, or "+
+			"merge line breaks or paragraphs. Keep any {{variable}} placeholders and HTML tags unchanged. "+
+			"Respond with only the translated text — no preamble, notes, or quotation marks.",
 		from, target,
 	)
 

--- a/internal/service/translation_client_factory_test.go
+++ b/internal/service/translation_client_factory_test.go
@@ -71,6 +71,12 @@ func TestBuildTranslationPrompt(t *testing.T) {
 		if !strings.Contains(systemPrompt, "from French into German") {
 			t.Fatalf("system prompt missing language names: %q", systemPrompt)
 		}
+
+		// The model must not re-flow the text — it was inserting paragraph breaks into
+		// run-on source text (see Johannes' German login-issue example).
+		if !strings.Contains(systemPrompt, "same line breaks") {
+			t.Fatalf("system prompt missing line-break preservation instruction: %q", systemPrompt)
+		}
 	})
 
 	t.Run("unknown source falls back to original language", func(t *testing.T) {

--- a/internal/service/translation_client_factory_test.go
+++ b/internal/service/translation_client_factory_test.go
@@ -72,8 +72,6 @@ func TestBuildTranslationPrompt(t *testing.T) {
 			t.Fatalf("system prompt missing language names: %q", systemPrompt)
 		}
 
-		// The model must not re-flow the text — it was inserting paragraph breaks into
-		// run-on source text (see Johannes' German login-issue example).
 		if !strings.Contains(systemPrompt, "same line breaks") {
 			t.Fatalf("system prompt missing line-break preservation instruction: %q", systemPrompt)
 		}


### PR DESCRIPTION
## What does this PR do?

Keeps translated open text visually faithful to the original by telling the translator model to preserve line breaks and whitespace.

### Context

From Johannes' report: a German feedback record (one run-on paragraph) came back translated to English split into three paragraphs with blank lines inserted, so the "English" view no longer matched the original's structure.

### Root cause

The translation system prompt only asked to "preserve … formatting", which the model interprets loosely — it re-flows run-on text into "tidier" paragraphs. There was no explicit instruction to keep line breaks and whitespace as-is.

### Change

`buildTranslationPrompt` now instructs the model to reproduce the original formatting exactly: keep the same line breaks, blank lines, and leading/trailing whitespace, and not add, remove, or merge line breaks or paragraphs. `{{variable}}` placeholder and HTML-tag preservation is unchanged.

Note: this is a prompt-level constraint (best-effort — the model still ultimately controls output), not a hard post-processing guarantee. It targets the specific "extra paragraph breaks" behavior seen in the report.

## How should this be tested?

- `make tests` / unit tests in `internal/service/`.
- `TestBuildTranslationPrompt` now also asserts the prompt contains the line-break preservation instruction.
- Manual: translate a multi-line and a run-on record and confirm the translated text keeps the same line/paragraph structure as the original.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read Repository Guidelines
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`) — ran unit tests via pre-commit; no `tests/` logic affected
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: N/A

### Appreciated

- [ ] If API changed: N/A
- [ ] If API behavior changed: N/A
- [ ] Updated docs in `docs/`: N/A
- [x] Ran `make tests-coverage` for meaningful logic changes — prompt builder test updated
