### PR TITLE
 fix(taxonomy): reap stalled runs so taxonomy generation can recover (ENG-1924)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,9 +53,11 @@ LOG_LEVEL=info
 # HUB_INTERNAL_API_TOKEN=dev-hub-internal-api-token
 #
 # Stuck-run reaper (only runs when the taxonomy service is configured):
-# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS: seconds a run may sit in pending/running before the reaper
-#   force-fails it (default 1800 = 30 min). WARNING: this MUST exceed the longest legitimate taxonomy
-#   run, or healthy long-running generations will be marked failed.
+# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS: max seconds a pending/running run may go without its updated_at
+#   being bumped (via the internal heartbeat endpoint) before the reaper force-fails it (default
+#   1800 = 30 min). Once the taxonomy service heartbeats during generation, tune this down to a small
+#   multiple of its heartbeat interval. WARNING: until heartbeats flow, updated_at only advances on
+#   state changes, so this MUST exceed the longest legitimate run or healthy generations get reaped.
 # TAXONOMY_REAPER_INTERVAL_SECONDS: seconds between reaper sweeps for stuck runs (default 60).
 # TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=1800
 # TAXONOMY_REAPER_INTERVAL_SECONDS=60

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,14 @@ LOG_LEVEL=info
 # TAXONOMY_SERVICE_URL=http://localhost:8000
 # TAXONOMY_SERVICE_TOKEN=dev-taxonomy-service-token
 # HUB_INTERNAL_API_TOKEN=dev-hub-internal-api-token
+#
+# Stuck-run reaper (only runs when the taxonomy service is configured):
+# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS: seconds a run may sit in pending/running before the reaper
+#   force-fails it (default 1800 = 30 min). WARNING: this MUST exceed the longest legitimate taxonomy
+#   run, or healthy long-running generations will be marked failed.
+# TAXONOMY_REAPER_INTERVAL_SECONDS: seconds between reaper sweeps for stuck runs (default 60).
+# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=1800
+# TAXONOMY_REAPER_INTERVAL_SECONDS=60
 
 # Message publisher: event channel buffer size (optional). Default: 1024
 MESSAGE_PUBLISHER_QUEUE_MAX_SIZE=16384

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -820,14 +820,12 @@ func runTaxonomyRunReaper(
 	reap := func() {
 		failed, err := repo.FailStuckRuns(ctx, timeout, stuckTaxonomyRunMessage,
 			models.TaxonomyRunFailureCodeInternalError)
-		if err != nil {
-			slog.WarnContext(ctx, "taxonomy stuck-run reaper failed", "error", err)
-
-			return
-		}
-
 		if failed > 0 {
 			slog.InfoContext(ctx, "taxonomy stuck-run reaper failed stalled runs", "count", failed)
+		}
+
+		if err != nil {
+			slog.WarnContext(ctx, "taxonomy stuck-run reaper failed", "error", err)
 		}
 	}
 

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -641,6 +641,7 @@ func newHTTPServer(
 		internalTaxonomy.HandleFunc("GET /internal/v1/taxonomy/runs/{run_id}/input", taxonomyInternal.GetRunInput)
 		internalTaxonomy.HandleFunc("PUT /internal/v1/taxonomy/runs/{run_id}/result", taxonomyInternal.CompleteRun)
 		internalTaxonomy.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/failed", taxonomyInternal.FailRun)
+		internalTaxonomy.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/heartbeat", taxonomyInternal.Heartbeat)
 		internalTaxonomyWithAuth := middleware.Auth(cfg.Taxonomy.HubInternalAPIToken)(internalTaxonomy)
 		mux.Handle("/internal/v1/taxonomy/", internalTaxonomyWithAuth)
 	}

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -40,6 +40,7 @@ type App struct {
 	meterProvider  *sdkmetric.MeterProvider
 	tracerProvider *sdktrace.TracerProvider
 	metrics        *observability.Metrics
+	taxonomyRepo   *repository.TaxonomyRepository
 }
 
 var (
@@ -569,6 +570,7 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 		meterProvider:  meterProvider,
 		tracerProvider: tracerProvider,
 		metrics:        metrics,
+		taxonomyRepo:   taxonomyRepo,
 	}, nil
 }
 
@@ -689,6 +691,13 @@ func (a *App) Run(ctx context.Context) error {
 		go runRiverQueueDepthPoller(ctx, a.db, a.metrics.Events)
 	}
 
