### PR TITLE
fix(taxonomy): 404 node records on a tenant mismatch (ENG-1887)

### DIFF
--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -1038,12 +1038,22 @@ func (r *TaxonomyRepository) RemoveNode(
 }
 
 // ListNodeRecords returns feedback records assigned to a visible taxonomy node or descendants.
+// The node must be visible and belong to the tenant, otherwise a not-found error is returned —
+// the same contract as every other node-scoped operation.
 func (r *TaxonomyRepository) ListNodeRecords(
 	ctx context.Context,
 	nodeID uuid.UUID,
 	tenantID string,
 	limit int,
 ) ([]models.FeedbackRecord, int, error) {
+	// The records query below is already tenant-safe on its own (it filters on the run's tenant, so a
+	// foreign node simply matches no rows). This guard is about the contract, not isolation: without it
+	// a foreign or removed node is indistinguishable from one that genuinely holds no records, which is
+	// what CountNodeRecords, GetTree, RenameNode and RemoveNode all avoid by resolving ownership first.
+	if _, err := r.GetNodeForTenant(ctx, nodeID, tenantID); err != nil {
+		return nil, 0, err
+	}
+
 	if limit <= 0 {
 		limit = defaultTaxonomyNodeRecordLimit
 	}
@@ -1097,6 +1107,28 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	}
 
 	return records, limit, nil
