### PR TITLE
test: strengthen taxonomy API contracts (ENG-1202)

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/formbricks/hub/internal/api/handlers"
 	"github.com/formbricks/hub/internal/api/middleware"
+	"github.com/formbricks/hub/internal/api/routes"
 	"github.com/formbricks/hub/internal/config"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/observability"
@@ -646,16 +647,7 @@ func newHTTPServer(
 	protected.HandleFunc("POST /v1/feedback-records/search/semantic", search.SemanticSearch)
 	protected.HandleFunc("GET /v1/feedback-records/{id}/similar", search.SimilarFeedback)
 
-	protected.HandleFunc("GET /v1/taxonomy/fields", taxonomy.ListFields)
-	protected.HandleFunc("POST /v1/taxonomy/runs", taxonomy.CreateRun)
-	protected.HandleFunc("GET /v1/taxonomy/runs", taxonomy.ListRuns)
-	protected.HandleFunc("GET /v1/taxonomy/runs/active/tree", taxonomy.GetActiveTree)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}", taxonomy.GetRun)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/tree", taxonomy.GetTree)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/record-counts", taxonomy.RecordCounts)
-	protected.HandleFunc("PATCH /v1/taxonomy/nodes/{node_id}", taxonomy.RenameNode)
-	protected.HandleFunc("DELETE /v1/taxonomy/nodes/{node_id}", taxonomy.RemoveNode)
-	protected.HandleFunc("GET /v1/taxonomy/nodes/{node_id}/records", taxonomy.ListNodeRecords)
+	routes.RegisterPublicTaxonomy(protected, taxonomy)
 
 	protectedWithAuth := middleware.Auth(cfg.Server.HubAPIKey)(protected)
 