+	// Reap taxonomy runs orphaned in a non-terminal state, but only when the taxonomy service is wired
+	// (no runs exist otherwise, so the sweep would be pointless).
+	if a.taxonomyRepo != nil && (a.cfg.Taxonomy.ServiceURL != "" || a.cfg.Taxonomy.ServiceToken != "") {
+		go runTaxonomyRunReaper(ctx, a.taxonomyRepo,
+			a.cfg.Taxonomy.StuckRunTimeout.Duration(), a.cfg.Taxonomy.ReaperInterval.Duration())
+	}
+
 	go func() {
 		slog.Info("Starting server", "port", a.cfg.Server.Port)
 
@@ -781,6 +790,46 @@ func runRiverQueueDepthPoller(ctx context.Context, db *pgxpool.Pool, eventMetric
 			return
 		case <-ticker.C:
 			update()
+		}
+	}
+}
+
+// stuckTaxonomyRunMessage is stored on runs the reaper force-fails. The Web maps the internal_error
+// code to a localized, user-facing message; this raw string is for operators (logs / API consumers).
+const stuckTaxonomyRunMessage = "taxonomy run timed out without completing"
+
+// runTaxonomyRunReaper periodically fails taxonomy runs orphaned in a non-terminal state — the
+// taxonomy service crashed mid-run or its terminal callback was lost — so they stop being polled
+// forever in the UI and generation can be retried. Idempotent: the repository's status filter skips
+// runs that finished on their own between sweeps.
+func runTaxonomyRunReaper(
+	ctx context.Context, repo *repository.TaxonomyRepository, timeout, interval time.Duration,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	reap := func() {
+		failed, err := repo.FailStuckRuns(ctx, timeout, stuckTaxonomyRunMessage,
+			models.TaxonomyRunFailureCodeInternalError)
+		if err != nil {
+			slog.WarnContext(ctx, "taxonomy stuck-run reaper failed", "error", err)
+
+			return
+		}
+
+		if failed > 0 {
+			slog.InfoContext(ctx, "taxonomy stuck-run reaper failed stalled runs", "count", failed)
+		}
+	}
+
+	reap()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reap()
 		}
 	}
 }

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -805,6 +805,15 @@ const stuckTaxonomyRunMessage = "taxonomy run timed out without completing"
 func runTaxonomyRunReaper(
 	ctx context.Context, repo *repository.TaxonomyRepository, timeout, interval time.Duration,
 ) {
+	// A non-positive interval panics time.NewTicker, and a non-positive timeout would reap active
+	// runs (cutoff would be now or in the future). Either is misconfiguration — disable the reaper.
+	if interval <= 0 || timeout <= 0 {
+		slog.WarnContext(ctx, "taxonomy stuck-run reaper disabled: non-positive interval or timeout",
+			"interval", interval, "timeout", timeout)
+
+		return
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/internal/api/handlers/taxonomy_internal_handler.go
+++ b/internal/api/handlers/taxonomy_internal_handler.go
@@ -20,6 +20,7 @@ type TaxonomyInternalService interface {
 		message string,
 		errorCode models.TaxonomyRunFailureCode,
 	) (*models.TaxonomyRun, error)
+	Heartbeat(ctx context.Context, runID uuid.UUID) error
 }
 
 // TaxonomyInternalHandler hosts internal taxonomy service endpoints.
@@ -126,4 +127,26 @@ func (h *TaxonomyInternalHandler) FailRun(w http.ResponseWriter, r *http.Request
 	}
 
 	response.RespondJSON(w, http.StatusOK, result)
+}
+
+// Heartbeat records that a taxonomy run is still alive so the stuck-run reaper does not fail it.
+func (h *TaxonomyInternalHandler) Heartbeat(w http.ResponseWriter, r *http.Request) {
+	if h.service == nil {
+		response.RespondServiceUnavailable(w, r, "Taxonomy internals are not available.")
+
+		return
+	}
+
+	runID, ok := parseUUIDPathValue(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Heartbeat(r.Context(), runID); err != nil {
+		respondTaxonomyError(w, r, err)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,11 @@ type TaxonomyConfig struct {
 	HubInternalAPIToken    string `env:"HUB_INTERNAL_API_TOKEN"`
 	EmbeddingModel         string `env:"TAXONOMY_EMBEDDING_MODEL"`
 	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
+	// StuckRunTimeout is how long a run may sit in pending/running before the reaper force-fails it;
+	// it must exceed the longest legitimate run so healthy long-running generations are not reaped.
+	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"1800"`
+	// ReaperInterval is how often the reaper sweeps for stuck runs.
+	ReaperInterval DurationSec `env:"TAXONOMY_REAPER_INTERVAL_SECONDS" env-default:"60"`
 }
 
 // TenantDataConfig holds tenant data purge settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,8 +215,11 @@ type TaxonomyConfig struct {
 	HubInternalAPIToken    string `env:"HUB_INTERNAL_API_TOKEN"`
 	EmbeddingModel         string `env:"TAXONOMY_EMBEDDING_MODEL"`
 	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
-	// StuckRunTimeout is how long a run may sit in pending/running before the reaper force-fails it;
-	// it must exceed the longest legitimate run so healthy long-running generations are not reaped.
+	// StuckRunTimeout is the maximum time a pending/running run may go without its updated_at being
+	// bumped (via the internal heartbeat endpoint) before the reaper force-fails it. Once the taxonomy
+	// service heartbeats during generation this can be tuned down to a small multiple of the heartbeat
+	// interval; until then updated_at only advances on state changes, so keep it above the longest
+	// legitimate run so healthy long-running generations are not reaped.
 	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"1800"`
 	// ReaperInterval is how often the reaper sweeps for stuck runs.
 	ReaperInterval DurationSec `env:"TAXONOMY_REAPER_INTERVAL_SECONDS" env-default:"60"`

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -326,6 +327,33 @@ func (r *TaxonomyRepository) MarkRunFailed(
 	}
 
 	return run, nil
+}
+
+// FailStuckRuns marks taxonomy runs stuck in a non-terminal state (pending/running) past olderThan
+// as failed. Runs are orphaned when the taxonomy service crashes mid-run or its terminal callback is
+// lost; without this sweep they are polled forever in the UI and block regeneration. The status
+// filter keeps it idempotent and race-safe — a run that finishes between sweeps no longer matches.
+// Returns the number of runs failed.
+func (r *TaxonomyRepository) FailStuckRuns(
+	ctx context.Context,
+	olderThan time.Duration,
+	message string,
+	errorCode models.TaxonomyRunFailureCode,
+) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+
+	tag, err := r.db.Exec(ctx, `
+		UPDATE taxonomy_runs
+		SET status = 'failed', error = $1, error_code = $2, finished_at = NOW(), updated_at = NOW()
+		WHERE status IN ('pending', 'running')
+		  AND COALESCE(started_at, created_at) < $3`,
+		message, nullableFailureCode(errorCode), cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("fail stuck taxonomy runs: %w", err)
+	}
+
+	return tag.RowsAffected(), nil
 }
 
 // GetRunForInternalService returns run metadata for internal taxonomy service-token workflows.

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -430,9 +430,16 @@ func (r *TaxonomyRepository) FailStuckRuns(
 			continue
 		}
 
-		// A run that finished (ErrConflict) or was purged (ErrNotFound) between the select and here
-		// is no longer stuck — skip it. Record the first unexpected error but keep reaping.
-		if errors.Is(markErr, huberrors.ErrConflict) || errors.Is(markErr, huberrors.ErrNotFound) {
+		// Skip a run that is no longer ours to fail rather than erroring the whole sweep:
+		//   - ErrConflict: it reached a terminal state between the select and here.
+		//   - ErrNotFound: it was purged between the select and here.
+		//   - ErrTenantWriteConflict: a tenant data purge holds the exclusive lock, so the shared
+		//     write lock is unavailable; the purge is deleting these runs anyway, and any that
+		//     survive it are caught by the next sweep.
+		// Record the first genuinely unexpected error but keep reaping the remaining candidates.
+		if errors.Is(markErr, huberrors.ErrConflict) ||
+			errors.Is(markErr, huberrors.ErrNotFound) ||
+			errors.Is(markErr, huberrors.ErrTenantWriteConflict) {
 			continue
 		}
 

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -331,9 +331,14 @@ func (r *TaxonomyRepository) MarkRunFailed(
 
 // FailStuckRuns marks taxonomy runs stuck in a non-terminal state (pending/running) past olderThan
 // as failed. Runs are orphaned when the taxonomy service crashes mid-run or its terminal callback is
-// lost; without this sweep they are polled forever in the UI and block regeneration. The status
-// filter keeps it idempotent and race-safe — a run that finishes between sweeps no longer matches.
-// Returns the number of runs failed.
+// lost; without this sweep they are polled forever in the UI and block regeneration.
+//
+// Candidates are selected up front (a scoped update needs each run's tenant), then failed one at a
+// time through MarkRunFailed so every mutation takes the shared tenant write lock — the repository
+// invariant that coordinates tenant-owned writes with tenant-data purges. Stuck runs are rare, so a
+// per-run loop rather than a batched per-tenant update is sufficient. A run that reaches a terminal
+// state between selection and update is no longer stuck (ErrConflict / ErrNotFound) and is skipped.
+// Returns the number of runs failed and the first unexpected error, if any.
 func (r *TaxonomyRepository) FailStuckRuns(
 	ctx context.Context,
 	olderThan time.Duration,
@@ -342,18 +347,66 @@ func (r *TaxonomyRepository) FailStuckRuns(
 ) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 
-	tag, err := r.db.Exec(ctx, `
-		UPDATE taxonomy_runs
-		SET status = 'failed', error = $1, error_code = $2, finished_at = NOW(), updated_at = NOW()
-		WHERE status IN ('pending', 'running')
-		  AND COALESCE(started_at, created_at) < $3`,
-		message, nullableFailureCode(errorCode), cutoff,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("fail stuck taxonomy runs: %w", err)
+	type stuckRun struct {
+		id       uuid.UUID
+		tenantID string
 	}
 
-	return tag.RowsAffected(), nil
+	rows, err := r.db.Query(ctx, `
+		SELECT id, tenant_id
+		FROM taxonomy_runs
+		WHERE status IN ('pending', 'running')
+		  AND COALESCE(started_at, created_at) < $1`,
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("select stuck taxonomy runs: %w", err)
+	}
+
+	var candidates []stuckRun
+
+	for rows.Next() {
+		var run stuckRun
+		if scanErr := rows.Scan(&run.id, &run.tenantID); scanErr != nil {
+			rows.Close()
+
+			return 0, fmt.Errorf("scan stuck taxonomy run: %w", scanErr)
+		}
+
+		candidates = append(candidates, run)
+	}
+
+	rows.Close()
+
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return 0, fmt.Errorf("iterate stuck taxonomy runs: %w", rowsErr)
+	}
+
+	var (
+		reaped   int64
+		firstErr error
+	)
+
+	for _, run := range candidates {
+		_, markErr := r.MarkRunFailed(ctx, run.id, run.tenantID, message, errorCode)
+		if markErr == nil {
+			reaped++
+
+			continue
+		}
+
+		// A run that finished (ErrConflict) or was purged (ErrNotFound) between the select and here
+		// is no longer stuck — skip it. Record the first unexpected error but keep reaping.
+		if errors.Is(markErr, huberrors.ErrConflict) || errors.Is(markErr, huberrors.ErrNotFound) {
+			continue
+		}
+
+		if firstErr == nil {
+			firstErr = markErr
+		}
+	}
+
+	return reaped, firstErr
 }
 
 // GetRunForInternalService returns run metadata for internal taxonomy service-token workflows.

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -329,9 +329,44 @@ func (r *TaxonomyRepository) MarkRunFailed(
 	return run, nil
 }
 
+// Heartbeat bumps updated_at to NOW() for a run still in a non-terminal state (pending/running),
+// keeping it out of the stuck-run reaper's reach for another timeout window. The taxonomy service
+// calls this periodically while a generation is in flight; updated_at is the liveness signal the
+// reaper (FailStuckRuns) checks against.
+//
+// The update runs through the shared tenant write lock — the repository invariant that coordinates
+// tenant-owned writes with tenant-data purges. A heartbeat that finds no pending/running row (the run
+// finished, was purged, or its id is stale) is a benign no-op: there is nothing left to keep alive, so
+// it succeeds silently rather than erroring. Callers resolve the run (and thus a 404 for an unknown
+// id) before reaching here.
+func (r *TaxonomyRepository) Heartbeat(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+) error {
+	return withTenantWritePoolTx(ctx, r.db, []string{tenantID}, func(dbTx tenantWriteTx) error {
+		if _, err := dbTx.Exec(ctx, `
+			UPDATE taxonomy_runs
+			SET updated_at = NOW()
+			WHERE id = $1 AND tenant_id = $2 AND status IN ('pending', 'running')`,
+			runID, tenantID,
+		); err != nil {
+			return fmt.Errorf("heartbeat taxonomy run: %w", err)
+		}
+
+		return nil
+	})
+}
+
 // FailStuckRuns marks taxonomy runs stuck in a non-terminal state (pending/running) past olderThan
 // as failed. Runs are orphaned when the taxonomy service crashes mid-run or its terminal callback is
 // lost; without this sweep they are polled forever in the UI and block regeneration.
+//
+// Staleness is measured against updated_at, the run's liveness signal: the taxonomy service bumps it
+// via Heartbeat while a generation is in flight (see Heartbeat), so olderThan is the maximum tolerated
+// gap between heartbeats, not a ceiling on total run duration. Until heartbeats flow, updated_at holds
+// the timestamp of the run's last state change, so the sweep degrades to a coarse "no progress since"
+// safety net.
 //
 // Candidates are selected up front (a scoped update needs each run's tenant), then failed one at a
 // time through MarkRunFailed so every mutation takes the shared tenant write lock — the repository
@@ -356,7 +391,7 @@ func (r *TaxonomyRepository) FailStuckRuns(
 		SELECT id, tenant_id
 		FROM taxonomy_runs
 		WHERE status IN ('pending', 'running')
-		  AND COALESCE(started_at, created_at) < $1`,
+		  AND updated_at < $1`,
 		cutoff,
 	)
 	if err != nil {

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -40,6 +40,7 @@ type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service 
 		message string,
 		errorCode models.TaxonomyRunFailureCode,
 	) (*models.TaxonomyRun, error)
+	Heartbeat(ctx context.Context, runID uuid.UUID, tenantID string) error
 	GetRunForInternalService(ctx context.Context, runID uuid.UUID) (*models.TaxonomyRun, error)
 	GetRunForTenant(ctx context.Context, runID uuid.UUID, tenantID string) (*models.TaxonomyRun, error)
 	GetActiveRun(ctx context.Context, scope models.TaxonomyScope) (*models.TaxonomyRun, error)
@@ -372,6 +373,24 @@ func (s *TaxonomyService) FailRun(
 	}
 
 	return run, nil
+}
+
+// Heartbeat records that a taxonomy run is still alive, keeping it out of the stuck-run reaper's
+// reach. Resolving the run first yields its tenant and a not-found error for unknown ids.
+func (s *TaxonomyService) Heartbeat(
+	ctx context.Context,
+	runID uuid.UUID,
+) error {
+	existingRun, err := s.repo.GetRunForInternalService(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	if err := s.repo.Heartbeat(ctx, runID, existingRun.TenantID); err != nil {
+		return fmt.Errorf("heartbeat taxonomy run: %w", err)
+	}
+
+	return nil
 }
 
 func normalizeRunFailure(

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -22,6 +22,7 @@ type mockTaxonomyRepo struct {
 	markRunFailedMessage string
 	markRunFailedCode    models.TaxonomyRunFailureCode
 	markRunFailedTenant  string
+	heartbeatTenant      string
 
 	countNodeRecords       []models.TaxonomyNodeRecordCount
 	countNodeRecordsErr    error
@@ -81,6 +82,12 @@ func (m *mockTaxonomyRepo) MarkRunFailed(
 		Error:     &message,
 		ErrorCode: &errorCode,
 	}, nil
+}
+
+func (m *mockTaxonomyRepo) Heartbeat(_ context.Context, _ uuid.UUID, tenantID string) error {
+	m.heartbeatTenant = tenantID
+
+	return nil
 }
 
 func (m *mockTaxonomyRepo) GetRunForInternalService(_ context.Context, runID uuid.UUID) (*models.TaxonomyRun, error) {
@@ -269,6 +276,20 @@ func TestTaxonomyService_StartManualRunMarksServiceUnavailableFailure(t *testing
 
 	if repo.markRunFailedCode != models.TaxonomyRunFailureCodeServiceUnavailable {
 		t.Fatalf("MarkRunFailed code = %q, want service_unavailable", repo.markRunFailedCode)
+	}
+}
+
+func TestTaxonomyService_HeartbeatResolvesTenant(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-333333333333")
+	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{ID: runID, TenantID: "tenant-7"}}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	if err := svc.Heartbeat(context.Background(), runID); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+
+	if repo.heartbeatTenant != "tenant-7" {
+		t.Fatalf("Heartbeat tenant = %q, want tenant-7", repo.heartbeatTenant)
 	}
 }
 

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -126,9 +126,9 @@ func TestTaxonomyRepository_RunLifecycle(t *testing.T) {
 	})
 }
 
-// TestTaxonomyRepository_FailStuckRuns covers the reaper sweep: runs left in running (via started_at)
-// or pending (via created_at) past the timeout are transitioned to failed with the internal_error
-// code, while a run newer than the timeout is left untouched. The sweep is cross-tenant, so the test
+// TestTaxonomyRepository_FailStuckRuns covers the reaper sweep: pending/running runs whose updated_at
+// (the liveness signal) is older than the timeout are transitioned to failed with the internal_error
+// code, while a run with a recent updated_at is left untouched. The sweep is cross-tenant, so the test
 // asserts on the specific runs rather than an exact count.
 func TestTaxonomyRepository_FailStuckRuns(t *testing.T) {
 	ctx := context.Background()
@@ -143,21 +143,21 @@ func TestTaxonomyRepository_FailStuckRuns(t *testing.T) {
 		cleanupTaxonomyTenant(ctx, t, db, s.TenantID)
 	}
 
-	// A run orphaned in `running`: started_at is old, so COALESCE(started_at, created_at) is old.
+	// A run orphaned in `running` with a stale updated_at (no heartbeat for two hours).
 	stuck, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: stuckScope})
 	require.NoError(t, err)
 	_, err = repo.MarkRunRunning(ctx, stuck.ID, stuckScope.TenantID)
 	require.NoError(t, err)
-	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET started_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, stuck.ID)
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, stuck.ID)
 	require.NoError(t, err)
 
