### PR TITLE
fix: honor LOG_LEVEL in hub-worker

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -6,12 +6,12 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/pkg/database"
 )
 
@@ -27,20 +27,20 @@ func main() {
 func run() int {
 	cfg, err := config.Load()
 	if err != nil {
-		setupLogging("info")
+		observability.SetupLogging("info")
 		slog.Error("Failed to load configuration", "error", err)
 
 		return exitFailure
 	}
 
 	if cfg.Server.HubAPIKey == "" {
-		setupLogging(cfg.Server.LogLevel)
+		observability.SetupLogging(cfg.Server.LogLevel)
 		slog.Error("API_KEY is required for hub-api")
 
 		return exitFailure
 	}
 
-	setupLogging(cfg.Server.LogLevel)
+	observability.SetupLogging(cfg.Server.LogLevel)
 
 	ctx := context.Background()
 
@@ -90,25 +90,4 @@ func run() int {
 	slog.Info("Server stopped")
 
 	return exitSuccess
-}
-
-func setupLogging(level string) {
-	var logLevel slog.Level
-
-	switch strings.ToLower(level) {
-	case "debug":
-		logLevel = slog.LevelDebug
-	case "info":
-		logLevel = slog.LevelInfo
-	case "warn":
-		logLevel = slog.LevelWarn
-	case "error":
-		logLevel = slog.LevelError
-	default:
-		logLevel = slog.LevelInfo
-	}
-
-	opts := &slog.HandlerOptions{Level: logLevel}
-	handler := slog.NewTextHandler(os.Stdout, opts)
-	slog.SetDefault(slog.New(handler))
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -12,6 +12,7 @@ import (
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/pkg/database"
 )
 
@@ -27,10 +28,14 @@ func main() {
 func run() int {
 	cfg, err := config.Load()
 	if err != nil {
+		// Configure logging before reporting the failure, so a broken config still produces output.
+		observability.SetupLogging("info")
 		slog.Error("Failed to load configuration", "error", err)
 
 		return exitFailure
 	}
+
+	observability.SetupLogging(cfg.Server.LogLevel)
 
 	if cfg.Database.URL == "" || cfg.Database.URL == config.DefaultDatabaseURL {
 		slog.Error("DATABASE_URL must be set explicitly for hub-worker (do not use the default test URL)")

--- a/internal/observability/logging.go
+++ b/internal/observability/logging.go
@@ -4,9 +4,37 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ParseLogLevel maps a LOG_LEVEL value to a slog.Level, falling back to info for anything
+// unrecognized (including the empty string) so a typo degrades to the default rather than silencing
+// logs.
+func ParseLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// SetupLogging installs the default slog handler at the given level. Both binaries call it during
+// startup: hub-api and hub-worker have to agree on log format and honor the same LOG_LEVEL, or a
+// failure that only reproduces in one of them is harder to read than it needs to be.
+func SetupLogging(level string) {
+	opts := &slog.HandlerOptions{Level: ParseLogLevel(level)}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, opts)))
+}
 
 // requestIDKey is the context key for the request ID (X-Request-ID).
 // Middleware sets it; the TraceContextHandler adds it to log records.

--- a/internal/observability/logging_test.go
+++ b/internal/observability/logging_test.go
@@ -1,0 +1,33 @@
+package observability
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// ParseLogLevel backs LOG_LEVEL for both hub-api and hub-worker, so an unrecognized value must
+// degrade to info rather than silencing logs — a config typo that hid worker output would defeat the
+// point of honoring the level at all.
+func TestParseLogLevel(t *testing.T) {
+	tests := map[string]slog.Level{
+		"debug":     slog.LevelDebug,
+		"info":      slog.LevelInfo,
+		"warn":      slog.LevelWarn,
+		"error":     slog.LevelError,
+		"DEBUG":     slog.LevelDebug,
+		"Warn":      slog.LevelWarn,
+		"":          slog.LevelInfo,
+		"trace":     slog.LevelInfo,
+		"verbose":   slog.LevelInfo,
+		"warning":   slog.LevelInfo,
+		"not-level": slog.LevelInfo,
+	}
+
+	for level, want := range tests {
+		t.Run(level, func(t *testing.T) {
+			if got := ParseLogLevel(level); got != want {
+				t.Fatalf("ParseLogLevel(%q) = %v, want %v", level, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

`hub-worker` never configured `slog`, so it ignored `LOG_LEVEL` entirely and ran on Go's default handler, while `hub-api` honored it. Setting `LOG_LEVEL=error` on the worker did nothing.

It's a bit worse than just the level being ignored: because the worker was on the default handler and the API on a configured `TextHandler`, the two processes emitted *different formats to different streams*. Same deployment, same image, two log shapes.

This came out of ENG-1916 (hub#114), where a missing enrichment credential takes down `hub-worker`. After that change the worker's logs become the only place the actionable error appears, so it matters that they're readable and that debug is reachable. Splitting it out from #114 since it's an independent concern and, as below, it changes output that people may be parsing.

The level parsing and handler setup move into `internal/observability`, which already owns the logging handler (`TraceContextHandler`), and both entrypoints call it. Living there also means the logic is actually covered by `make test-unit`, which runs `./cmd/api` and `./internal/...` but not `./cmd/worker`.

### Heads-up for operators — output changes, not just the level

`hub-worker` previously wrote to **stderr** as:

```
2026/07/28 10:37:10 INFO Worker running client_id=...
```

and now matches `hub-api`, writing to **stdout** as:

```
time=2026-07-28T10:37:10.962Z level=INFO msg="Worker running" client_id=...
```

Container log collection is unaffected (both streams are captured), but anything parsing `hub-worker` output, or relying on stderr/stdout separation, needs updating. Worth a line in the release notes.

`hub-api` behavior is unchanged, including that it configures logging *before* reporting a config-load failure so a broken config still produces output — the worker now does the same. Unrecognized levels still fall back to info rather than silencing logs, which felt like the safer default for a typo'd env var.

One small oddity preserved rather than fixed: only the exact string `warn` matches, so `LOG_LEVEL=warning` falls back to info. That's pre-existing; I pinned it in a test rather than changing it, but happy to make it accept `warning` if people think that's a trap.

## How should this be tested?

```
make fmt && make lint && make build && make test-unit
```

The behavior is easiest to see as a before/after against a released image. With any valid `DATABASE_URL` and `API_KEY`, run the worker briefly with `LOG_LEVEL=error`:

```
docker run --rm -e API_KEY=... -e DATABASE_URL=... -e LOG_LEVEL=error \
  --entrypoint sh <image> -c '/app/hub-worker & sleep 3; kill %1'
```

- `ghcr.io/formbricks/hub:0.8.1` → still prints `INFO` lines (`2026/07/28 ... INFO Worker running ...`), i.e. `LOG_LEVEL` ignored, default-handler format.
- this branch → prints nothing at `INFO`, and with `LOG_LEVEL` unset prints `time=... level=INFO msg="Worker running" ...`, matching `hub-api`.

`ParseLogLevel` itself is covered by a table test in `internal/observability/logging_test.go`, including the casing and unknown-value fallbacks.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`) — not run for this change; it touches no DB or job path, and `make test-unit` covers the added logic
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` — n/a, no schema change

### Appreciated

- [ ] If API changed: added or updated OpenAPI spec — n/a, no API change
- [ ] If API behavior changed: added request/response examples — n/a
- [ ] Updated docs in `docs/` if changes were necessary — n/a, though the stream/format change above is worth a release note
- [ ] Ran `make tests-coverage` — n/a for a change this size; the new logic has a direct unit test