@@ -664,11 +656,7 @@ func newHTTPServer(
 
 	if cfg.Taxonomy.HubInternalAPIToken != "" {
 		internalTaxonomy := http.NewServeMux()
-		internalTaxonomy.HandleFunc("GET /internal/v1/taxonomy/auth-check", taxonomyInternal.AuthCheck)
-		internalTaxonomy.HandleFunc("GET /internal/v1/taxonomy/runs/{run_id}/input", taxonomyInternal.GetRunInput)
-		internalTaxonomy.HandleFunc("PUT /internal/v1/taxonomy/runs/{run_id}/result", taxonomyInternal.CompleteRun)
-		internalTaxonomy.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/failed", taxonomyInternal.FailRun)
-		internalTaxonomy.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/heartbeat", taxonomyInternal.Heartbeat)
+		routes.RegisterInternalTaxonomy(internalTaxonomy, taxonomyInternal)
 		internalTaxonomyWithAuth := middleware.Auth(cfg.Taxonomy.HubInternalAPIToken)(internalTaxonomy)
 		mux.Handle("/internal/v1/taxonomy/", internalTaxonomyWithAuth)
 	}

--- a/internal/api/routes/taxonomy.go
+++ b/internal/api/routes/taxonomy.go
@@ -7,43 +7,18 @@ import (
 	"github.com/formbricks/hub/internal/api/handlers"
 )
 
-type publicTaxonomyHandlerID uint8
-
-const (
-	publicListFields publicTaxonomyHandlerID = iota
-	publicCreateRun
-	publicListRuns
-	publicGetActiveTree
-	publicGetRun
-	publicGetTree
-	publicRecordCounts
-	publicRenameNode
-	publicRemoveNode
-	publicListNodeRecords
-)
-
-type internalTaxonomyHandlerID uint8
-
-const (
-	internalAuthCheck internalTaxonomyHandlerID = iota
-	internalGetRunInput
-	internalCompleteRun
-	internalFailRun
-	internalHeartbeat
-)
-
 type publicTaxonomyRoute struct {
 	method           string
 	path             string
 	operationID      string
 	responseStatuses []string
-	handlerID        publicTaxonomyHandlerID
+	handler          func(*handlers.TaxonomyHandler, http.ResponseWriter, *http.Request)
 }
 
 type internalTaxonomyRoute struct {
-	method    string
-	path      string
-	handlerID internalTaxonomyHandlerID
+	method  string
+	path    string
+	handler func(*handlers.TaxonomyInternalHandler, http.ResponseWriter, *http.Request)
 }
 
 var publicTaxonomyRoutes = []publicTaxonomyRoute{
@@ -52,138 +27,115 @@ var publicTaxonomyRoutes = []publicTaxonomyRoute{
 		path:             "/v1/taxonomy/fields",
 		operationID:      "list-taxonomy-fields",
 		responseStatuses: []string{"200", "400", "401", "503", "default"},
-		handlerID:        publicListFields,
+		handler:          (*handlers.TaxonomyHandler).ListFields,
 	},
 	{
 		method:           http.MethodPost,
 		path:             "/v1/taxonomy/runs",
 		operationID:      "create-taxonomy-run",
 		responseStatuses: []string{"200", "202", "400", "401", "409", "503", "default"},
-		handlerID:        publicCreateRun,
+		handler:          (*handlers.TaxonomyHandler).CreateRun,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/runs",
 		operationID:      "list-taxonomy-runs",
 		responseStatuses: []string{"200", "400", "401", "default"},
-		handlerID:        publicListRuns,
+		handler:          (*handlers.TaxonomyHandler).ListRuns,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/runs/active/tree",
 		operationID:      "get-active-taxonomy-tree",
 		responseStatuses: []string{"200", "400", "401", "404", "default"},
-		handlerID:        publicGetActiveTree,
+		handler:          (*handlers.TaxonomyHandler).GetActiveTree,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/runs/{run_id}",
 		operationID:      "get-taxonomy-run",
 		responseStatuses: []string{"200", "400", "401", "404", "default"},
-		handlerID:        publicGetRun,
+		handler:          (*handlers.TaxonomyHandler).GetRun,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/runs/{run_id}/tree",
 		operationID:      "get-taxonomy-run-tree",
 		responseStatuses: []string{"200", "400", "401", "404", "default"},
-		handlerID:        publicGetTree,
+		handler:          (*handlers.TaxonomyHandler).GetTree,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/runs/{run_id}/record-counts",
 		operationID:      "count-taxonomy-node-records",
 		responseStatuses: []string{"200", "400", "401", "404", "default"},
-		handlerID:        publicRecordCounts,
+		handler:          (*handlers.TaxonomyHandler).RecordCounts,
 	},
 	{
 		method:           http.MethodPatch,
 		path:             "/v1/taxonomy/nodes/{node_id}",
 		operationID:      "rename-taxonomy-node",
 		responseStatuses: []string{"200", "400", "401", "404", "409", "default"},
-		handlerID:        publicRenameNode,
+		handler:          (*handlers.TaxonomyHandler).RenameNode,
 	},
 	{
 		method:           http.MethodDelete,
 		path:             "/v1/taxonomy/nodes/{node_id}",
 		operationID:      "remove-taxonomy-node",
 		responseStatuses: []string{"200", "400", "401", "404", "409", "default"},
-		handlerID:        publicRemoveNode,
+		handler:          (*handlers.TaxonomyHandler).RemoveNode,
 	},
 	{
 		method:           http.MethodGet,
 		path:             "/v1/taxonomy/nodes/{node_id}/records",
 		operationID:      "list-taxonomy-node-records",
 		responseStatuses: []string{"200", "400", "401", "default"},
-		handlerID:        publicListNodeRecords,
+		handler:          (*handlers.TaxonomyHandler).ListNodeRecords,
 	},
 }
 
 var internalTaxonomyRoutes = []internalTaxonomyRoute{
-	{method: http.MethodGet, path: "/internal/v1/taxonomy/auth-check", handlerID: internalAuthCheck},
-	{method: http.MethodGet, path: "/internal/v1/taxonomy/runs/{run_id}/input", handlerID: internalGetRunInput},
-	{method: http.MethodPut, path: "/internal/v1/taxonomy/runs/{run_id}/result", handlerID: internalCompleteRun},
-	{method: http.MethodPost, path: "/internal/v1/taxonomy/runs/{run_id}/failed", handlerID: internalFailRun},
-	{method: http.MethodPost, path: "/internal/v1/taxonomy/runs/{run_id}/heartbeat", handlerID: internalHeartbeat},
+	{
+		method:  http.MethodGet,
+		path:    "/internal/v1/taxonomy/auth-check",
+		handler: (*handlers.TaxonomyInternalHandler).AuthCheck,
+	},
+	{
+		method:  http.MethodGet,
+		path:    "/internal/v1/taxonomy/runs/{run_id}/input",
+		handler: (*handlers.TaxonomyInternalHandler).GetRunInput,
+	},
+	{
+		method:  http.MethodPut,
+		path:    "/internal/v1/taxonomy/runs/{run_id}/result",
+		handler: (*handlers.TaxonomyInternalHandler).CompleteRun,
+	},
+	{
+		method:  http.MethodPost,
+		path:    "/internal/v1/taxonomy/runs/{run_id}/failed",
+		handler: (*handlers.TaxonomyInternalHandler).FailRun,
+	},
+	{
+		method:  http.MethodPost,
+		path:    "/internal/v1/taxonomy/runs/{run_id}/heartbeat",
+		handler: (*handlers.TaxonomyInternalHandler).Heartbeat,
+	},
 }
 
 // RegisterPublicTaxonomy registers the Hub API key-protected taxonomy endpoints.
 func RegisterPublicTaxonomy(mux *http.ServeMux, handler *handlers.TaxonomyHandler) {
 	for _, route := range publicTaxonomyRoutes {
-		mux.HandleFunc(route.method+" "+route.path, publicTaxonomyHandler(handler, route.handlerID))
+		mux.HandleFunc(route.method+" "+route.path, func(w http.ResponseWriter, r *http.Request) {
+			route.handler(handler, w, r)
+		})
 	}
 }
 
 // RegisterInternalTaxonomy registers the internal taxonomy-service endpoints.
 func RegisterInternalTaxonomy(mux *http.ServeMux, handler *handlers.TaxonomyInternalHandler) {
 	for _, route := range internalTaxonomyRoutes {
-		mux.HandleFunc(route.method+" "+route.path, internalTaxonomyHandler(handler, route.handlerID))
-	}
-}
-
-func publicTaxonomyHandler(handler *handlers.TaxonomyHandler, handlerID publicTaxonomyHandlerID) http.HandlerFunc {
-	switch handlerID {
-	case publicListFields:
-		return handler.ListFields
-	case publicCreateRun:
-		return handler.CreateRun
-	case publicListRuns:
-		return handler.ListRuns
-	case publicGetActiveTree:
-		return handler.GetActiveTree
-	case publicGetRun:
-		return handler.GetRun
-	case publicGetTree:
-		return handler.GetTree
-	case publicRecordCounts:
-		return handler.RecordCounts
-	case publicRenameNode:
-		return handler.RenameNode
-	case publicRemoveNode:
-		return handler.RemoveNode
-	case publicListNodeRecords:
-		return handler.ListNodeRecords
-	default:
-		panic("unknown public taxonomy handler")
-	}
-}
-
-func internalTaxonomyHandler(
-	handler *handlers.TaxonomyInternalHandler,
-	handlerID internalTaxonomyHandlerID,
-) http.HandlerFunc {
-	switch handlerID {
-	case internalAuthCheck:
-		return handler.AuthCheck
-	case internalGetRunInput:
-		return handler.GetRunInput
-	case internalCompleteRun:
-		return handler.CompleteRun
-	case internalFailRun:
-		return handler.FailRun
-	case internalHeartbeat:
-		return handler.Heartbeat
-	default:
-		panic("unknown internal taxonomy handler")
+		mux.HandleFunc(route.method+" "+route.path, func(w http.ResponseWriter, r *http.Request) {
+			route.handler(handler, w, r)
+		})
 	}
 }

--- a/internal/api/routes/taxonomy.go
+++ b/internal/api/routes/taxonomy.go
@@ -1,0 +1,189 @@
+// Package routes contains shared HTTP route registration for API domains.
+package routes
+
+import (
+	"net/http"
+
+	"github.com/formbricks/hub/internal/api/handlers"
+)
+
+type publicTaxonomyHandlerID uint8
+
+const (
+	publicListFields publicTaxonomyHandlerID = iota
+	publicCreateRun
+	publicListRuns
+	publicGetActiveTree
+	publicGetRun
+	publicGetTree
+	publicRecordCounts
+	publicRenameNode
+	publicRemoveNode
+	publicListNodeRecords
+)
+
+type internalTaxonomyHandlerID uint8
+
+const (
+	internalAuthCheck internalTaxonomyHandlerID = iota
+	internalGetRunInput
+	internalCompleteRun
+	internalFailRun
+	internalHeartbeat
+)
+
+type publicTaxonomyRoute struct {
+	method           string
+	path             string
+	operationID      string
+	responseStatuses []string
+	handlerID        publicTaxonomyHandlerID
+}
+
+type internalTaxonomyRoute struct {
+	method    string
+	path      string
+	handlerID internalTaxonomyHandlerID
+}
+
+var publicTaxonomyRoutes = []publicTaxonomyRoute{
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/fields",
+		operationID:      "list-taxonomy-fields",
+		responseStatuses: []string{"200", "400", "401", "503", "default"},
+		handlerID:        publicListFields,
+	},
+	{
+		method:           http.MethodPost,
+		path:             "/v1/taxonomy/runs",
+		operationID:      "create-taxonomy-run",
+		responseStatuses: []string{"200", "202", "400", "401", "409", "503", "default"},
+		handlerID:        publicCreateRun,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/runs",
+		operationID:      "list-taxonomy-runs",
+		responseStatuses: []string{"200", "400", "401", "default"},
+		handlerID:        publicListRuns,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/runs/active/tree",
+		operationID:      "get-active-taxonomy-tree",
+		responseStatuses: []string{"200", "400", "401", "404", "default"},
+		handlerID:        publicGetActiveTree,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/runs/{run_id}",
+		operationID:      "get-taxonomy-run",
+		responseStatuses: []string{"200", "400", "401", "404", "default"},
+		handlerID:        publicGetRun,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/runs/{run_id}/tree",
+		operationID:      "get-taxonomy-run-tree",
+		responseStatuses: []string{"200", "400", "401", "404", "default"},
+		handlerID:        publicGetTree,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/runs/{run_id}/record-counts",
+		operationID:      "count-taxonomy-node-records",
+		responseStatuses: []string{"200", "400", "401", "404", "default"},
+		handlerID:        publicRecordCounts,
+	},
+	{
+		method:           http.MethodPatch,
+		path:             "/v1/taxonomy/nodes/{node_id}",
+		operationID:      "rename-taxonomy-node",
+		responseStatuses: []string{"200", "400", "401", "404", "409", "default"},
+		handlerID:        publicRenameNode,
+	},
+	{
+		method:           http.MethodDelete,
+		path:             "/v1/taxonomy/nodes/{node_id}",
+		operationID:      "remove-taxonomy-node",
+		responseStatuses: []string{"200", "400", "401", "404", "409", "default"},
+		handlerID:        publicRemoveNode,
+	},
+	{
+		method:           http.MethodGet,
+		path:             "/v1/taxonomy/nodes/{node_id}/records",
+		operationID:      "list-taxonomy-node-records",
+		responseStatuses: []string{"200", "400", "401", "default"},
+		handlerID:        publicListNodeRecords,
+	},
+}
+
+var internalTaxonomyRoutes = []internalTaxonomyRoute{
+	{method: http.MethodGet, path: "/internal/v1/taxonomy/auth-check", handlerID: internalAuthCheck},
+	{method: http.MethodGet, path: "/internal/v1/taxonomy/runs/{run_id}/input", handlerID: internalGetRunInput},
+	{method: http.MethodPut, path: "/internal/v1/taxonomy/runs/{run_id}/result", handlerID: internalCompleteRun},
+	{method: http.MethodPost, path: "/internal/v1/taxonomy/runs/{run_id}/failed", handlerID: internalFailRun},
+	{method: http.MethodPost, path: "/internal/v1/taxonomy/runs/{run_id}/heartbeat", handlerID: internalHeartbeat},
+}
+
+// RegisterPublicTaxonomy registers the Hub API key-protected taxonomy endpoints.
+func RegisterPublicTaxonomy(mux *http.ServeMux, handler *handlers.TaxonomyHandler) {
+	for _, route := range publicTaxonomyRoutes {
+		mux.HandleFunc(route.method+" "+route.path, publicTaxonomyHandler(handler, route.handlerID))
+	}
+}
+
+// RegisterInternalTaxonomy registers the internal taxonomy-service endpoints.
+func RegisterInternalTaxonomy(mux *http.ServeMux, handler *handlers.TaxonomyInternalHandler) {
+	for _, route := range internalTaxonomyRoutes {
+		mux.HandleFunc(route.method+" "+route.path, internalTaxonomyHandler(handler, route.handlerID))
+	}
+}
+
+func publicTaxonomyHandler(handler *handlers.TaxonomyHandler, handlerID publicTaxonomyHandlerID) http.HandlerFunc {
+	switch handlerID {
+	case publicListFields:
+		return handler.ListFields
+	case publicCreateRun:
+		return handler.CreateRun
+	case publicListRuns:
+		return handler.ListRuns
+	case publicGetActiveTree:
+		return handler.GetActiveTree
+	case publicGetRun:
+		return handler.GetRun
+	case publicGetTree:
+		return handler.GetTree
+	case publicRecordCounts:
+		return handler.RecordCounts
+	case publicRenameNode:
+		return handler.RenameNode
+	case publicRemoveNode:
+		return handler.RemoveNode
+	case publicListNodeRecords:
+		return handler.ListNodeRecords
+	default:
+		panic("unknown public taxonomy handler")
+	}
+}
+
+func internalTaxonomyHandler(
+	handler *handlers.TaxonomyInternalHandler,
+	handlerID internalTaxonomyHandlerID,
+) http.HandlerFunc {
+	switch handlerID {
+	case internalAuthCheck:
+		return handler.AuthCheck
+	case internalGetRunInput:
+		return handler.GetRunInput
+	case internalCompleteRun:
+		return handler.CompleteRun
+	case internalFailRun:
+		return handler.FailRun
+	case internalHeartbeat:
+		return handler.Heartbeat
+	default:
+		panic("unknown internal taxonomy handler")
+	}
+}