-	// A run orphaned in `pending`: started_at is NULL, so the reaper falls back to created_at.
+	// A run orphaned in `pending` with an equally stale updated_at.
 	pending, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: pendingScope})
 	require.NoError(t, err)
-	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET created_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, pending.ID)
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, pending.ID)
 	require.NoError(t, err)
 
-	// A fresh run that must survive the sweep.
+	// A fresh run (updated_at set to NOW by MarkRunRunning) that must survive the sweep.
 	fresh, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: freshScope})
 	require.NoError(t, err)
 	_, err = repo.MarkRunRunning(ctx, fresh.ID, freshScope.TenantID)
@@ -181,6 +181,58 @@ func TestTaxonomyRepository_FailStuckRuns(t *testing.T) {
 	assert.Equal(t, models.TaxonomyRunStatusRunning, survivor.Status, "a run newer than the timeout must not be reaped")
 }
 
+// TestTaxonomyRepository_Heartbeat covers the liveness heartbeat: bumping updated_at keeps an
+// otherwise-stale run out of the reaper's reach, and a heartbeat on a terminal run is a no-op that
+// neither errors nor resurrects it.
+func TestTaxonomyRepository_Heartbeat(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	t.Run("heartbeat keeps a stale running run from being reaped", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-heartbeat-alive")
+		cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+		run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: scope})
+		require.NoError(t, err)
+		_, err = repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+		require.NoError(t, err)
+
+		// Age it past the timeout, then heartbeat: updated_at returns to NOW.
+		_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, run.ID)
+		require.NoError(t, err)
+		require.NoError(t, repo.Heartbeat(ctx, run.ID, scope.TenantID))
+
+		_, err = repo.FailStuckRuns(ctx, time.Hour, "stuck run", models.TaxonomyRunFailureCodeInternalError)
+		require.NoError(t, err)
+
+		survivor, err := repo.GetRunForInternalService(ctx, run.ID)
+		require.NoError(t, err)
+		assert.Equal(t, models.TaxonomyRunStatusRunning, survivor.Status, "a heartbeated run must not be reaped")
+	})
+
+	t.Run("heartbeat on a terminal run is a no-op", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-heartbeat-terminal")
+		cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+		run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: scope})
+		require.NoError(t, err)
+		failed, err := repo.MarkRunFailed(
+			ctx, run.ID, scope.TenantID, "boom", models.TaxonomyRunFailureCodeInternalError,
+		)
+		require.NoError(t, err)
+
+		// A late heartbeat racing with completion must not error or reopen the run.
+		require.NoError(t, repo.Heartbeat(ctx, run.ID, scope.TenantID))
+
+		after, err := repo.GetRunForInternalService(ctx, run.ID)
+		require.NoError(t, err)
+		assert.Equal(t, models.TaxonomyRunStatusFailed, after.Status, "a terminal run must stay terminal")
+		require.NotNil(t, after.FinishedAt)
+		assert.WithinDuration(t, *failed.FinishedAt, *after.FinishedAt, time.Second, "finished_at must be unchanged")
+	})
+}
+
 // TestTaxonomyRepository_FailStuckRunsCoordinatesWithPurge is a purge-race regression test: the
 // reaper fails runs through the shared tenant write lock, so it must serialize with a concurrent
 // tenant-data purge (which takes the exclusive tenant lock) rather than deadlock on row locks, and
