### PR TITLE
fix: stop the Hub API from requiring enrichment credentials, and honor LOG_LEVEL in hub-worker (ENG-1916)

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -28,7 +28,6 @@ import (
 	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/internal/repository"
 	"github.com/formbricks/hub/internal/service"
-	"github.com/formbricks/hub/internal/workers"
 )
 
 // App holds all server dependencies and coordinates startup and shutdown.
@@ -89,19 +88,18 @@ func embeddingProviderAndModel(cfg *config.Config) (provider, model string) {
 
 const searchQueryCacheSize = 1000
 
-// setupEmbeddingSearchHandler creates embedding client, worker, and search handler when embeddings are enabled.
+// setupEmbeddingSearchHandler creates the embedding client and search handler when embeddings are
+// enabled. The client is used synchronously on the search path (it embeds the incoming query), which
+// is why the API needs embedding credentials even though it works no embedding jobs.
 // Returns (handler, nil) or (nil, err). Caller should use errors.Is for service.ErrEmbeddingProviderAPIKey and
 // service.ErrEmbeddingGoogleGeminiConfig to return app-level sentinel errors.
 func setupEmbeddingSearchHandler(
 	ctx context.Context,
 	cfg *config.Config,
-	embeddingProviderName, embeddingModel, embeddingDocPrefix string,
-	feedbackRecordsService *service.FeedbackRecordsService,
+	embeddingProviderName, embeddingModel string,
 	embeddingsRepo *repository.EmbeddingsRepository,
-	embeddingMetrics observability.EmbeddingMetrics,
 	metrics *observability.Metrics,
 	meterProvider *sdkmetric.MeterProvider,
-	riverWorkers *river.Workers,
 ) (*handlers.SearchHandler, error) {
 	embeddingCfg := service.EmbeddingClientConfig{
 		Provider:            embeddingProviderName,
@@ -120,10 +118,6 @@ func setupEmbeddingSearchHandler(
 	if err != nil {
 		return nil, fmt.Errorf("create embedding client: %w", err)
 	}
-
-	embeddingWorker := workers.NewFeedbackEmbeddingWorker(
-		feedbackRecordsService, embeddingClient, embeddingDocPrefix, embeddingMetrics)
-	river.AddWorker(riverWorkers, embeddingWorker)
 
 	queryCache, err := lru.New[string, []float32](searchQueryCacheSize)
 	if err != nil {
@@ -251,15 +245,6 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	messageManager := service.NewMessagePublisherManager(cfg.MessagePublisher.BufferSize, perEventTimeout, eventMetrics)
 
 	webhooksRepo := repository.NewWebhooksRepository(db)
-	webhookSender := service.NewWebhookSenderImpl(
-		webhooksRepo, webhookMetrics, cfg.Webhook.URLBlacklist, cfg.Webhook.HTTPTimeout.Duration(), nil)
-
-	deps := workers.RiverDeps{
-		WebhooksRepo:       webhooksRepo,
-		WebhookSender:      webhookSender,
-		WebhookHTTPTimeout: cfg.Webhook.HTTPTimeout.Duration(),
-		WebhookMetrics:     webhookMetrics,
-	}
 
 	feedbackRecordsRepo := repository.NewFeedbackRecordsRepository(db)
 	embeddingsRepo := repository.NewEmbeddingsRepository(db)
@@ -297,21 +282,15 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	tenantSettingsRepo := repository.NewTenantSettingsRepository(db)
 	tenantSettingsService := service.NewTenantSettingsService(tenantSettingsRepo)
 
-	// Shared worker/queue registration first (webhook + optional embedding added below).
-	riverWorkers, queues := workers.NewRiverWorkersAndQueues(cfg, deps, 1)
-
 	var searchHandler *handlers.SearchHandler
 
 	if embeddingProviderName != "" {
-		embeddingDocPrefix := service.EmbeddingPrefixForProvider(embeddingProviderName)
-
 		var err error
 
 		searchHandler, err = setupEmbeddingSearchHandler(
 			context.Background(), cfg,
-			embeddingProviderName, embeddingModel, embeddingDocPrefix,
-			feedbackRecordsService, embeddingsRepo, embeddingMetrics,
-			metrics, meterProvider, riverWorkers)
+			embeddingProviderName, embeddingModel, embeddingsRepo,
+			metrics, meterProvider)
 		if err != nil {
 			cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
 
@@ -325,100 +304,20 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 
 			return nil, fmt.Errorf("embedding config: %w", err)
 		}
-
-		queues[service.EmbeddingsQueueName] = river.QueueConfig{MaxWorkers: 1}
 	} else {
 		searchHandler = handlers.NewSearchHandler(nil) // 503 when embeddings disabled
 	}
 
-	// Register the translation worker and declare its queue so the River client can
-	// enqueue translation jobs (River requires the job kind registered and the queue
-	// declared at insert time); the jobs are processed by hub-worker, not in this
-	// process. Gated on TRANSLATION_PROVIDER+MODEL like embeddings; the enqueue
-	// provider is registered below, after the River client and tenant settings exist.
-	if cfg.Translation.Provider != "" && cfg.Translation.Model != "" {
-		translationCfg := service.TranslationClientConfig{
-			Provider:            cfg.Translation.Provider,
-			ProviderAPIKey:      cfg.Translation.ProviderAPIKey,
-			Model:               cfg.Translation.Model,
-			BaseURL:             cfg.Translation.BaseURL,
-			GoogleCloudProject:  cfg.Translation.GoogleCloudProject,
-			GoogleCloudLocation: cfg.Translation.GoogleCloudLocation,
-		}
-
-		translationClient, translationErr := service.NewTranslationClient(context.Background(), translationCfg)
-		if translationErr != nil {
-			cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
-
-			return nil, fmt.Errorf("translation config: %w", translationErr)
-		}
-
-		river.AddWorker(riverWorkers, workers.NewFeedbackTranslationWorker(feedbackRecordsService, translationClient, translationMetrics))
-
-		queues[service.TranslationsQueueName] = river.QueueConfig{MaxWorkers: 1}
-
-		// Per-tenant re-translation backfill, enqueued by the settings-change listener
-		// below. Registered here only so the River client can validate the kind and queue
-		// at insert time; the fan-out is processed by hub-worker.
-		river.AddWorker(riverWorkers, workers.NewTenantTranslationBackfillWorker(feedbackRecordsService, cfg.Translation.MaxAttempts))
-
-		queues[service.TranslationBackfillsQueueName] = river.QueueConfig{MaxWorkers: 1}
-	}
-
-	// Register the sentiment worker and declare its queue so the River client can enqueue
-	// sentiment jobs (kind + queue must be known at insert time); the jobs are processed by
-	// hub-worker, not in this process. Gated on SENTIMENT_PROVIDER+MODEL; the enqueue provider
-	// is registered below, after the River client exists.
-	if cfg.Sentiment.Enabled() {
-		sentimentClient, sentimentErr := service.NewSentimentClient(context.Background(), service.SentimentClientConfig{
-			Provider:            cfg.Sentiment.Provider,
-			ProviderAPIKey:      cfg.Sentiment.ProviderAPIKey,
-			Model:               cfg.Sentiment.Model,
-			BaseURL:             cfg.Sentiment.BaseURL,
-			GoogleCloudProject:  cfg.Sentiment.GoogleCloudProject,
-			GoogleCloudLocation: cfg.Sentiment.GoogleCloudLocation,
-		})
-		if sentimentErr != nil {
-			cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
-
-			return nil, fmt.Errorf("sentiment config: %w", sentimentErr)
-		}
-
-		river.AddWorker(riverWorkers, workers.NewFeedbackSentimentWorker(
-			feedbackRecordsService, tenantSettingsService, sentimentClient, sentimentMetrics))
-
-		queues[service.SentimentsQueueName] = river.QueueConfig{MaxWorkers: 1}
-	}
-
-	// Register the emotions worker and declare its queue so the River client can enqueue emotion
-	// jobs (kind + queue must be known at insert time); the jobs are processed by hub-worker, not
-	// in this process. Gated on EMOTIONS_PROVIDER+MODEL; the enqueue provider is registered below,
-	// after the River client exists.
-	if cfg.Emotions.Enabled() {
-		emotionsClient, emotionsErr := service.NewEmotionsClient(context.Background(), service.EmotionsClientConfig{
-			Provider:            cfg.Emotions.Provider,
-			ProviderAPIKey:      cfg.Emotions.ProviderAPIKey,
-			Model:               cfg.Emotions.Model,
-			BaseURL:             cfg.Emotions.BaseURL,
-			GoogleCloudProject:  cfg.Emotions.GoogleCloudProject,
-			GoogleCloudLocation: cfg.Emotions.GoogleCloudLocation,
-		})
-		if emotionsErr != nil {
-			cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
-
-			return nil, fmt.Errorf("emotions config: %w", emotionsErr)
-		}
-
-		river.AddWorker(riverWorkers, workers.NewFeedbackEmotionsWorker(
-			feedbackRecordsService, tenantSettingsService, emotionsClient, emotionsMetrics))
-
-		queues[service.EmotionsQueueName] = river.QueueConfig{MaxWorkers: 1}
-	}
-
-	riverClient, err := river.NewClient(riverpgxv5.New(db), &river.Config{
-		Queues:  queues,
-		Workers: riverWorkers,
-	})
+	// Insert-only River client: this process enqueues jobs but works none of them, so it registers
+	// no workers and declares no queues (River requires Workers and Queues to be set together, and
+	// checks that a kind has a registered worker only when Workers is non-nil). hub-worker owns
+	// registration — see workers.NewRiverWorkersAndQueues, and the parity test that keeps the kinds
+	// this process inserts in step with the ones hub-worker registers.
+	//
+	// This is what keeps the API independent of enrichment credentials: sentiment, emotions, and
+	// translation clients are only ever needed by the process that runs their workers, so a missing
+	// or unreadable credential takes down hub-worker (loudly, on purpose) instead of the whole API.
+	riverClient, err := river.NewClient(riverpgxv5.New(db), &river.Config{})
 	if err != nil {
 		cleanupNewAppStartupFailure(context.Background(), messageManager, nil, tracerProvider, meterProvider)
 

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -757,16 +757,10 @@ func (a *App) Run(ctx context.Context) error {
 }
 
 // riverDepthQueues is the fixed queue set the depth poller reports — every queue the Hub
-// declares. The list bounds the gauge's queue-label cardinality; a queue with no backlog is
-// reported as 0 so dashboards see the series exist.
-var riverDepthQueues = []string{
-	river.QueueDefault,
-	service.EmbeddingsQueueName,
-	service.TranslationsQueueName,
-	service.TranslationBackfillsQueueName,
-	service.SentimentsQueueName,
-	service.EmotionsQueueName,
-}
+// declares, derived from service.JobKindSpecs so a new job kind cannot be added without its
+// queue appearing on the gauge. The list bounds the gauge's queue-label cardinality; a queue with
+// no backlog is reported as 0 so dashboards see the series exist.
+var riverDepthQueues = service.JobQueueNames()
 
 // enrichmentBacklogPollConfig configures runEnrichmentBacklogPoller: the deployment default target
 // language and which enrichments are deployment-configured (only those emit a gauge).

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
@@ -102,6 +103,30 @@ func TestSetupMetricsDisabledWithNilConfig(t *testing.T) {
 	}
 }
 
+// NewApp builds its River client insert-only — no Workers, no Queues — so the API never needs the
+// enrichment credentials that only hub-worker's workers use (ENG-1916). River rejects a config that
+// sets Queues without Workers, so omitting both is the only legal way to express insert-only; this
+// asserts that config stays valid, which is what lets NewApp boot without a worker bundle.
+//
+// That the resulting client may insert kinds it registers no worker for needs a database, so it is
+// covered by the integration suite rather than here.
+func TestRiverClientIsInsertOnly(t *testing.T) {
+	if _, err := river.NewClient(riverpgxv5.New(nil), &river.Config{}); err != nil {
+		t.Fatalf("river.NewClient(insert-only config) error = %v, want nil", err)
+	}
+
+	// The constraint that forces the shape above: declaring queues obliges us to supply a worker
+	// bundle, which is what used to drag the enrichment clients (and their credentials) into this
+	// process. If a River upgrade ever drops this rule, revisit whether the API can declare queues
+	// again for insert-time validation without taking on the credentials.
+	_, err := river.NewClient(riverpgxv5.New(nil), &river.Config{
+		Queues: map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
+	})
+	if err == nil {
+		t.Fatal("river.NewClient(queues without workers) error = nil, want a validation error")
+	}
+}
+
 func TestSetupEmbeddingSearchHandler(t *testing.T) {
 	cfg := &config.Config{
 		Embedding: config.EmbeddingConfig{
@@ -114,13 +139,9 @@ func TestSetupEmbeddingSearchHandler(t *testing.T) {
 		cfg,
 		service.EmbeddingProviderOpenAI,
 		"text-embedding-3-small",
-		"",
 		nil,
 		nil,
 		nil,
-		nil,
-		nil,
-		river.NewWorkers(),
 	)
 	if err != nil {
 		t.Fatalf("setupEmbeddingSearchHandler() error = %v, want nil", err)
@@ -137,13 +158,9 @@ func TestSetupEmbeddingSearchHandlerValidatesConfig(t *testing.T) {
 		&config.Config{},
 		service.EmbeddingProviderOpenAI,
 		"text-embedding-3-small",
-		"",
 		nil,
 		nil,
 		nil,
-		nil,
-		nil,
-		river.NewWorkers(),
 	)
 	if !errors.Is(err, service.ErrEmbeddingProviderAPIKey) {
 		t.Fatalf("setupEmbeddingSearchHandler() error = %v, want %v", err, service.ErrEmbeddingProviderAPIKey)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -6,12 +6,12 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/pkg/database"
 )
 
@@ -27,20 +27,20 @@ func main() {
 func run() int {
 	cfg, err := config.Load()
 	if err != nil {
-		setupLogging("info")
+		observability.SetupLogging("info")
 		slog.Error("Failed to load configuration", "error", err)
 
 		return exitFailure
 	}
 
 	if cfg.Server.HubAPIKey == "" {
-		setupLogging(cfg.Server.LogLevel)
+		observability.SetupLogging(cfg.Server.LogLevel)
 		slog.Error("API_KEY is required for hub-api")
 
 		return exitFailure
 	}
 
-	setupLogging(cfg.Server.LogLevel)
+	observability.SetupLogging(cfg.Server.LogLevel)
 
 	ctx := context.Background()
 
@@ -90,25 +90,4 @@ func run() int {
 	slog.Info("Server stopped")
 
 	return exitSuccess
-}
-
-func setupLogging(level string) {
-	var logLevel slog.Level
-
-	switch strings.ToLower(level) {
-	case "debug":
-		logLevel = slog.LevelDebug
-	case "info":
-		logLevel = slog.LevelInfo
-	case "warn":
-		logLevel = slog.LevelWarn
-	case "error":
-		logLevel = slog.LevelError
-	default:
-		logLevel = slog.LevelInfo
-	}
-
-	opts := &slog.HandlerOptions{Level: logLevel}
-	handler := slog.NewTextHandler(os.Stdout, opts)
-	slog.SetDefault(slog.New(handler))
 }

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -253,7 +253,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		deps.EmotionsMetrics = emotionsMetrics
 	}
 
-	riverWorkers, queues := workers.NewRiverWorkersAndQueues(cfg, deps, 0)
+	riverWorkers, queues := workers.NewRiverWorkersAndQueues(cfg, deps)
 
 	riverCfg := &river.Config{
 		Queues:  queues,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -12,6 +12,7 @@ import (
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/pkg/database"
 )
 
@@ -27,10 +28,14 @@ func main() {
 func run() int {
 	cfg, err := config.Load()
 	if err != nil {
+		// Configure logging before reporting the failure, so a broken config still produces output.
+		observability.SetupLogging("info")
 		slog.Error("Failed to load configuration", "error", err)
 
 		return exitFailure
 	}
+
+	observability.SetupLogging(cfg.Server.LogLevel)
 
 	if cfg.Database.URL == "" || cfg.Database.URL == config.DefaultDatabaseURL {
 		slog.Error("DATABASE_URL must be set explicitly for hub-worker (do not use the default test URL)")

--- a/internal/observability/logging.go
+++ b/internal/observability/logging.go
@@ -4,9 +4,37 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ParseLogLevel maps a LOG_LEVEL value to a slog.Level, falling back to info for anything
+// unrecognized (including the empty string) so a typo degrades to the default rather than silencing
+// logs.
+func ParseLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// SetupLogging installs the default slog handler at the given level. Both binaries call it during
+// startup: hub-api and hub-worker have to agree on log format and honor the same LOG_LEVEL, or a
+// failure that only reproduces in one of them is harder to read than it needs to be.
+func SetupLogging(level string) {
+	opts := &slog.HandlerOptions{Level: ParseLogLevel(level)}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+}
 
 // requestIDKey is the context key for the request ID (X-Request-ID).
 // Middleware sets it; the TraceContextHandler adds it to log records.

--- a/internal/observability/logging_test.go
+++ b/internal/observability/logging_test.go
@@ -1,0 +1,33 @@
+package observability
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// ParseLogLevel backs LOG_LEVEL for both hub-api and hub-worker, so an unrecognized value must
+// degrade to info rather than silencing logs — a config typo that hid worker output would defeat the
+// point of honoring the level at all.
+func TestParseLogLevel(t *testing.T) {
+	tests := map[string]slog.Level{
+		"debug":     slog.LevelDebug,
+		"info":      slog.LevelInfo,
+		"warn":      slog.LevelWarn,
+		"error":     slog.LevelError,
+		"DEBUG":     slog.LevelDebug,
+		"Warn":      slog.LevelWarn,
+		"":          slog.LevelInfo,
+		"trace":     slog.LevelInfo,
+		"verbose":   slog.LevelInfo,
+		"warning":   slog.LevelInfo,
+		"not-level": slog.LevelInfo,
+	}
+
+	for level, want := range tests {
+		t.Run(level, func(t *testing.T) {
+			if got := ParseLogLevel(level); got != want {
+				t.Fatalf("ParseLogLevel(%q) = %v, want %v", level, got, want)
+			}
+		})
+	}
+}

--- a/internal/service/job_kinds.go
+++ b/internal/service/job_kinds.go
@@ -1,0 +1,56 @@
+package service
+
+import "github.com/riverqueue/river"
+
+// JobKindSpec pairs a River job kind with the queue its inserts land on.
+type JobKindSpec struct {
+	// Args is a zero value of the job's argument type; Args.Kind() is the River job kind.
+	Args river.JobArgs
+	// Queue is the River queue the kind is inserted on.
+	Queue string
+}
+
+// Kind returns the River job kind this spec describes.
+func (s JobKindSpec) Kind() string { return s.Args.Kind() }
+
+// JobKindSpecs enumerates the Hub's River job kinds and the queues they are inserted on. It is the
+// declaration the API's queue-depth poller derives from, and the reference the parity test in
+// internal/workers checks hub-worker's registration against.
+//
+// hub-worker's registration (workers.NewRiverWorkersAndQueues) deliberately still names its queues
+// itself, because it attaches a per-enrichment MaxWorkers that this list has no notion of. So the
+// two are kept consistent by assertion, not by derivation — the parity test is what fails when they
+// drift, and it is the reason adding a kind here is safe.
+//
+// The API inserts every kind below but works none of them: its River client is insert-only, so
+// hub-worker owns registration. Adding a kind here without registering a worker for it strands its
+// jobs, which is exactly what that test catches.
+func JobKindSpecs() []JobKindSpec {
+	return []JobKindSpec{
+		{Args: WebhookDispatchArgs{}, Queue: river.QueueDefault},
+		{Args: FeedbackEmbeddingArgs{}, Queue: EmbeddingsQueueName},
+		{Args: FeedbackTranslationArgs{}, Queue: TranslationsQueueName},
+		{Args: TenantTranslationBackfillArgs{}, Queue: TranslationBackfillsQueueName},
+		{Args: FeedbackSentimentArgs{}, Queue: SentimentsQueueName},
+		{Args: FeedbackEmotionsArgs{}, Queue: EmotionsQueueName},
+	}
+}
+
+// JobQueueNames returns the distinct River queue names from JobKindSpecs, in declaration order.
+// Several kinds may share a queue, so callers that need queues rather than kinds use this.
+func JobQueueNames() []string {
+	specs := JobKindSpecs()
+	seen := make(map[string]struct{}, len(specs))
+	queues := make([]string, 0, len(specs))
+
+	for _, spec := range specs {
+		if _, ok := seen[spec.Queue]; ok {
+			continue
+		}
+
+		seen[spec.Queue] = struct{}{}
+		queues = append(queues, spec.Queue)
+	}
+
+	return queues
+}

--- a/internal/service/job_kinds.go
+++ b/internal/service/job_kinds.go
@@ -39,7 +39,13 @@ func JobKindSpecs() []JobKindSpec {
 // JobQueueNames returns the distinct River queue names from JobKindSpecs, in declaration order.
 // Several kinds may share a queue, so callers that need queues rather than kinds use this.
 func JobQueueNames() []string {
-	specs := JobKindSpecs()
+	return distinctQueues(JobKindSpecs())
+}
+
+// distinctQueues collapses specs to their queue names, preserving declaration order and dropping
+// repeats. Taking the specs as a parameter keeps the dedup reachable from a test: every kind
+// declared today owns its own queue, so the duplicate path would otherwise never run.
+func distinctQueues(specs []JobKindSpec) []string {
 	seen := make(map[string]struct{}, len(specs))
 	queues := make([]string, 0, len(specs))
 

--- a/internal/service/job_kinds_test.go
+++ b/internal/service/job_kinds_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+)
+
+// JobKindSpecs is what the API's queue-depth gauge and the worker-registration parity test both read,
+// so the pairing of every kind to its queue is pinned here rather than left implicit.
+func TestJobKindSpecs(t *testing.T) {
+	want := map[string]string{
+		"webhook_dispatch":            river.QueueDefault,
+		"feedback_embedding":          EmbeddingsQueueName,
+		"feedback_translation":        TranslationsQueueName,
+		"tenant_translation_backfill": TranslationBackfillsQueueName,
+		"feedback_sentiment":          SentimentsQueueName,
+		"feedback_emotions":           EmotionsQueueName,
+	}
+
+	specs := JobKindSpecs()
+	require.Len(t, specs, len(want), "a new job kind needs a worker registered for it in internal/workers")
+
+	for _, spec := range specs {
+		wantQueue, ok := want[spec.Kind()]
+		require.True(t, ok, "unexpected job kind %q", spec.Kind())
+		require.Equal(t, wantQueue, spec.Queue, "kind %q is on the wrong queue", spec.Kind())
+	}
+}
+
+func TestJobQueueNames(t *testing.T) {
+	require.Equal(t, []string{
+		river.QueueDefault,
+		EmbeddingsQueueName,
+		TranslationsQueueName,
+		TranslationBackfillsQueueName,
+		SentimentsQueueName,
+		EmotionsQueueName,
+	}, JobQueueNames())
+}
+
+// The dedup only matters for a future kind that shares an existing queue, which no declared kind
+// does — so it is exercised directly rather than through JobKindSpecs.
+func TestDistinctQueues(t *testing.T) {
+	tests := map[string]struct {
+		specs []JobKindSpec
+		want  []string
+	}{
+		"collapses repeats and keeps first-seen order": {
+			specs: []JobKindSpec{
+				{Args: FeedbackSentimentArgs{}, Queue: "enrichments"},
+				{Args: FeedbackEmotionsArgs{}, Queue: "enrichments"},
+				{Args: WebhookDispatchArgs{}, Queue: river.QueueDefault},
+				{Args: FeedbackTranslationArgs{}, Queue: "enrichments"},
+			},
+			want: []string{"enrichments", river.QueueDefault},
+		},
+		"passes distinct queues through unchanged": {
+			specs: []JobKindSpec{
+				{Args: WebhookDispatchArgs{}, Queue: river.QueueDefault},
+				{Args: FeedbackSentimentArgs{}, Queue: SentimentsQueueName},
+			},
+			want: []string{river.QueueDefault, SentimentsQueueName},
+		},
+		"handles no specs": {
+			specs: nil,
+			want:  []string{},
+		},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, testCase.want, distinctQueues(testCase.specs))
+		})
+	}
+}

--- a/internal/workers/wiring.go
+++ b/internal/workers/wiring.go
@@ -11,7 +11,8 @@ import (
 )
 
 // RiverDeps holds dependencies required to build River workers and queue config.
-// When EmbeddingClient is nil, only webhook workers are registered.
+// Each optional group is gated on its client: leave a client nil and neither its worker nor its
+// queue is registered.
 type RiverDeps struct {
 	// Webhook worker
 	WebhooksRepo       webhookDispatchRepo
@@ -46,11 +47,15 @@ type RiverDeps struct {
 	EmotionsMetrics  observability.EmotionsMetrics
 }
 
-// NewRiverWorkersAndQueues builds River workers and queue config from cfg and deps.
-// When deps.EmbeddingClient is nil, only webhook workers are registered and the embeddings queue is not added.
-// When placeholderMaxWorkers > 0 (e.g. 1 for insert-only API), all queue MaxWorkers use it; otherwise use cfg.
+// NewRiverWorkersAndQueues builds River workers and queue config from cfg and deps. Each optional
+// worker is registered only when its client is set, and its queue is declared alongside it, so a
+// disabled enrichment leaves no queue for jobs to pile up on unworked.
+//
+// Only hub-worker calls this: the API inserts jobs through an insert-only River client and registers
+// nothing (see cmd/api/app.go), so the queue MaxWorkers below are always the real configured
+// concurrency.
 func NewRiverWorkersAndQueues(
-	cfg *config.Config, deps RiverDeps, placeholderMaxWorkers int,
+	cfg *config.Config, deps RiverDeps,
 ) (*river.Workers, map[string]river.QueueConfig) {
 	workers := river.NewWorkers()
 
@@ -62,14 +67,6 @@ func NewRiverWorkersAndQueues(
 	maxTranslation := cfg.Translation.MaxConcurrent
 	maxSentiment := cfg.Sentiment.MaxConcurrent
 	maxEmotions := cfg.Emotions.MaxConcurrent
-
-	if placeholderMaxWorkers > 0 {
-		maxDefault = placeholderMaxWorkers
-		maxEmbedding = placeholderMaxWorkers
-		maxTranslation = placeholderMaxWorkers
-		maxSentiment = placeholderMaxWorkers
-		maxEmotions = placeholderMaxWorkers
-	}
 
 	queues := map[string]river.QueueConfig{
 		river.QueueDefault: {MaxWorkers: maxDefault},

--- a/internal/workers/wiring_test.go
+++ b/internal/workers/wiring_test.go
@@ -1,0 +1,166 @@
+package workers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/riverqueue/river"
+
+	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/service"
+)
+
+// The API inserts every kind in service.JobKindSpecs but registers no workers — its River client is
+// insert-only (ENG-1916), so River's insert-time unknown-kind check no longer catches a kind that
+// nothing registers. These tests are what replaced it: a kind added to JobKindSpecs, or an insert
+// path added to the API, without a matching worker here would otherwise strand jobs silently.
+
+// stubTranslationBackfillService satisfies tenantTranslationBackfillService. The tests only register
+// workers, never run them, so the method is never called.
+type stubTranslationBackfillService struct{}
+
+func (stubTranslationBackfillService) BackfillTranslationsForTenant(
+	_ context.Context, _ service.RiverJobInserter, _ string, _ int, _, _ string,
+) (int, error) {
+	return 0, nil
+}
+
+// kindProbe re-registers a job kind to observe whether it is already registered.
+// river.AddWorkerSafely errors only on a duplicate kind, and *river.Workers exposes no way to
+// enumerate its kinds (workersMap is unexported with no accessor), so this is the only way to assert
+// registration without a database.
+type kindProbe[T river.JobArgs] struct {
+	river.WorkerDefaults[T]
+}
+
+func (kindProbe[T]) Work(context.Context, *river.Job[T]) error { return nil }
+
+// assertKindRegistered fails unless kind T's registration in workers matches want. It consumes the
+// bundle (a probe for an unregistered kind gets added), so pass a bundle you are done asserting on.
+func assertKindRegistered[T river.JobArgs](t *testing.T, workers *river.Workers, want bool) {
+	t.Helper()
+
+	var args T
+
+	registered := river.AddWorkerSafely(workers, kindProbe[T]{}) != nil
+	if registered != want {
+		t.Fatalf("kind %q registered = %v, want %v", args.Kind(), registered, want)
+	}
+}
+
+// fullRiverDeps populates every optional client so NewRiverWorkersAndQueues registers all workers.
+// The gate is only that each client is non-nil; the enrichment worker constructors take method
+// values off their service dependency, so those must be non-nil too.
+func fullRiverDeps() RiverDeps {
+	return RiverDeps{
+		WebhooksRepo:   &mockDispatchRepo{},
+		WebhookSender:  &mockSender{},
+		WebhookMetrics: newCountingWebhookMetrics(),
+
+		EmbeddingService: &mockEmbeddingService{},
+		EmbeddingClient:  &mockEmbeddingClient{},
+		EmbeddingMetrics: &countingEmbeddingMetrics{},
+
+		TranslationService:         &mockTranslationWorkerService{},
+		TranslationClient:          &stubTranslationClient{},
+		TranslationMetrics:         newCountingTranslationMetrics(),
+		TranslationBackfillService: stubTranslationBackfillService{},
+
+		SentimentService:  &mockSentimentWorkerService{},
+		SentimentResolver: stubSentimentSettings{},
+		SentimentClient:   &stubSentimentClient{},
+		SentimentMetrics:  &countingSentimentMetrics{},
+
+		EmotionsService:  &mockEmotionsWorkerService{},
+		EmotionsResolver: stubEmotionsSettings{},
+		EmotionsClient:   &stubEmotionsClient{},
+		EmotionsMetrics:  &countingEmotionsMetrics{},
+	}
+}
+
+// TestNewRiverWorkersAndQueuesCoversEveryJobKind locks hub-worker's registration against
+// service.JobKindSpecs: every kind the API can insert must have a worker and a declared queue here.
+func TestNewRiverWorkersAndQueuesCoversEveryJobKind(t *testing.T) {
+	cfg := &config.Config{}
+
+	workerBundle, queues := NewRiverWorkersAndQueues(cfg, fullRiverDeps())
+
+	for _, spec := range service.JobKindSpecs() {
+		if _, ok := queues[spec.Queue]; !ok {
+			t.Fatalf("queue %q for kind %q missing from queue config, want declared", spec.Queue, spec.Kind())
+		}
+	}
+
+	// One probe per kind: AddWorkerSafely is generic over the concrete args type, so these cannot be
+	// looped over the JobKindSpecs slice. The count assertion below is what keeps this list honest.
+	assertKindRegistered[service.WebhookDispatchArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackEmbeddingArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackTranslationArgs](t, workerBundle, true)
+	assertKindRegistered[service.TenantTranslationBackfillArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackSentimentArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackEmotionsArgs](t, workerBundle, true)
+
+	const probedKinds = 6
+	if got := len(service.JobKindSpecs()); got != probedKinds {
+		t.Fatalf("JobKindSpecs has %d kinds but %d are probed above — add a probe for the new kind "+
+			"and register a worker for it in NewRiverWorkersAndQueues", got, probedKinds)
+	}
+}
+
+// TestNewRiverWorkersAndQueuesWithoutOptionalClients pins the disabled-enrichment shape: webhook
+// dispatch always runs, and a nil client must leave both its worker and its queue out rather than
+// registering a worker that would fail on every job.
+func TestNewRiverWorkersAndQueuesWithoutOptionalClients(t *testing.T) {
+	cfg := &config.Config{}
+	deps := RiverDeps{
+		WebhooksRepo:   &mockDispatchRepo{},
+		WebhookSender:  &mockSender{},
+		WebhookMetrics: newCountingWebhookMetrics(),
+	}
+
+	workerBundle, queues := NewRiverWorkersAndQueues(cfg, deps)
+
+	if len(queues) != 1 {
+		t.Fatalf("queues = %v, want only %q", queues, river.QueueDefault)
+	}
+
+	if _, ok := queues[river.QueueDefault]; !ok {
+		t.Fatalf("queues = %v, want %q declared", queues, river.QueueDefault)
+	}
+
+	assertKindRegistered[service.WebhookDispatchArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackEmbeddingArgs](t, workerBundle, false)
+	assertKindRegistered[service.FeedbackTranslationArgs](t, workerBundle, false)
+	assertKindRegistered[service.TenantTranslationBackfillArgs](t, workerBundle, false)
+	assertKindRegistered[service.FeedbackSentimentArgs](t, workerBundle, false)
+	assertKindRegistered[service.FeedbackEmotionsArgs](t, workerBundle, false)
+}
+
+// TestNewRiverWorkersAndQueuesUsesConfiguredConcurrency pins each queue to its own configured
+// concurrency. hub-worker is the only caller, so a queue silently picking up another enrichment's
+// limit — or a zero, which would stall it entirely — would otherwise go unnoticed.
+func TestNewRiverWorkersAndQueuesUsesConfiguredConcurrency(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Webhook.DeliveryMaxConcurrent = 2
+	cfg.Embedding.MaxConcurrent = 3
+	cfg.Translation.MaxConcurrent = 4
+	cfg.Sentiment.MaxConcurrent = 5
+	cfg.Emotions.MaxConcurrent = 6
+
+	_, queues := NewRiverWorkersAndQueues(cfg, fullRiverDeps())
+
+	want := map[string]int{
+		river.QueueDefault:                    2,
+		service.EmbeddingsQueueName:           3,
+		service.TranslationsQueueName:         4,
+		service.TranslationBackfillsQueueName: 4,
+		service.SentimentsQueueName:           5,
+		service.EmotionsQueueName:             6,
+	}
+
+	for name, wantMax := range want {
+		if got := queues[name].MaxWorkers; got != wantMax {
+			t.Fatalf("queue %q MaxWorkers = %d, want %d", name, got, wantMax)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Local Hub crashes on boot when the sentiment/emotion providers are configured but the Google credentials file isn't reachable inside the container — the API exits 1 with `sentiment config: ... failed to find default credentials`, nothing listens on `:8080`, and every web-side Hub call fails with a generic `fetch failed`.

Linear: https://linear.app/formbricks/issue/ENG-1916/dev-hub-crashes-on-boot-when-gemini-enrichment-creds-arent-mounted

The root cause turned out to be a bit more interesting than a dev-env problem. The API was building sentiment, emotions, and translation LLM clients at startup and passing each to exactly one consumer: `river.AddWorker`. But the API's River client is never `Start()`ed — `hub-worker` runs the workers — so the API cannot work those jobs even in principle. It was constructing credentialed Vertex clients it can never call, and any one of them failing took the whole HTTP API down with it.

The registration existed to satisfy River's insert-time unknown-kind check, but that check only runs when `Workers` is non-nil (`client.go:2228-2239`), and declaring a queue is never required in order to insert onto it (`client.go:1693-1695`). So the requirement was self-imposed: building the client insert-only (`river.Config{}`, both `Workers` and `Queues` omitted — River rejects setting one without the other) makes it disappear, and with it the API's need for credentials it can't use.

**This is not the graceful degradation the ticket proposed, on purpose.** `hub-worker` still fails fast when a credential is missing, because silently disabling a provider somebody explicitly configured turns a visible boot failure into an unnoticed data-quality outage — you'd deploy green and quietly enrich nothing for weeks. Config errors should fail loudly; what was wrong here was the blast radius, not the fail-fast. This narrows it to the process that actually needs the credential.

It's worth flagging that this is production-relevant and not only a local-dev annoyance: enable `google-gemini` in Helm values without the matching IAM binding and today the entire API CrashLoopBackOffs, taking down all feedback ingestion rather than just enrichment.

**Embeddings are deliberately untouched** — the API keeps its embedding client, because search uses it synchronously to embed the incoming query. So `EMBEDDING_PROVIDER=google-gemini` does still require credentials in the API, and that's correct.

### Trade-off

Going insert-only gives up River's insert-time `UnknownJobKindError`, so a kind added to the insert side without a matching worker would strand jobs silently. `internal/workers` had no test for its wiring at all, so this adds one and puts that invariant in it, checked against a new `service.JobKindSpecs`. River exposes no way to enumerate a bundle's registered kinds (`workersMap` is unexported with no accessor), so registration is observed via `AddWorkerSafely`, which errors only on a duplicate kind. Net effect: the guard moves from boot time (where it needed credentials) to test time (where it doesn't).

`JobKindSpecs` also collapses `riverDepthQueues`, which was a third hand-maintained copy of the queue set. `wiring.go` still names its own queues, since it pairs each with a per-enrichment `MaxWorkers` that the list has no notion of — the two are kept in step by assertion rather than derivation, which is what the parity test is for.

Dropping `placeholderMaxWorkers` is fallout: it existed only for the API (which passed `1` for workers it never ran), so with the API registering nothing, `hub-worker` is the only caller and it always passed `0`.

### One thing for reviewers to weigh

A deployment can now have a healthy API happily enqueueing jobs while `hub-worker` crash-loops — enrichment stops while ingestion continues. That's the intended narrowing, but it does move detection off "the API is down" and onto the queue signals. Both are preserved: the River queue-depth gauge (now derived from `JobKindSpecs`, so a new kind can't be added without its queue appearing on the gauge) and the enrichment-backlog gauge. Happy to add an explicit alert suggestion if that feels thin.

### Not closed by this PR

ENG-1916 also asks for the dev `docker-compose.dev.yml` credential mount and an `.env.example` guardrail. Those live in the formbricks monorepo and come in a follow-up — and that follow-up is the part that actually gets Gemini enrichment running locally, which is what the ticket was filed for. This PR stops the API dying; it doesn't make enrichment work.

### Also here: `hub-worker` now honors `LOG_LEVEL`

This came up while debugging the above. `hub-worker` never configured `slog`, so it ignored `LOG_LEVEL` entirely and ran on Go's default handler, while `hub-api` honored it. That matters more after this change, because once the API stops dying the worker's logs are the *only* place the actionable credential error appears — and its debug lines were unreachable.

The level parsing and handler setup move into `internal/observability`, which already owns the logging handler, and both entrypoints call it. Living there also means the logic is covered by `make test-unit`, which runs `./cmd/api` and `./internal/...` but not `./cmd/worker`.

**Heads-up for operators — the worker's output changes, not just its level.** It previously wrote to **stderr** as:

```
2026/07/28 10:37:10 INFO Worker running client_id=...
```

and now matches `hub-api`, writing to **stdout** as:

```
time=2026-07-28T10:37:10.962Z level=INFO msg="Worker running" client_id=...
```

Container log collection is unaffected (both streams are captured), but anything parsing `hub-worker` output or relying on stderr/stdout separation needs updating. Worth a line in the release notes.

`hub-api` is unchanged, including that it configures logging *before* reporting a config-load failure so a broken config still produces output — the worker now does the same. Unrecognized levels still fall back to info rather than silencing logs. One pre-existing oddity preserved rather than fixed: only the exact string `warn` matches, so `LOG_LEVEL=warning` falls back to info. Pinned in a test; happy to make it accept `warning` if that reads as a trap.

## How should this be tested?

Unit, lint and integration:

```
make fmt && make lint && make build && make test-unit && make tests
```

Note on `make tests` locally: it sources `.env`, and if your `DATABASE_URL` points at a Postgres that isn't running you'll get a wall of connection failures unrelated to this change. Against a live `test_db` it's green:

```
DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_db?sslmode=disable" \
  go test ./tests/... -timeout 180s
```

End-to-end, reproducing the ticket. Build this branch, point `HUB_IMAGE_TAG` at it, and set the enrichment providers with a credentials path that does **not** exist inside the container:

```
SENTIMENT_PROVIDER=google-gemini
SENTIMENT_MODEL=gemini-2.5-flash
SENTIMENT_GOOGLE_CLOUD_PROJECT=some-project
SENTIMENT_GOOGLE_CLOUD_LOCATION=us-central1
EMOTIONS_PROVIDER=google-gemini          # same shape
TRANSLATION_PROVIDER=google-gemini       # same shape, plus TRANSLATION_DEFAULT_LANGUAGE
EMBEDDING_PROVIDER=openai
EMBEDDING_MODEL=text-embedding-3-small
EMBEDDING_PROVIDER_API_KEY=sk-anything-unused-at-boot
GOOGLE_APPLICATION_CREDENTIALS=/does/not/exist/in/container.json
```

Expected, and what I saw:

| | `ghcr.io/formbricks/hub:0.8.1` | this branch |
|---|---|---|
| API boot | `ERROR Failed to create application` → exit 1 | `INFO Starting server port=8080` |
| `GET /health` | nothing listening | `200` |
| `POST /v1/feedback-records` | — | `201`, record persisted |
| `hub-worker` | exit 1 | exit 1 (unchanged, on purpose) |

Then confirm inserts still land correctly with no `Workers`/`Queues` declared — this is the load-bearing bit, so worth checking rather than trusting:

```
select kind, queue, state from river_job order by kind;
```

All six kinds should appear on their own queues, matching `service.JobKindSpecs` exactly:

```
 feedback_embedding          | embeddings            | available
 feedback_emotions           | emotions              | available
 feedback_sentiment          | sentiments            | available
 feedback_translation        | translations          | available
 tenant_translation_backfill | translation_backfills | available
 webhook_dispatch            | default               | available
```

(`webhook_dispatch` needs a webhook registered first; `tenant_translation_backfill` is triggered by a `PATCH /v1/tenants/{tenant_id}/settings` writing `target_language`.)

Both new guards were checked by breaking them deliberately, so they aren't just passing decoration: dropping the sentiment registration from `wiring.go` fails the parity test on its missing queue (`queue "sentiments" for kind "feedback_sentiment" missing from queue config`), and sourcing a queue's `MaxWorkers` from the wrong enrichment fails the concurrency test (`MaxWorkers = 5, want 4`).

For the `LOG_LEVEL` part, run the worker briefly with `LOG_LEVEL=error` against any valid `DATABASE_URL`/`API_KEY`:

```
docker run --rm -e API_KEY=... -e DATABASE_URL=... -e LOG_LEVEL=error \
  --entrypoint sh <image> -c '/app/hub-worker & sleep 3; kill %1'
```

`ghcr.io/formbricks/hub:0.8.1` still prints `INFO` lines in the default-handler format (`2026/07/28 ... INFO Worker running ...`), i.e. the level is ignored. This branch prints nothing at `INFO`, and with `LOG_LEVEL` unset prints `time=... level=INFO msg="Worker running" ...`, matching `hub-api`. `ParseLogLevel` also has a table test covering casing and the unknown-value fallback.

Beyond that I exercised the wider surface to check nothing regressed: full CRUD on feedback records (create/get/list/count/patch/delete, plus 401 unauthenticated and 404 after delete), tenant settings get/patch, semantic search returning 503 with embeddings disabled and reaching the provider when enabled, the worker draining a real `webhook_dispatch` job (attempted and retried on a non-2xx), and SIGTERM giving a clean exit 0 with `Server stopped` / `Worker stopped` on both binaries.

Enrichment itself was verified end to end against a stubbed OpenAI-compatible endpoint (no credentials, no external egress): `feedback_sentiment` and `feedback_emotions` both reached `completed` on the first attempt and the values persisted on the record. Disabling sentiment for the tenant then produced an emotions job but no sentiment job, so the per-tenant enrichment gate still applies.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`) — green against a live `test_db`, see the note above
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` — n/a, no schema change

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec — n/a, no API surface change (routes, request and response shapes are all untouched)
- [ ] If API behavior changed: added request/response examples — n/a, externally observable behavior is unchanged except that the API now boots where it previously exited
- [ ] Updated docs in `docs/` if changes were necessary — n/a here; the env-var guardrail lands in the formbricks follow-up
- [x] Ran `make tests-coverage` for meaningful logic changes — 74.3% total, comfortably over the 15% gate