--- a/internal/api/routes/taxonomy_test.go
+++ b/internal/api/routes/taxonomy_test.go
@@ -1,0 +1,113 @@
+package routes
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type openAPIDocument struct {
+	Paths map[string]map[string]openAPIOperation `yaml:"paths"`
+}
+
+type openAPIOperation struct {
+	OperationID string         `yaml:"operationId"`
+	Responses   map[string]any `yaml:"responses"`
+}
+
+func TestPublicTaxonomyRoutesMatchOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	document := loadOpenAPI(t)
+	registered := make(map[string]publicTaxonomyRoute, len(publicTaxonomyRoutes))
+
+	for _, route := range publicTaxonomyRoutes {
+		key := strings.ToLower(route.method) + " " + route.path
+		registered[key] = route
+
+		path, ok := document.Paths[route.path]
+		require.Truef(t, ok, "OpenAPI is missing taxonomy path %s", route.path)
+
+		operation, ok := path[strings.ToLower(route.method)]
+		require.Truef(t, ok, "OpenAPI is missing %s %s", route.method, route.path)
+		assert.Equal(t, route.operationID, operation.OperationID)
+
+		actualStatuses := make([]string, 0, len(operation.Responses))
+		for status := range operation.Responses {
+			actualStatuses = append(actualStatuses, status)
+		}
+
+		slices.Sort(actualStatuses)
+
+		expectedStatuses := slices.Clone(route.responseStatuses)
+		slices.Sort(expectedStatuses)
+		assert.Equal(t, expectedStatuses, actualStatuses, "%s %s response statuses", route.method, route.path)
+	}
+
+	openAPIRoutes := make(map[string]struct{})
+
+	for path, pathItem := range document.Paths {
+		if !strings.HasPrefix(path, "/v1/taxonomy") {
+			continue
+		}
+
+		for method := range pathItem {
+			upperMethod := strings.ToUpper(method)
+			if !isHTTPMethod(upperMethod) {
+				continue
+			}
+
+			key := method + " " + path
+			openAPIRoutes[key] = struct{}{}
+			_, ok := registered[key]
+			assert.Truef(t, ok, "OpenAPI taxonomy operation is not registered by Hub: %s %s", upperMethod, path)
+		}
+	}
+
+	assert.Len(t, openAPIRoutes, len(publicTaxonomyRoutes))
+}
+
+func TestInternalTaxonomyRoutesStayOutOfPublicOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	document := loadOpenAPI(t)
+
+	for _, route := range internalTaxonomyRoutes {
+		_, ok := document.Paths[route.path]
+		assert.Falsef(t, ok, "internal route must not be published in OpenAPI: %s %s", route.method, route.path)
+	}
+}
+
+func loadOpenAPI(t *testing.T) openAPIDocument {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	specPath := filepath.Join(filepath.Dir(filename), "..", "..", "..", "openapi.yaml")
+	// #nosec G304 -- the repository-local spec path is derived from this test file's location.
+	contents, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+
+	var document openAPIDocument
+	require.NoError(t, yaml.Unmarshal(contents, &document))
+
+	return document
+}
+
+func isHTTPMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/api/routes/taxonomy_test.go
+++ b/internal/api/routes/taxonomy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type openAPIDocument struct {
-	Paths map[string]map[string]openAPIOperation `yaml:"paths"`
+	Paths map[string]map[string]yaml.Node `yaml:"paths"`
 }
 
 type openAPIOperation struct {
@@ -36,7 +36,7 @@ func TestPublicTaxonomyRoutesMatchOpenAPI(t *testing.T) {
 		path, ok := document.Paths[route.path]
 		require.Truef(t, ok, "OpenAPI is missing taxonomy path %s", route.path)
 
-		operation, ok := path[strings.ToLower(route.method)]
+		operation, ok := decodeOpenAPIOperation(t, path, strings.ToLower(route.method))
 		require.Truef(t, ok, "OpenAPI is missing %s %s", route.method, route.path)
 		assert.Equal(t, route.operationID, operation.OperationID)
 
@@ -86,6 +86,31 @@ func TestInternalTaxonomyRoutesStayOutOfPublicOpenAPI(t *testing.T) {
 	}
 }
 
+func TestOpenAPIPathItemMetadataIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	document := decodeOpenAPI(t, []byte(`
+paths:
+  /v1/taxonomy/fields:
+    summary: Taxonomy field discovery
+    parameters:
+      - name: tenant_id
+        in: query
+    get:
+      operationId: list-taxonomy-fields
+      responses:
+        "200": {}
+`))
+
+	path, ok := document.Paths["/v1/taxonomy/fields"]
+	require.True(t, ok)
+
+	operation, ok := decodeOpenAPIOperation(t, path, "get")
+	require.True(t, ok)
+	assert.Equal(t, "list-taxonomy-fields", operation.OperationID)
+	assert.Contains(t, operation.Responses, "200")
+}
+
 func loadOpenAPI(t *testing.T) openAPIDocument {
 	t.Helper()
 
@@ -97,10 +122,34 @@ func loadOpenAPI(t *testing.T) openAPIDocument {
 	contents, err := os.ReadFile(specPath)
 	require.NoError(t, err)
 
+	return decodeOpenAPI(t, contents)
+}
+
+func decodeOpenAPI(t *testing.T, contents []byte) openAPIDocument {
+	t.Helper()
+
 	var document openAPIDocument
 	require.NoError(t, yaml.Unmarshal(contents, &document))
 
 	return document
+}
+
+func decodeOpenAPIOperation(
+	t *testing.T,
+	pathItem map[string]yaml.Node,
+	method string,
+) (openAPIOperation, bool) {
+	t.Helper()
+
+	node, ok := pathItem[method]
+	if !ok {
+		return openAPIOperation{}, false
+	}
+
+	var operation openAPIOperation
+	require.NoErrorf(t, node.Decode(&operation), "decode OpenAPI %s operation", strings.ToUpper(method))
+
+	return operation, true
 }
 
 func isHTTPMethod(method string) bool {

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/formbricks/hub/internal/api/response"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/repository"
 )
@@ -37,9 +39,60 @@ func requestTaxonomyJSON(
 
 	require.Equal(t, wantStatus, resp.StatusCode)
 
+	if wantStatus >= http.StatusBadRequest {
+		assert.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	} else {
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	}
+
 	if out != nil {
 		require.NoError(t, decodeData(resp, out))
 	}
+}
+
+// requestTaxonomyProblem asserts the stable RFC 9457 contract used by taxonomy errors.
+func requestTaxonomyProblem(
+	ctx context.Context,
+	t *testing.T,
+	method, requestURL, token string,
+	body any,
+	wantStatus int,
+	wantCode, wantType string,
+) response.ProblemDetails {
+	t.Helper()
+
+	resp := doTaxonomyRequest(ctx, t, method, requestURL, token, body)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, wantStatus, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+
+	var problem response.ProblemDetails
+	require.NoError(t, decodeData(resp, &problem))
+	assert.Equal(t, wantStatus, problem.Status)
+	assert.Equal(t, wantCode, problem.Code)
+	assert.Equal(t, wantType, problem.Type)
+	assert.Equal(t, resp.Request.URL.Path, problem.Instance)
+	assert.NotEmpty(t, problem.Title)
+
+	return problem
+}
+
+func assertTaxonomyInvalidParam(t *testing.T, problem response.ProblemDetails, name, reasonContains string) {
+	t.Helper()
+
+	require.NotEmpty(t, problem.InvalidParams)
+
+	for _, param := range problem.InvalidParams {
+		if param.Name == name || strings.HasSuffix(param.Name, "."+name) {
+			assert.Contains(t, param.Reason, reasonContains)
+
+			return
+		}
+	}
+
+	require.Failf(t, "invalid parameter not found", "wanted %q in %#v", name, problem.InvalidParams)
 }
 
 // findTaxonomyNode returns the first node in the tree matching predicate.
@@ -71,8 +124,10 @@ func TestTaxonomyAPI_Auth(t *testing.T) {
 	authCheckURL := harness.server.URL + "/internal/v1/taxonomy/auth-check"
 
 	t.Run("public endpoint rejects missing and wrong credentials", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, "", nil, http.StatusUnauthorized, nil)
-		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, "wrong-key", nil, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, fieldsURL, "", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, fieldsURL, "wrong-key", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 	})
 
 	t.Run("public endpoint accepts the Hub API key", func(t *testing.T) {
@@ -80,21 +135,26 @@ func TestTaxonomyAPI_Auth(t *testing.T) {
 	})
 
 	t.Run("internal endpoint rejects missing and wrong credentials", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, "", nil, http.StatusUnauthorized, nil)
-		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, "wrong-token", nil, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, authCheckURL, "", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, authCheckURL, "wrong-token", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 	})
 
 	t.Run("internal endpoint accepts the internal token", func(t *testing.T) {
 		var body map[string]any
 		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, harness.internalToken, nil, http.StatusOK, &body)
 		assert.Equal(t, "ok", body["status"])
+		assert.Equal(t, "hub-taxonomy-internal", body["service"])
 	})
 
 	t.Run("credentials do not cross auth layers", func(t *testing.T) {
 		// The internal token must not authorize the public API...
-		requestTaxonomyJSON(ctx, t, http.MethodGet, fieldsURL, harness.internalToken, nil, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, fieldsURL, harness.internalToken, nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 		// ...and the public API key must not authorize the internal service API.
-		requestTaxonomyJSON(ctx, t, http.MethodGet, authCheckURL, harness.apiKey, nil, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, authCheckURL, harness.apiKey, nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 	})
 }
 
@@ -106,6 +166,7 @@ func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
 
 	scope := uniqueTaxonomyScope("tax-api-read")
 	ids := seedTaxonomyGraph(ctx, t, harness.db, scope)
+	seedEmbeddedFeedback(ctx, t, harness, scope, 1)
 
 	scopeQuery := url.Values{
 		"tenant_id":   {scope.TenantID},
@@ -114,6 +175,21 @@ func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
 		"field_id":    {scope.FieldID},
 	}
 	tenantQuery := url.Values{"tenant_id": {scope.TenantID}}
+
+	t.Run("list fields returns the expected scope and counts", func(t *testing.T) {
+		var resp models.TaxonomyFieldsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/fields", tenantQuery),
+			harness.apiKey, nil, http.StatusOK, &resp)
+
+		require.Len(t, resp.Data, 1)
+		assert.Equal(t, scope.TenantID, resp.Data[0].TenantID)
+		assert.Equal(t, scope.SourceType, resp.Data[0].SourceType)
+		assert.Equal(t, scope.SourceID, resp.Data[0].SourceID)
+		assert.Equal(t, scope.FieldID, resp.Data[0].FieldID)
+		assert.Equal(t, 2, resp.Data[0].RecordCount)
+		assert.Equal(t, 1, resp.Data[0].EmbeddingCount)
+	})
 
 	t.Run("list runs returns the seeded run", func(t *testing.T) {
 		var resp models.ListTaxonomyRunsResponse
@@ -197,30 +273,62 @@ func TestTaxonomyAPI_TenantIsolation(t *testing.T) {
 
 	scope := uniqueTaxonomyScope("tax-api-iso")
 	ids := seedTaxonomyGraph(ctx, t, harness.db, scope)
+	seedEmbeddedFeedback(ctx, t, harness, scope, 1)
 
-	otherTenant := "tax-api-iso-other-" + uuid.NewString()
+	otherScope := uniqueTaxonomyScope("tax-api-iso-other")
+	otherIDs := seedTaxonomyGraph(ctx, t, harness.db, otherScope)
+	seedEmbeddedFeedback(ctx, t, harness, otherScope, 1)
+
+	otherTenant := otherScope.TenantID
 	otherQuery := url.Values{"tenant_id": {otherTenant}}
+	tenantQuery := url.Values{"tenant_id": {scope.TenantID}}
+
+	t.Run("list endpoints return only the requested tenant", func(t *testing.T) {
+		var fields models.TaxonomyFieldsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/fields", tenantQuery),
+			harness.apiKey, nil, http.StatusOK, &fields)
+		require.NotEmpty(t, fields.Data)
+
+		for _, field := range fields.Data {
+			assert.Equal(t, scope.TenantID, field.TenantID)
+			assert.NotEqual(t, otherTenant, field.TenantID)
+		}
+
+		var runs models.ListTaxonomyRunsResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs", tenantQuery),
+			harness.apiKey, nil, http.StatusOK, &runs)
+		require.Len(t, runs.Data, 1)
+		assert.Equal(t, ids.RunID, runs.Data[0].ID)
+		assert.NotEqual(t, otherIDs.RunID, runs.Data[0].ID)
+		assert.Equal(t, scope.TenantID, runs.Data[0].TenantID)
+	})
 
 	t.Run("get run 404s for another tenant", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet,
-			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String(), otherQuery), harness.apiKey, nil, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String(), otherQuery),
+			harness.apiKey, nil, http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("get tree 404s for another tenant", func(t *testing.T) {
 		treeURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/runs/"+ids.RunID.String()+"/tree", otherQuery)
-		requestTaxonomyJSON(ctx, t, http.MethodGet, treeURL, harness.apiKey, nil, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, treeURL, harness.apiKey, nil,
+			http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("rename 404s for another tenant", func(t *testing.T) {
 		body := models.RenameTaxonomyNodeRequest{TenantID: otherTenant, ActorID: "attacker", Label: "Hijacked"}
-		requestTaxonomyJSON(ctx, t, http.MethodPatch,
-			harness.server.URL+"/v1/taxonomy/nodes/"+ids.BranchID.String(), harness.apiKey, body, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodPatch,
+			harness.server.URL+"/v1/taxonomy/nodes/"+ids.BranchID.String(), harness.apiKey, body,
+			http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("remove 404s for another tenant", func(t *testing.T) {
 		removeQuery := url.Values{"tenant_id": {otherTenant}, "actor_id": {"attacker"}}
-		requestTaxonomyJSON(ctx, t, http.MethodDelete,
-			taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.BranchID.String(), removeQuery), harness.apiKey, nil, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodDelete,
+			taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.BranchID.String(), removeQuery),
+			harness.apiKey, nil, http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("node records return nothing for another tenant", func(t *testing.T) {
@@ -305,23 +413,25 @@ func TestTaxonomyAPI_RecordCounts(t *testing.T) {
 
 	t.Run("404s for another tenant", func(t *testing.T) {
 		otherQuery := url.Values{"tenant_id": {"tax-api-count-other-" + uuid.NewString()}}
-		requestTaxonomyJSON(ctx, t, http.MethodGet, countsURL(ids.RunID.String(), otherQuery),
-			harness.apiKey, nil, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, countsURL(ids.RunID.String(), otherQuery),
+			harness.apiKey, nil, http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("404s for an unknown run", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet, countsURL(uuid.NewString(), tenantQuery),
-			harness.apiKey, nil, http.StatusNotFound, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, countsURL(uuid.NewString(), tenantQuery),
+			harness.apiKey, nil, http.StatusNotFound, response.CodeNotFound, response.ProblemTypeNotFound)
 	})
 
 	t.Run("400s for an invalid run ID", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet, countsURL("not-a-uuid", tenantQuery),
-			harness.apiKey, nil, http.StatusBadRequest, nil)
+		problem := requestTaxonomyProblem(ctx, t, http.MethodGet, countsURL("not-a-uuid", tenantQuery),
+			harness.apiKey, nil, http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "run_id", "valid UUID")
 	})
 
 	t.Run("400s when tenant_id is missing", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodGet, countsURL(ids.RunID.String(), url.Values{}),
-			harness.apiKey, nil, http.StatusBadRequest, nil)
+		problem := requestTaxonomyProblem(ctx, t, http.MethodGet, countsURL(ids.RunID.String(), url.Values{}),
+			harness.apiKey, nil, http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "tenant_id", "required")
 	})
 }
 
@@ -333,18 +443,42 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 	runsURL := harness.server.URL + "/v1/taxonomy/runs"
 
 	t.Run("missing scope fields are rejected", func(t *testing.T) {
-		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey,
-			map[string]any{"source_type": "formbricks"}, http.StatusBadRequest, nil)
+		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey,
+			map[string]any{"source_type": "formbricks"}, http.StatusBadRequest,
+			response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "tenant_id", "required")
 	})
 
-	t.Run("insufficient embedded records are rejected", func(t *testing.T) {
-		scope := uniqueTaxonomyScope("tax-api-create-insufficient")
+	t.Run("scope without text records is rejected", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-api-create-empty")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
-		// One text record but no embeddings: below the embedding threshold.
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
+		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey, body,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "field_id", "no text feedback records")
+	})
+
+	t.Run("scope with missing embeddings is rejected", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-api-create-no-embeddings")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 		insertScopeFeedbackRecord(ctx, t, harness.db, scope)
 
 		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
-		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusBadRequest, nil)
+		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey, body,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "field_id", "found 0")
+	})
+
+	t.Run("scope below the minimum embedded record count is rejected", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-api-create-insufficient")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords-1)
+
+		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
+		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey, body,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "field_id", "found 1")
 	})
 
 	t.Run("directory scope rejects field selectors", func(t *testing.T) {
@@ -352,7 +486,9 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 		scope.SourceType = "formbricks"
 
 		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
-		requestTaxonomyJSON(ctx, t, http.MethodPost, runsURL, harness.apiKey, body, http.StatusBadRequest, nil)
+		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey, body,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
+		assertTaxonomyInvalidParam(t, problem, "source_type", "empty")
 	})
 
 	t.Run("accepts a new run and reuses an in-progress one", func(t *testing.T) {
@@ -416,6 +552,49 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 	})
 }
 