@@ -200,7 +252,7 @@ func TestTaxonomyRepository_FailStuckRunsCoordinatesWithPurge(t *testing.T) {
 	_, err = repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
 	require.NoError(t, err)
 
-	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET started_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, run.ID)
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, run.ID)
 	require.NoError(t, err)
 
 	var (

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -178,6 +179,57 @@ func TestTaxonomyRepository_FailStuckRuns(t *testing.T) {
 	survivor, err := repo.GetRunForInternalService(ctx, fresh.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.TaxonomyRunStatusRunning, survivor.Status, "a run newer than the timeout must not be reaped")
+}
+
+// TestTaxonomyRepository_FailStuckRunsCoordinatesWithPurge is a purge-race regression test: the
+// reaper fails runs through the shared tenant write lock, so it must serialize with a concurrent
+// tenant-data purge (which takes the exclusive tenant lock) rather than deadlock on row locks, and
+// the run must end up purged regardless of interleaving.
+func TestTaxonomyRepository_FailStuckRunsCoordinatesWithPurge(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+	tenantData := repository.NewTenantDataRepository(db, 5*time.Second)
+
+	scope := uniqueTaxonomyScope("tax-reap-purge-race")
+	cleanupTaxonomyTenant(ctx, t, db, scope.TenantID)
+
+	run, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: scope})
+	require.NoError(t, err)
+
+	_, err = repo.MarkRunRunning(ctx, run.ID, scope.TenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET started_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, run.ID)
+	require.NoError(t, err)
+
+	var (
+		waitGroup sync.WaitGroup
+		reapErr   error
+		purgeErr  error
+	)
+
+	waitGroup.Add(2)
+
+	go func() {
+		defer waitGroup.Done()
+
+		_, reapErr = repo.FailStuckRuns(ctx, time.Hour, "stuck run", models.TaxonomyRunFailureCodeInternalError)
+	}()
+
+	go func() {
+		defer waitGroup.Done()
+
+		_, purgeErr = tenantData.DeleteByTenant(ctx, scope.TenantID)
+	}()
+
+	waitGroup.Wait()
+
+	require.NoError(t, reapErr, "reaper must not error while a purge runs concurrently")
+	require.NoError(t, purgeErr, "purge must not error while the reaper runs concurrently")
+
+	_, err = repo.GetRunForInternalService(ctx, run.ID)
+	require.ErrorIs(t, err, huberrors.ErrNotFound, "the run must be purged regardless of interleaving")
 }
 
 // TestTaxonomyRepository_StoreResultAndActivate covers persisting the full artifact graph

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -125,6 +125,61 @@ func TestTaxonomyRepository_RunLifecycle(t *testing.T) {
 	})
 }
 