+}
+
+// GetNodeForTenant returns a visible taxonomy node addressable by the tenant, or a not-found error.
+// The read-only counterpart of getNodeForUpdate: same ownership predicate, no row lock, no transaction.
+func (r *TaxonomyRepository) GetNodeForTenant(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyNode, error) {
+	node, err := queryTaxonomyNode(ctx, r.db, taxonomyNodeSelect+`
+		FROM taxonomy_nodes`+taxonomyNodeForTenantWhere,
+		nodeID, tenantID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_node", "taxonomy node not found")
+		}
+
+		return nil, fmt.Errorf("get taxonomy node for tenant: %w", err)
+	}
+
+	return node, nil
 }
 
 func (r *TaxonomyRepository) queryRunInputRows(
@@ -1342,6 +1374,16 @@ func scanTaxonomyNode(row scanner) (*models.TaxonomyNode, error) {
 	return &node, nil
 }
 
+// A node is addressable by a tenant when it is visible and its run belongs to that tenant. Shared by
+// the locking write path and the read path so the two can never drift apart on what "yours" means.
+// $1 is the node id, $2 the tenant id.
+const taxonomyNodeForTenantWhere = `
+		WHERE id = $1 AND removed_at IS NULL
+		  AND EXISTS (
+		    SELECT 1 FROM taxonomy_runs
+		    WHERE taxonomy_runs.id = taxonomy_nodes.run_id AND taxonomy_runs.tenant_id = $2
+		  )`
+
 // getNodeForUpdate takes a tenantWriteTx (not the narrower queryer) so the
 // compiler enforces that the SELECT ... FOR UPDATE row lock is held for the
 // life of a transaction; outside one, the lock would release at statement end.
@@ -1354,12 +1396,7 @@ func getNodeForUpdate(
 	// The tenant predicate keeps the row lock tenant-scoped: a caller can never
 	// lock another tenant's node row, even transiently.
 	node, err := queryTaxonomyNode(ctx, transaction, taxonomyNodeSelect+`
-		FROM taxonomy_nodes
-		WHERE id = $1 AND removed_at IS NULL
-		  AND EXISTS (
-		    SELECT 1 FROM taxonomy_runs
-		    WHERE taxonomy_runs.id = taxonomy_nodes.run_id AND taxonomy_runs.tenant_id = $2
-		  )
+		FROM taxonomy_nodes`+taxonomyNodeForTenantWhere+`
 		FOR UPDATE`,
 		nodeID, tenantID,
 	)

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -1046,19 +1046,33 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	tenantID string,
 	limit int,
 ) ([]models.FeedbackRecord, int, error) {
-	// The records query below is already tenant-safe on its own (it filters on the run's tenant, so a
-	// foreign node simply matches no rows). This guard is about the contract, not isolation: without it
-	// a foreign or removed node is indistinguishable from one that genuinely holds no records, which is
-	// what CountNodeRecords, GetTree, RenameNode and RemoveNode all avoid by resolving ownership first.
-	if _, err := r.GetNodeForTenant(ctx, nodeID, tenantID); err != nil {
-		return nil, 0, err
-	}
-
 	if limit <= 0 {
 		limit = defaultTaxonomyNodeRecordLimit
 	}
 
-	rows, err := r.db.Query(ctx, `
+	// The records query below is already tenant-safe on its own (it filters on the run's tenant, so a
+	// foreign node simply matches no rows). The ownership guard is about the contract, not isolation:
+	// without it a foreign or removed node is indistinguishable from one that genuinely holds no
+	// records, which is what CountNodeRecords, GetTree, RenameNode and RemoveNode all avoid by
+	// resolving ownership first.
+	//
+	// Both reads share one REPEATABLE READ snapshot. On separate statements a RemoveNode committing
+	// between them would pass the guard and then match no rows in the recursive CTE, handing back the
+	// ambiguous 200-empty this contract exists to remove. Under one snapshot the node is either
+	// visible to both reads or to neither, so a removal mid-request lands as a 404. Read-only, so the
+	// deferred rollback is the only exit.
+	dbTx, err := r.db.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, 0, fmt.Errorf("begin taxonomy node records tx: %w", err)
+	}
+
+	defer rollbackQuietly(ctx, dbTx, "list taxonomy node records: rollback failed")
+
+	if _, err := getNodeForTenant(ctx, dbTx, nodeID, tenantID); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := dbTx.Query(ctx, `
 		WITH RECURSIVE visible_nodes AS (
 			SELECT id, run_id, cluster_id
 			FROM taxonomy_nodes
@@ -1107,28 +1121,6 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	}
 
 	return records, limit, nil
-}
-
-// GetNodeForTenant returns a visible taxonomy node addressable by the tenant, or a not-found error.
-// The read-only counterpart of getNodeForUpdate: same ownership predicate, no row lock, no transaction.
-func (r *TaxonomyRepository) GetNodeForTenant(
-	ctx context.Context,
-	nodeID uuid.UUID,
-	tenantID string,
-) (*models.TaxonomyNode, error) {
-	node, err := queryTaxonomyNode(ctx, r.db, taxonomyNodeSelect+`
-		FROM taxonomy_nodes`+taxonomyNodeForTenantWhere,
-		nodeID, tenantID,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, huberrors.NewNotFoundError("taxonomy_node", "taxonomy node not found")
-		}
-
-		return nil, fmt.Errorf("get taxonomy node for tenant: %w", err)
-	}
-
-	return node, nil
 }
 
 func (r *TaxonomyRepository) queryRunInputRows(
@@ -1383,6 +1375,31 @@ const taxonomyNodeForTenantWhere = `
 		    SELECT 1 FROM taxonomy_runs
 		    WHERE taxonomy_runs.id = taxonomy_nodes.run_id AND taxonomy_runs.tenant_id = $2
 		  )`
+
+// getNodeForTenant returns a visible taxonomy node addressable by the tenant, or a not-found error.
+// The read-only counterpart of getNodeForUpdate: same ownership predicate, no row lock. It takes a
+// queryer so the caller decides the snapshot — ListNodeRecords passes its transaction so the check
+// and the records read cannot disagree about whether the node is still there.
+func getNodeForTenant(
+	ctx context.Context,
+	q queryer,
+	nodeID uuid.UUID,
+	tenantID string,
+) (*models.TaxonomyNode, error) {
+	node, err := queryTaxonomyNode(ctx, q, taxonomyNodeSelect+`
+		FROM taxonomy_nodes`+taxonomyNodeForTenantWhere,
+		nodeID, tenantID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, huberrors.NewNotFoundError("taxonomy_node", "taxonomy node not found")
+		}
+
+		return nil, fmt.Errorf("get taxonomy node for tenant: %w", err)
+	}
+
+	return node, nil
+}
 
 // getNodeForUpdate takes a tenantWriteTx (not the narrower queryer) so the
 // compiler enforces that the SELECT ... FOR UPDATE row lock is held for the

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2080,7 +2080,9 @@ paths:
             summary: List feedback records for a taxonomy node
             description: |
                 Returns the feedback records assigned to a node and all of its (visible) descendant nodes, via the
-                clusters those nodes reference. Tenant-scoped. The `limit` in the response reflects the applied cap.
+                clusters those nodes reference. Tenant-scoped; returns 404 if the node does not belong to the tenant
+                or has been removed. An empty `data` therefore means the node genuinely holds no records. The `limit`
+                in the response reflects the applied cap.
             operationId: list-taxonomy-node-records
             parameters:
                 - name: node_id
@@ -2125,6 +2127,12 @@ paths:
                                 $ref: '#/components/schemas/ErrorModel'
                 "401":
                     description: Unauthorized (missing or invalid API key)
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+                "404":
+                    description: Not Found – no node with this ID for the tenant.
                     content:
                         application/problem+json:
                             schema:

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -223,12 +223,11 @@ func TestTaxonomyAPI_TenantIsolation(t *testing.T) {
 			taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.BranchID.String(), removeQuery), harness.apiKey, nil, http.StatusNotFound, nil)
 	})
 