+// TestTaxonomyAPI_ServiceAvailability locks in the documented 503 contracts when Hub
+// embeddings or the external taxonomy compute service are not configured.
+func TestTaxonomyAPI_ServiceAvailability(t *testing.T) {
+	t.Run("missing embedding model rejects public and internal input endpoints", func(t *testing.T) {
+		harness := setupTaxonomyAPIServer(t, withTaxonomyEmbeddingModel(""))
+		ctx := context.Background()
+		scope := uniqueTaxonomyScope("tax-api-unconfigured-embeddings")
+		runID := createRunningRun(ctx, t, harness, scope)
+
+		fieldsURL := taxonomyURL(
+			harness.server.URL,
+			"/v1/taxonomy/fields",
+			url.Values{"tenant_id": {scope.TenantID}},
+		)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, fieldsURL, harness.apiKey, nil,
+			http.StatusServiceUnavailable, response.CodeServiceUnavailable, response.ProblemTypeServiceUnavailable)
+
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+		requestTaxonomyProblem(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil,
+			http.StatusServiceUnavailable, response.CodeServiceUnavailable, response.ProblemTypeServiceUnavailable)
+	})
+
+	t.Run("missing taxonomy starter rejects run creation", func(t *testing.T) {
+		harness := setupTaxonomyAPIServer(t, withoutTaxonomyStarter())
+		ctx := context.Background()
+		scope := uniqueTaxonomyScope("tax-api-unconfigured-starter")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords)
+
+		requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPost,
+			harness.server.URL+"/v1/taxonomy/runs",
+			harness.apiKey,
+			models.CreateTaxonomyRunRequest{TaxonomyScope: scope},
+			http.StatusServiceUnavailable,
+			response.CodeServiceUnavailable,
+			response.ProblemTypeServiceUnavailable,
+		)
+	})
+}
+
 // TestTaxonomyAPI_InternalServiceEndpoints covers the internal service flow: fetching run
 // input, completing a run (storing artifacts and activating), and failing a run.
 func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