+// TestTaxonomyRepository_FailStuckRuns covers the reaper sweep: runs left in running (via started_at)
+// or pending (via created_at) past the timeout are transitioned to failed with the internal_error
+// code, while a run newer than the timeout is left untouched. The sweep is cross-tenant, so the test
+// asserts on the specific runs rather than an exact count.
+func TestTaxonomyRepository_FailStuckRuns(t *testing.T) {
+	ctx := context.Background()
+	db := taxonomyTestDB(t)
+	repo := repository.NewTaxonomyRepository(db)
+
+	stuckScope := uniqueTaxonomyScope("tax-reap-stuck")
+	pendingScope := uniqueTaxonomyScope("tax-reap-pending")
+	freshScope := uniqueTaxonomyScope("tax-reap-fresh")
+
+	for _, s := range []models.TaxonomyScope{stuckScope, pendingScope, freshScope} {
+		cleanupTaxonomyTenant(ctx, t, db, s.TenantID)
+	}
+
+	// A run orphaned in `running`: started_at is old, so COALESCE(started_at, created_at) is old.
+	stuck, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: stuckScope})
+	require.NoError(t, err)
+	_, err = repo.MarkRunRunning(ctx, stuck.ID, stuckScope.TenantID)
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET started_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, stuck.ID)
+	require.NoError(t, err)
+
+	// A run orphaned in `pending`: started_at is NULL, so the reaper falls back to created_at.
+	pending, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: pendingScope})
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `UPDATE taxonomy_runs SET created_at = NOW() - INTERVAL '2 hours' WHERE id = $1`, pending.ID)
+	require.NoError(t, err)
+
+	// A fresh run that must survive the sweep.
+	fresh, _, err := repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{TaxonomyScope: freshScope})
+	require.NoError(t, err)
+	_, err = repo.MarkRunRunning(ctx, fresh.ID, freshScope.TenantID)
+	require.NoError(t, err)
+
+	failed, err := repo.FailStuckRuns(ctx, time.Hour, "stuck run", models.TaxonomyRunFailureCodeInternalError)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, failed, int64(2), "both orphaned runs should be reaped")
+
+	for _, id := range []uuid.UUID{stuck.ID, pending.ID} {
+		reaped, err := repo.GetRunForInternalService(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, models.TaxonomyRunStatusFailed, reaped.Status)
+		require.NotNil(t, reaped.ErrorCode)
+		assert.Equal(t, models.TaxonomyRunFailureCodeInternalError, *reaped.ErrorCode)
+		assert.NotNil(t, reaped.FinishedAt)
+	}
+
+	survivor, err := repo.GetRunForInternalService(ctx, fresh.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.TaxonomyRunStatusRunning, survivor.Status, "a run newer than the timeout must not be reaped")
+}
+
 // TestTaxonomyRepository_StoreResultAndActivate covers persisting the full artifact graph
 // (clusters, memberships, nodes), activating the run, replacing a prior active run, and the
 // conflict when the run is not in the running state.