-	t.Run("node records return nothing for another tenant", func(t *testing.T) {
+	t.Run("node records 404 for another tenant", func(t *testing.T) {
+		// Not 200-with-empty: that would make a foreign node indistinguishable from one of your own
+		// that holds no records. Same contract as the run, tree, rename and remove cases above.
 		recordsURL := taxonomyURL(harness.server.URL, "/v1/taxonomy/nodes/"+ids.RootID.String()+"/records", otherQuery)
-
-		var resp models.TaxonomyNodeRecordsResponse
-		requestTaxonomyJSON(ctx, t, http.MethodGet, recordsURL, harness.apiKey, nil, http.StatusOK, &resp)
-		require.Empty(t, resp.Data)
+		requestTaxonomyJSON(ctx, t, http.MethodGet, recordsURL, harness.apiKey, nil, http.StatusNotFound, nil)
 	})
 }
 

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -466,10 +466,27 @@ func TestTaxonomyRepository_ListNodeRecords(t *testing.T) {
 	require.Len(t, records, 1)
 	require.Equal(t, ids.FeedbackRecordID, records[0].ID)
 
-	// A different tenant sees nothing for the same node id.
-	otherTenantRecords, _, err := repo.ListNodeRecords(ctx, ids.RootID, "other-tenant-"+uuid.NewString(), 50)
+	// A different tenant cannot address the node at all — not even to be told it is empty.
+	_, _, err = repo.ListNodeRecords(ctx, ids.RootID, "other-tenant-"+uuid.NewString(), 50)
+	require.ErrorIs(t, err, huberrors.ErrNotFound, "node records must be tenant-scoped")
+
+	// An unknown node id is the same not-found, so ownership is never enumerable.
+	_, _, err = repo.ListNodeRecords(ctx, uuid.New(), scope.TenantID, 50)
+	require.ErrorIs(t, err, huberrors.ErrNotFound)
+
+	// A soft-removed node is not addressable either, matching rename and remove: the tree has already
+	// dropped it, so a caller asking for its records is working from stale state.
+	_, err = repo.RemoveNode(ctx, ids.LeafID, scope.TenantID, "actor-remove")
 	require.NoError(t, err)
-	require.Empty(t, otherTenantRecords, "node records must be tenant-scoped")
+
+	_, _, err = repo.ListNodeRecords(ctx, ids.LeafID, scope.TenantID, 50)
+	require.ErrorIs(t, err, huberrors.ErrNotFound)
+
+	// The root survives and now genuinely holds no records, because the removed leaf carried the only
+	// cluster membership. That empty result is only meaningful because the cases above are 404s.
+	rootRecords, _, err := repo.ListNodeRecords(ctx, ids.RootID, scope.TenantID, 50)
+	require.NoError(t, err)
+	require.Empty(t, rootRecords)
 }
 
 // TestTaxonomyRepository_TenantIsolation proves every tenant-scoped read and mutation refuses
@@ -498,6 +515,11 @@ func TestTaxonomyRepository_TenantIsolation(t *testing.T) {
 
 	t.Run("get tree refuses another tenant", func(t *testing.T) {
 		_, err := repo.GetTree(ctx, ids.RunID, otherTenant)
+		require.ErrorIs(t, err, huberrors.ErrNotFound)
+	})
+
+	t.Run("node records refuse another tenant", func(t *testing.T) {
+		_, _, err := repo.ListNodeRecords(ctx, ids.RootID, otherTenant, 50)
 		require.ErrorIs(t, err, huberrors.ErrNotFound)
 	})
 


### PR DESCRIPTION
## What does this PR do?

Linear: https://linear.app/formbricks/issue/ENG-1887/triage-drilldown-nodesidrecords-returns-200-empty-not-404-on-tenant

`GET /v1/taxonomy/nodes/{node_id}/records` returned **200 with an empty `data`** when the node belonged to another tenant, while every sibling node-scoped operation returns **404** for the same mismatch:

| Endpoint | On tenant mismatch |
| --- | --- |
| `GET /v1/taxonomy/runs/{run_id}` | 404 |
| `GET /v1/taxonomy/runs/{run_id}/tree` | 404 |
| `GET /v1/taxonomy/runs/{run_id}/record-counts` | 404 |
| `PATCH /v1/taxonomy/nodes/{node_id}` (rename) | 404 |
| `DELETE /v1/taxonomy/nodes/{node_id}` (soft remove) | 404 |
| `GET /v1/taxonomy/nodes/{node_id}/records` | **200 + empty** ← the odd one out |

**Nothing leaked.** The tenant is a predicate on the records query (`WHERE tr.tenant_id = $2`), so a foreign node simply matches no rows. This is a contract problem, not an isolation one — surfaced by the ENG-1214 tenant-isolation verification, which confirmed zero cross-tenant records.

The problem is that the answer was ambiguous. "Empty" meant three different things at once and a caller could not tell them apart:

1. the node is yours and genuinely holds no records
2. the node belongs to someone else
3. the node does not exist

### The change

`ListNodeRecords` now resolves ownership **before** running the records query — the same shape `CountNodeRecords` and `GetTree` already use:

```go
if _, err := r.GetNodeForTenant(ctx, nodeID, tenantID); err != nil {
    return nil, 0, err
}
```

`getNodeForTenant` is the read-only counterpart of the existing `getNodeForUpdate`: same ownership predicate, no row lock. The predicate itself moves into a shared `taxonomyNodeForTenantWhere` const so the locking write path and the read path cannot drift on what "yours" means.

Both reads run inside **one `REPEATABLE READ`, read-only transaction**. That matters: on separate statements each read gets its own `READ COMMITTED` snapshot, so a `RemoveNode` committing between them would pass the guard and then match no rows in the CTE anchor (`WHERE id = $1 AND removed_at IS NULL`) — handing back the very 200-empty this contract exists to remove. Worse, it would not even be a state that ever existed: soft-remove leaves cluster memberships intact, so the node held records at guard time and holds them still.

Postgres takes the `REPEATABLE READ` snapshot at the **first statement**, so the node is either visible to both reads or to neither — a removal landing after the guard still returns the records, one landing before it returns 404. Read-only, so there is no write conflict to serialize against (`could not serialize access` cannot occur here) and the deferred `rollbackQuietly` is the only exit.

Ownership stays **non-enumerable**: an unknown node id, a foreign node and a removed node are all the same 404.

`openapi.yaml` documents the 404 on the endpoint and drops the now-inaccurate description. That regenerates the `listRecords` SDK docstring, which promised only *"Tenant-scoped"* while `rename` / `softRemove` already promised *"404 if the node does not belong to the tenant"*.

### Behaviour change to be aware of

A **soft-removed node of your own tenant** now 404s where it previously returned 200-empty. That is deliberate:

- it matches `rename` and `softRemove`, which already 404 on a removed node;
- the tree has already dropped the node, so a caller asking for its records is working from stale state.

If we would rather keep removed nodes readable, it is one line — drop `removed_at IS NULL` from the shared const.

### API behaviour: before / after

Request, with `node_id` owned by tenant `org-A`:

```
GET /v1/taxonomy/nodes/019f177f-9abe-78cd-8008-f40b58e3147d/records?tenant_id=org-B
```

Before:

```
HTTP/1.1 200 OK
Content-Type: application/json

{ "data": [], "limit": 50 }
```

After:

```
HTTP/1.1 404 Not Found
Content-Type: application/problem+json

{
  "type": "https://hub.formbricks.com/problems/not-found",
  "title": "Not Found",
  "status": 404,
  "detail": "taxonomy node not found",
  "code": "taxonomy_node"
}
```

A node that is yours and genuinely holds no records still returns `200 { "data": [], "limit": … }` — and now that answer actually means something.

### Consumers

`ListNodeRecords` has exactly one caller — the public endpoint itself. No worker or internal service depends on it, so the blast radius is that one route.

On the Formbricks Web side, [ENG-1886](https://linear.app/formbricks/issue/ENG-1886) (formbricks#8707) already maps a Hub 404 on this call to a 404 of its own. That mapping is currently unreachable because the Hub never sends one; once this merges it starts working with **no further change on the web side**.

## How should this be tested?

Automated (all run locally against `compose.yml` Postgres on `POSTGRES_PORT=5433`, migrations at version 20):

- `make build` → both binaries built ✅
- `make tests` → `ok github.com/formbricks/hub/tests` ✅
- `go test ./...` → all 17 packages green ✅
- `make fmt` + `make lint` → `0 issues` ✅
- `make lint-openapi` → `No results with a severity of 'error' found!` ✅
- Pre-commit hook (fmt + lint + unit tests) passed on commit ✅

Tests updated — both places that pinned the old behaviour, plus new coverage:

| Test | Now asserts |
| --- | --- |
| `tests/taxonomy_api_test.go` → `node records 404 for another tenant` | HTTP **404** (was 200 + empty), alongside the existing run / tree / rename / remove 404 cases |
| `tests/taxonomy_persistence_test.go` → `TestTaxonomyRepository_ListNodeRecords` | foreign tenant → `ErrNotFound`; unknown node id → the same `ErrNotFound`; soft-removed node → `ErrNotFound`; surviving root → **200-empty**, which is now a meaningful answer |
| `tests/taxonomy_persistence_test.go` → `TestTaxonomyRepository_TenantIsolation` | new `node records refuse another tenant` subtest, so the isolation suite covers every tenant-scoped op as its docstring claims |

**Not covered by a test: the concurrent-removal window itself.** Exercising it needs a removal to commit *between* the two statements inside `ListNodeRecords`, which would require a test seam in the method; any goroutine-and-sleep approximation would be flaky. The contract either side of the race is covered by the tests above, and the snapshot change is exercised by the whole suite still passing. Happy to add the seam and a deterministic test if reviewers would rather have it.

Manual reproduction against a local Hub:

1. Seed a taxonomy for tenant `org-A` and note a node id from the tree.
2. `GET /v1/taxonomy/nodes/{node_id}/records?tenant_id=org-A` → **200** with the assigned records.
3. Same node id with `?tenant_id=org-B` → **404** `application/problem+json` (was 200 + `"data": []`).
4. A random UUID with `?tenant_id=org-A` → the same **404**, so ownership is not enumerable.
5. `DELETE` the node, then re-run step 2 → **404**.
6. A node of your own that has no cluster memberships → still **200** with `"data": []`.

Test configuration: `DATABASE_URL=postgres://postgres:postgres@localhost:5433/test_db?sslmode=disable`, API key from `.env`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` — n/a, no schema change

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary — n/a, the endpoint's contract lives in `openapi.yaml`, which is updated here
- [ ] Ran `make tests-coverage` for meaningful logic changes