@@ -432,7 +611,8 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
 
 		// Auth is required.
-		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, "", nil, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodGet, inputURL, "", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 
 		var input models.TaxonomyRunInputResponse
 		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
@@ -440,6 +620,36 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		require.NotEmpty(t, input.Records)
 		assert.NotEmpty(t, input.Records[0].Embedding)
 		assert.NotEmpty(t, input.Records[0].ValueText)
+	})
+
+	t.Run("get run input never includes another tenant's matching records", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-input-tenant")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		ownedRecordIDs := seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords)
+
+		otherScope := scope
+		otherScope.TenantID = "tax-internal-input-other-" + uuid.NewString()
+		cleanupTaxonomyTenant(ctx, t, harness.db, otherScope.TenantID)
+		otherRecordIDs := seedEmbeddedFeedback(ctx, t, harness, otherScope, taxonomyMinEmbeddedRecords)
+
+		runID := startRunForScope(ctx, t, harness, scope)
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+
+		actualRecordIDs := make(map[uuid.UUID]struct{}, len(input.Records))
+		for _, record := range input.Records {
+			actualRecordIDs[record.FeedbackRecordID] = struct{}{}
+		}
+
+		for _, recordID := range ownedRecordIDs {
+			assert.Contains(t, actualRecordIDs, recordID)
+		}
+
+		for _, recordID := range otherRecordIDs {
+			assert.NotContains(t, actualRecordIDs, recordID)
+		}
 	})
 
 	t.Run("run input returns translated text when present", func(t *testing.T) {
@@ -579,7 +789,8 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 
 		// Auth is required.
-		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, "", result, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodPut, resultURL, "", result,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 
 		var run models.TaxonomyRun
 		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, harness.internalToken, result, http.StatusOK, &run)
@@ -604,13 +815,171 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		failedURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/failed"
 
 		// Auth is required.
-		requestTaxonomyJSON(ctx, t, http.MethodPost, failedURL, "", body, http.StatusUnauthorized, nil)
+		requestTaxonomyProblem(ctx, t, http.MethodPost, failedURL, "", body,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
 
 		var run models.TaxonomyRun
 		requestTaxonomyJSON(ctx, t, http.MethodPost, failedURL, harness.internalToken, body, http.StatusOK, &run)
 		assert.Equal(t, models.TaxonomyRunStatusFailed, run.Status)
 		require.NotNil(t, run.Error)
 		assert.Equal(t, "clustering did not converge", *run.Error)
+	})
+
+	t.Run("heartbeat returns the internal wire contract", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-heartbeat")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		runID := createRunningRun(ctx, t, harness, scope)
+		heartbeatURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/heartbeat"
+
+		requestTaxonomyProblem(ctx, t, http.MethodPost, heartbeatURL, "", nil,
+			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
+
+		var body map[string]string
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPost,
+			heartbeatURL,
+			harness.internalToken,
+			nil,
+			http.StatusOK,
+			&body,
+		)
+		assert.Equal(t, map[string]string{"status": "ok"}, body)
+	})
+}
+
+// TestTaxonomyAPI_InternalErrors covers missing runs, malformed identifiers, and invalid
+// terminal-state transitions across the internal taxonomy service contract.
+func TestTaxonomyAPI_InternalErrors(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+	unknownRunID := uuid.New()
+	failedBody := models.TaxonomyRunFailedRequest{
+		Error:     "generation failed",
+		ErrorCode: models.TaxonomyRunFailureCodeGenerationFailed,
+	}
+	resultBody := validTaxonomyResult(uuid.New())
+
+	t.Run("result payload validation is machine readable", func(t *testing.T) {
+		problem := requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPut,
+			harness.server.URL+"/internal/v1/taxonomy/runs/"+unknownRunID.String()+"/result",
+			harness.internalToken,
+			map[string]any{"clusters": []any{}},
+			http.StatusBadRequest,
+			response.CodeValidation,
+			response.ProblemTypeValidation,
+		)
+		assertTaxonomyInvalidParam(t, problem, "memberships", "required")
+	})
+
+	t.Run("failed payload validation is machine readable", func(t *testing.T) {
+		problem := requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPost,
+			harness.server.URL+"/internal/v1/taxonomy/runs/"+unknownRunID.String()+"/failed",
+			harness.internalToken,
+			map[string]any{"error_code": models.TaxonomyRunFailureCodeGenerationFailed},
+			http.StatusBadRequest,
+			response.CodeValidation,
+			response.ProblemTypeValidation,
+		)
+		assertTaxonomyInvalidParam(t, problem, "error", "required")
+	})
+
+	tests := []struct {
+		name   string
+		method string
+		suffix string
+		body   any
+	}{
+		{name: "input", method: http.MethodGet, suffix: "/input"},
+		{name: "result", method: http.MethodPut, suffix: "/result", body: resultBody},
+		{name: "failed", method: http.MethodPost, suffix: "/failed", body: failedBody},
+		{name: "heartbeat", method: http.MethodPost, suffix: "/heartbeat"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+" returns 404 for an unknown run", func(t *testing.T) {
+			requestTaxonomyProblem(
+				ctx,
+				t,
+				test.method,
+				harness.server.URL+"/internal/v1/taxonomy/runs/"+unknownRunID.String()+test.suffix,
+				harness.internalToken,
+				test.body,
+				http.StatusNotFound,
+				response.CodeNotFound,
+				response.ProblemTypeNotFound,
+			)
+		})
+
+		t.Run(test.name+" returns 400 for a malformed run ID", func(t *testing.T) {
+			problem := requestTaxonomyProblem(
+				ctx,
+				t,
+				test.method,
+				harness.server.URL+"/internal/v1/taxonomy/runs/not-a-uuid"+test.suffix,
+				harness.internalToken,
+				test.body,
+				http.StatusBadRequest,
+				response.CodeValidation,
+				response.ProblemTypeValidation,
+			)
+			assertTaxonomyInvalidParam(t, problem, "run_id", "valid UUID")
+		})
+	}
+
+	t.Run("completing a terminal run returns conflict", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-complete-conflict")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+		runID := createRunningRun(ctx, t, harness, scope)
+		result := validTaxonomyResult(feedbackRecordID)
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+
+		var completed models.TaxonomyRun
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPut,
+			resultURL,
+			harness.internalToken,
+			result,
+			http.StatusOK,
+			&completed,
+		)
+		require.Equal(t, models.TaxonomyRunStatusSucceeded, completed.Status)
+
+		requestTaxonomyProblem(ctx, t, http.MethodPut, resultURL, harness.internalToken, result,
+			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict)
+	})
+
+	t.Run("failing a terminal run returns conflict", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-fail-conflict")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		runID := createRunningRun(ctx, t, harness, scope)
+		failedURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/failed"
+
+		var failed models.TaxonomyRun
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPost,
+			failedURL,
+			harness.internalToken,
+			failedBody,
+			http.StatusOK,
+			&failed,
+		)
+		require.Equal(t, models.TaxonomyRunStatusFailed, failed.Status)
+
+		requestTaxonomyProblem(ctx, t, http.MethodPost, failedURL, harness.internalToken, failedBody,
+			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict)
 	})
 }
 