### PR DESCRIPTION
## What does this PR do?

A taxonomy run can be orphaned in `pending`/`running` if the taxonomy service crashes mid-run or its terminal callback (`POST /internal/v1/taxonomy/runs/{id}/failed` or the success PUT) is lost. The Hub never transitions the run, so Formbricks Web treats it as "in progress" — it disables Generate and polls `GET /runs/{id}` every 5s **forever**, recoverable only by a manual DB edit.

This adds a periodic Hub-side **reaper** that force-fails runs stalled past a timeout, so polling stops, the failure surfaces, and generation can be retried.

- **`TaxonomyRepository.FailStuckRuns(ctx, olderThan, message, code)`** — a single bulk `UPDATE` marking `pending`/`running` runs older than the cutoff (`COALESCE(started_at, created_at)`) as `failed`. Idempotent and race-safe: the `status IN ('pending','running')` filter skips runs that finished on their own between sweeps.
- **`runTaxonomyRunReaper`** — a ticker poller mirroring the existing `runRiverQueueDepthPoller`, launched in the API process only when the taxonomy service is configured. Cross-tenant, idempotent, safe under multiple replicas.
- **Config** — `TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS` (default 1800) and `TAXONOMY_REAPER_INTERVAL_SECONDS` (default 60), via the existing `DurationSec` pattern.

**Decisions flagged for review:**
- Reaped runs are failed with `error_code = internal_error` and the raw message *"taxonomy run timed out without completing"* (operator-facing; Formbricks Web maps the code to a localized message — ENG-1917). Alternative: `service_unavailable` (retry-friendlier). Easy to flip.
- ⚠️ The default timeout (30 min) **must exceed the longest legitimate run duration**, or healthy long-running generations get reaped. Tune to the real max + margin.

No schema/migration changes (uses existing columns). No API changes.

Closes ENG-1924 · Follow-up to ENG-1213 · pairs with the Web-side wedge fix ENG-1917.

## How should this be tested?

- **Automated:** `TestTaxonomyRepository_FailStuckRuns` (in `tests/`) creates a stuck `running` run (aged `started_at`), a stuck `pending` run (aged `created_at`), and a fresh run, then asserts the reaper fails the two stuck ones and leaves the fresh one. Runs via `make tests` (needs `test_db`) — executed in CI.
- **Manual (end-to-end):** with the taxonomy service configured, start a run and stop the taxonomy service mid-run so it's orphaned in `running`; within `TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS + TAXONOMY_REAPER_INTERVAL_SECONDS` the reaper marks it `failed`, the UI stops polling, and Generate re-enables.
- Verified locally: `go build ./...`, `make fmt`, `make lint` (0 issues), `go vet ./tests/`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` — _N/A, no schema change_

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow) — _N/A, no API change_
- [ ] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR — _N/A_
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