@@ -712,4 +1081,31 @@ func createRunningRun(ctx context.Context, t *testing.T, harness *taxonomyTestSe
 	require.NoError(t, err)
 
 	return run.ID
+}
+
+func validTaxonomyResult(feedbackRecordID uuid.UUID) models.TaxonomyRunResultRequest {
+	return models.TaxonomyRunResultRequest{
+		Clusters: []models.TaxonomyResultCluster{
+			{ClusterKey: 1, Label: new("login"), Size: 1},
+		},
+		Memberships: []models.TaxonomyResultMembership{
+			{ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9)},
+		},
+		Nodes: []models.TaxonomyResultNode{
+			{
+				NodeKey:  "root",
+				NodeType: models.TaxonomyNodeTypeRoot,
+				Label:    "Feedback",
+				Level:    0,
+			},
+			{
+				NodeKey:    "leaf",
+				ParentKey:  new("root"),
+				ClusterKey: new(1),
+				NodeType:   models.TaxonomyNodeTypeLeaf,
+				Label:      "Login",
+				Level:      1,
+			},
+		},
+	}
 }

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -75,6 +76,7 @@ func requestTaxonomyProblem(
 	assert.Equal(t, wantType, problem.Type)
 	assert.Equal(t, resp.Request.URL.Path, problem.Instance)
 	assert.NotEmpty(t, problem.Title)
+	assert.NotEmpty(t, problem.RequestID)
 
 	return problem
 }
@@ -158,6 +160,39 @@ func TestTaxonomyAPI_Auth(t *testing.T) {
 	})
 }
 
+func TestTaxonomyAPI_RoutingProblems(t *testing.T) {
+	ctx := context.Background()
+	harness := setupTaxonomyAPIServer(t)
+
+	t.Run("unknown paths use the problem contract", func(t *testing.T) {
+		requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodGet,
+			harness.server.URL+"/v1/taxonomy/not-a-route",
+			harness.apiKey,
+			nil,
+			http.StatusNotFound,
+			response.CodeNotFound,
+			response.ProblemTypeNotFound,
+		)
+	})
+
+	t.Run("wrong methods use the problem contract", func(t *testing.T) {
+		requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPost,
+			harness.server.URL+"/v1/taxonomy/fields",
+			harness.apiKey,
+			nil,
+			http.StatusMethodNotAllowed,
+			response.CodeMethodNotAllowed,
+			response.ProblemTypeMethodNotAllowed,
+		)
+	})
+}
+
 // TestTaxonomyAPI_PublicReadAndEdit covers the public read and edit endpoints against a
 // seeded, activated taxonomy graph.
 func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
@@ -166,7 +201,10 @@ func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
 
 	scope := uniqueTaxonomyScope("tax-api-read")
 	ids := seedTaxonomyGraph(ctx, t, harness.db, scope)
-	seedEmbeddedFeedback(ctx, t, harness, scope, 1)
+	seededRecordIDs := append(
+		[]uuid.UUID{ids.FeedbackRecordID},
+		seedEmbeddedFeedback(ctx, t, harness, scope, 1)...,
+	)
 
 	scopeQuery := url.Values{
 		"tenant_id":   {scope.TenantID},
@@ -187,7 +225,7 @@ func TestTaxonomyAPI_PublicReadAndEdit(t *testing.T) {
 		assert.Equal(t, scope.SourceType, resp.Data[0].SourceType)
 		assert.Equal(t, scope.SourceID, resp.Data[0].SourceID)
 		assert.Equal(t, scope.FieldID, resp.Data[0].FieldID)
-		assert.Equal(t, 2, resp.Data[0].RecordCount)
+		assert.Equal(t, len(seededRecordIDs), resp.Data[0].RecordCount)
 		assert.Equal(t, 1, resp.Data[0].EmbeddingCount)
 	})
 
@@ -473,12 +511,12 @@ func TestTaxonomyAPI_CreateRun(t *testing.T) {
 	t.Run("scope below the minimum embedded record count is rejected", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-api-create-insufficient")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
-		seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords-1)
+		seededRecordIDs := seedEmbeddedFeedback(ctx, t, harness, scope, taxonomyMinEmbeddedRecords-1)
 
 		body := models.CreateTaxonomyRunRequest{TaxonomyScope: scope}
 		problem := requestTaxonomyProblem(ctx, t, http.MethodPost, runsURL, harness.apiKey, body,
 			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation)
-		assertTaxonomyInvalidParam(t, problem, "field_id", "found 1")
+		assertTaxonomyInvalidParam(t, problem, "field_id", fmt.Sprintf("found %d", len(seededRecordIDs)))
 	})
 
 	t.Run("directory scope rejects field selectors", func(t *testing.T) {
@@ -773,18 +811,7 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
 		runID := createRunningRun(ctx, t, harness, scope)
 
-		result := models.TaxonomyRunResultRequest{
-			Clusters: []models.TaxonomyResultCluster{
-				{ClusterKey: 1, Label: new("login"), Size: 1},
-			},
-			Memberships: []models.TaxonomyResultMembership{
-				{ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9)},
-			},
-			Nodes: []models.TaxonomyResultNode{
-				{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
-				{NodeKey: "leaf", ParentKey: new("root"), ClusterKey: new(1), NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 1},
-			},
-		}
+		result := validTaxonomyResult(feedbackRecordID)
 
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 

--- a/tests/taxonomy_support_test.go
+++ b/tests/taxonomy_support_test.go
@@ -181,7 +181,7 @@ func setupTaxonomyAPIServer(t *testing.T, options ...taxonomyAPIServerOption) *t
 	mux.Handle("/v1/", protectedWithAuth)
 	mux.Handle("/internal/v1/taxonomy/", internalWithAuth)
 
-	server := httptest.NewServer(mux)
+	server := httptest.NewServer(middleware.RequestID(middleware.ProblemErrors(mux)))
 
 	t.Cleanup(func() {
 		server.Close()

--- a/tests/taxonomy_support_test.go
+++ b/tests/taxonomy_support_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/formbricks/hub/internal/api/handlers"
 	"github.com/formbricks/hub/internal/api/middleware"
+	"github.com/formbricks/hub/internal/api/routes"
 	"github.com/formbricks/hub/internal/config"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/repository"
@@ -98,12 +99,39 @@ type taxonomyTestServer struct {
 	apiKey         string
 }
 
+type taxonomyAPIServerConfig struct {
+	embeddingModel string
+	starterEnabled bool
+}
+
+type taxonomyAPIServerOption func(*taxonomyAPIServerConfig)
+
+func withTaxonomyEmbeddingModel(model string) taxonomyAPIServerOption {
+	return func(config *taxonomyAPIServerConfig) {
+		config.embeddingModel = model
+	}
+}
+
+func withoutTaxonomyStarter() taxonomyAPIServerOption {
+	return func(config *taxonomyAPIServerConfig) {
+		config.starterEnabled = false
+	}
+}
+
 // setupTaxonomyAPIServer builds an httptest server that mirrors cmd/api/app.go's taxonomy
 // wiring: public taxonomy routes behind the Hub API key, and the internal taxonomy routes
 // behind a separate internal token. It returns the server plus the repo/embeddings/starter
 // so tests can seed data and inspect start calls.
-func setupTaxonomyAPIServer(t *testing.T) *taxonomyTestServer {
+func setupTaxonomyAPIServer(t *testing.T, options ...taxonomyAPIServerOption) *taxonomyTestServer {
 	t.Helper()
+
+	serverConfig := taxonomyAPIServerConfig{
+		embeddingModel: taxonomyEmbeddingModel,
+		starterEnabled: true,
+	}
+	for _, option := range options {
+		option(&serverConfig)
+	}
 
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -125,36 +153,28 @@ func setupTaxonomyAPIServer(t *testing.T) *taxonomyTestServer {
 	embeddingsRepo := repository.NewEmbeddingsRepository(db)
 	starter := &fakeTaxonomyStarter{}
 
+	var runStarter service.TaxonomyRunStarter
+	if serverConfig.starterEnabled {
+		runStarter = starter
+	}
+
 	taxonomyService := service.NewTaxonomyService(service.NewTaxonomyServiceParams{
 		Repo:                  repo,
-		Starter:               starter,
-		EmbeddingModel:        taxonomyEmbeddingModel,
+		Starter:               runStarter,
+		EmbeddingModel:        serverConfig.embeddingModel,
 		MinimumEmbeddingCount: taxonomyMinEmbeddedRecords,
 	})
 	taxonomyHandler := handlers.NewTaxonomyHandler(taxonomyService)
 	taxonomyInternalHandler := handlers.NewTaxonomyInternalHandler(taxonomyService)
 
-	// Public taxonomy routes (Hub API key auth), matching cmd/api/app.go ordering so the
-	// {run_id} literal-vs-pattern precedence (active/tree before {run_id}) is preserved.
+	// Public taxonomy routes (Hub API key auth), using the same registry as cmd/api/app.go.
 	protected := http.NewServeMux()
-	protected.HandleFunc("GET /v1/taxonomy/fields", taxonomyHandler.ListFields)
-	protected.HandleFunc("POST /v1/taxonomy/runs", taxonomyHandler.CreateRun)
-	protected.HandleFunc("GET /v1/taxonomy/runs", taxonomyHandler.ListRuns)
-	protected.HandleFunc("GET /v1/taxonomy/runs/active/tree", taxonomyHandler.GetActiveTree)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}", taxonomyHandler.GetRun)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/tree", taxonomyHandler.GetTree)
-	protected.HandleFunc("GET /v1/taxonomy/runs/{run_id}/record-counts", taxonomyHandler.RecordCounts)
-	protected.HandleFunc("PATCH /v1/taxonomy/nodes/{node_id}", taxonomyHandler.RenameNode)
-	protected.HandleFunc("DELETE /v1/taxonomy/nodes/{node_id}", taxonomyHandler.RemoveNode)
-	protected.HandleFunc("GET /v1/taxonomy/nodes/{node_id}/records", taxonomyHandler.ListNodeRecords)
+	routes.RegisterPublicTaxonomy(protected, taxonomyHandler)
 	protectedWithAuth := middleware.Auth(cfg.Server.HubAPIKey)(protected)
 
 	// Internal taxonomy routes (separate internal-service token auth).
 	internal := http.NewServeMux()
-	internal.HandleFunc("GET /internal/v1/taxonomy/auth-check", taxonomyInternalHandler.AuthCheck)
-	internal.HandleFunc("GET /internal/v1/taxonomy/runs/{run_id}/input", taxonomyInternalHandler.GetRunInput)
-	internal.HandleFunc("PUT /internal/v1/taxonomy/runs/{run_id}/result", taxonomyInternalHandler.CompleteRun)
-	internal.HandleFunc("POST /internal/v1/taxonomy/runs/{run_id}/failed", taxonomyInternalHandler.FailRun)
+	routes.RegisterInternalTaxonomy(internal, taxonomyInternalHandler)
 	internalWithAuth := middleware.Auth(testInternalToken)(internal)
 
 	mux := http.NewServeMux()
@@ -296,8 +316,10 @@ func seedTaxonomyGraph(ctx context.Context, t *testing.T, db *pgxpool.Pool, scop
 // embedding under taxonomyEmbeddingModel, so StartManualRun's input counts are satisfied.
 func seedEmbeddedFeedback(
 	ctx context.Context, t *testing.T, harness *taxonomyTestServer, scope models.TaxonomyScope, count int,
-) {
+) []uuid.UUID {
 	t.Helper()
+
+	recordIDs := make([]uuid.UUID, 0, count)
 
 	for range count {
 		var recordID uuid.UUID
@@ -319,11 +341,14 @@ func seedEmbeddedFeedback(
 
 		// nil stillCurrent: unconditional write (test setup, no concurrent-job race to guard).
 		require.NoError(t, harness.embeddingsRepo.Upsert(ctx, recordID, taxonomyEmbeddingModel, embedding, nil))
+		recordIDs = append(recordIDs, recordID)
 	}
 
 	t.Cleanup(func() {
 		_, _ = harness.db.Exec(ctx, `DELETE FROM feedback_records WHERE tenant_id = $1`, scope.TenantID)
 	})
+
+	return recordIDs
 }
 
 // doTaxonomyRequest issues an HTTP request against the taxonomy test server. When token is


### PR DESCRIPTION
## Summary

- centralize public and internal taxonomy route registration so production and integration tests cannot drift
- verify the public route inventory, operation IDs, and response statuses bidirectionally against `openapi.yaml` while keeping internal routes private
- extend taxonomy HTTP contracts for RFC 9457 errors, heartbeat, service availability, missing/invalid runs, invalid transitions, and tenant isolation

Linear: [ENG-1202](https://linear.app/formbricks/issue/ENG-1202/add-hub-api-contract-tests)

## Validation

- `go test -run "^TestTaxonomyAPI" -count=1 ./tests`
- `go test ./tests/... -count=1 -timeout 120s` against a migrated pgvector Postgres database
- `make test-unit`
- `make build`
- `make lint-new`
- `make lint-openapi`
- downstream taxonomy client: `uv run pytest tests/test_hub_client.py tests/test_start_run.py tests/test_taxonomy_domain.py -q` (`34 passed`)
