### PR TITLE
feat(embeddings): batch worker requests and control backfills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,9 @@ WEBHOOK_MAX_COUNT=500
 # EMBEDDING_NORMALIZE=false          (optional; L2-normalize vectors client-side; cosine similarity is scale-invariant, so usually unneeded)
 # EMBEDDING_MAX_CONCURRENT=5         (worker concurrency; default 5)
 # EMBEDDING_MAX_ATTEMPTS=3           (River job retries before failing; default 3)
+# EMBEDDING_BATCH_SIZE=1             (document micro-batch size; 1 disables batching; provider must support batches)
+# EMBEDDING_BATCH_MAX_WAIT_MS=25     (maximum time to collect a partial batch; default 25ms)
+# EMBEDDING_BATCH_MAX_IN_FLIGHT=1    (maximum concurrent provider batch requests; default 1)
 
 # Translation (language enrichment) is optional. To enable, set both TRANSLATION_PROVIDER and TRANSLATION_MODEL; if either is unset, translation is disabled and no translation jobs run.
 # Open-text feedback (value_text) is translated into each tenant's configured target_language (Hub tenant settings), falling back to TRANSLATION_DEFAULT_LANGUAGE when a tenant has none. Same providers/auth model as embeddings.

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,11 @@ RUN mkdir -p /tmp/migration-tools && \
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Build the application (hub-api and hub-worker)
+# Build the application and controlled embedding backfill utility.
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/bin/hub-api ./cmd/api && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/bin/hub-worker ./cmd/worker
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/bin/hub-worker ./cmd/worker && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/bin/backfill-embeddings ./cmd/backfill-embeddings
 
 # =============================================================================
 # Stage 2: Runtime (default: hub-api)
@@ -60,6 +61,7 @@ WORKDIR /app
 # Copy binaries and migration tools from builder
 COPY --from=builder /build/bin/hub-api /app/hub-api
 COPY --from=builder /build/bin/hub-worker /app/hub-worker
+COPY --from=builder /build/bin/backfill-embeddings /app/backfill-embeddings
 COPY --from=builder /go/bin/goose /usr/local/bin/goose
 COPY --from=builder /go/bin/river /usr/local/bin/river
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,11 @@ USER app
 
 EXPOSE 8080
 
-# Health check for hub-api. Disable or override when running hub-worker (e.g. docker run ... hub-worker)
-# since workers do not expose HTTP.
+# Health check only hub-api. hub-worker and backfill-embeddings do not expose HTTP, so commands
+# that reuse this image must not inherit a failing API probe.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+	CMD [ "$(readlink /proc/1/exe)" != "/app/hub-api" ] || wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
-# Default: run hub-api. Override with command to run hub-worker: docker run ... hub-worker
+# Default: run hub-api. Override the entrypoint for another binary, for example
+# docker run --entrypoint /app/hub-worker ... or --entrypoint /app/backfill-embeddings ...
 ENTRYPOINT ["/app/hub-api"]

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -612,14 +612,8 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	if a.metrics != nil && a.metrics.EnrichmentBacklog != nil {
-		embeddingProvider, embeddingModel := embeddingProviderAndModel(a.cfg)
-
-		taxonomyEmbeddingModel := ""
-		if embeddingProvider != "" &&
-			(a.cfg.Taxonomy.ServiceURL != "" || a.cfg.Taxonomy.ServiceToken != "") {
-			taxonomyEmbeddingModel = service.TaxonomyEmbeddingModel(
-				embeddingModel, a.cfg.Taxonomy.EmbeddingModel)
-		}
+		translationConfigured := a.cfg.Translation.Provider != "" && a.cfg.Translation.Model != ""
+		taxonomyEmbeddingModel := taxonomyEmbeddingBacklogModel(a.cfg)
 
 		// Tracked, unlike the pollers above, because this one has cleanup that Shutdown must not
 		// race: it withdraws the backlog series and releases the leader's advisory lock on the way
@@ -634,7 +628,7 @@ func (a *App) Run(ctx context.Context) error {
 				// Trim to stay consistent with NewEnrichmentStatusService (config already canonicalizes
 				// this, so it's defensive symmetry) — the endpoint and the gauge resolve the same target.
 				defaultLang:            strings.TrimSpace(a.cfg.Translation.DefaultLanguage),
-				translationConfigured:  a.cfg.Translation.Provider != "" && a.cfg.Translation.Model != "",
+				translationConfigured:  translationConfigured,
 				sentimentConfigured:    a.cfg.Sentiment.Enabled(),
 				emotionsConfigured:     a.cfg.Emotions.Enabled(),
 				taxonomyEmbeddingModel: taxonomyEmbeddingModel,
@@ -666,6 +660,19 @@ func (a *App) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		return nil
 	}
+}
+
+// taxonomyEmbeddingBacklogModel returns the model whose missing text records should be reported.
+// Taxonomy embeddings are produced by successful translation writes, so the gauge is absent unless
+// embeddings, translation, and the taxonomy integration are all configured.
+func taxonomyEmbeddingBacklogModel(cfg *config.Config) string {
+	provider, embeddingModel := embeddingProviderAndModel(cfg)
+	if provider == "" || cfg.Translation.Provider == "" || cfg.Translation.Model == "" ||
+		(cfg.Taxonomy.ServiceURL == "" && cfg.Taxonomy.ServiceToken == "") {
+		return ""
+	}
+
+	return service.TaxonomyEmbeddingModel(embeddingModel, cfg.Taxonomy.EmbeddingModel)
 }
 
 // riverDepthQueues is the fixed queue set the depth poller reports — every queue the Hub

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -612,6 +612,15 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	if a.metrics != nil && a.metrics.EnrichmentBacklog != nil {
+		embeddingProvider, embeddingModel := embeddingProviderAndModel(a.cfg)
+
+		taxonomyEmbeddingModel := ""
+		if embeddingProvider != "" &&
+			(a.cfg.Taxonomy.ServiceURL != "" || a.cfg.Taxonomy.ServiceToken != "") {
+			taxonomyEmbeddingModel = service.TaxonomyEmbeddingModel(
+				embeddingModel, a.cfg.Taxonomy.EmbeddingModel)
+		}
+
 		// Tracked, unlike the pollers above, because this one has cleanup that Shutdown must not
 		// race: it withdraws the backlog series and releases the leader's advisory lock on the way
 		// out. See App.awaitEnrichmentBacklogPoller.
@@ -624,10 +633,11 @@ func (a *App) Run(ctx context.Context) error {
 			runEnrichmentBacklogPoller(ctx, a.db, a.metrics.EnrichmentBacklog, enrichmentBacklogPollConfig{
 				// Trim to stay consistent with NewEnrichmentStatusService (config already canonicalizes
 				// this, so it's defensive symmetry) — the endpoint and the gauge resolve the same target.
-				defaultLang:           strings.TrimSpace(a.cfg.Translation.DefaultLanguage),
-				translationConfigured: a.cfg.Translation.Provider != "" && a.cfg.Translation.Model != "",
-				sentimentConfigured:   a.cfg.Sentiment.Enabled(),
-				emotionsConfigured:    a.cfg.Emotions.Enabled(),
+				defaultLang:            strings.TrimSpace(a.cfg.Translation.DefaultLanguage),
+				translationConfigured:  a.cfg.Translation.Provider != "" && a.cfg.Translation.Model != "",
+				sentimentConfigured:    a.cfg.Sentiment.Enabled(),
+				emotionsConfigured:     a.cfg.Emotions.Enabled(),
+				taxonomyEmbeddingModel: taxonomyEmbeddingModel,
 			})
 		}()
 	}
@@ -667,10 +677,11 @@ var riverDepthQueues = service.JobQueueNames()
 // enrichmentBacklogPollConfig configures runEnrichmentBacklogPoller: the deployment default target
 // language and which enrichments are deployment-configured (only those emit a gauge).
 type enrichmentBacklogPollConfig struct {
-	defaultLang           string
-	translationConfigured bool
-	sentimentConfigured   bool
-	emotionsConfigured    bool
+	defaultLang            string
+	translationConfigured  bool
+	sentimentConfigured    bool
+	emotionsConfigured     bool
+	taxonomyEmbeddingModel string
 }
 
 // runEnrichmentBacklogPoller periodically refreshes the aggregate enrichment-backlog gauge
@@ -702,7 +713,8 @@ func runEnrichmentBacklogPoller(
 		defer cancel()
 
 		// Exactly one replica holds leadership and scans; the rest skip until it goes away.
-		counts, isLeader, err := leader.CountIfLeader(queryCtx, cfg.defaultLang)
+		counts, isLeader, err := leader.CountIfLeader(
+			queryCtx, cfg.defaultLang, cfg.taxonomyEmbeddingModel)
 		if err != nil {
 			// Shutdown cancels the scan mid-flight. That is not a poll failure, and counting it
 			// would fire the very alert this counter exists for on every rolling deploy.
@@ -753,6 +765,11 @@ func runEnrichmentBacklogPoller(
 
 		if cfg.emotionsConfigured {
 			backlog.SetEnrichmentPending(observability.EnrichmentTypeEmotions, counts.EmotionsEligible-counts.EmotionsDone)
+		}
+
+		if cfg.taxonomyEmbeddingModel != "" {
+			backlog.SetEnrichmentPending(
+				observability.EnrichmentTypeTaxonomyEmbedding, counts.TaxonomyEmbeddingPending)
 		}
 	}
 

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -76,6 +76,48 @@ func TestEmbeddingProviderAndModel(t *testing.T) {
 	}
 }
 
+func TestTaxonomyEmbeddingBacklogModelRequiresCompletePipeline(t *testing.T) {
+	complete := config.Config{
+		Embedding: config.EmbeddingConfig{
+			Provider: service.EmbeddingProviderOpenAI,
+			Model:    "embedding-model",
+		},
+		Translation: config.TranslationConfig{
+			Provider: "openai",
+			Model:    "translation-model",
+		},
+		Taxonomy: config.TaxonomyConfig{
+			ServiceURL:     "http://taxonomy",
+			EmbeddingModel: "taxonomy-model",
+		},
+	}
+
+	if got := taxonomyEmbeddingBacklogModel(&complete); got != "taxonomy-model" {
+		t.Fatalf("taxonomyEmbeddingBacklogModel(complete) = %q, want taxonomy-model", got)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{name: "embeddings disabled", mutate: func(cfg *config.Config) { cfg.Embedding.Provider = "" }},
+		{name: "translation provider missing", mutate: func(cfg *config.Config) { cfg.Translation.Provider = "" }},
+		{name: "translation model missing", mutate: func(cfg *config.Config) { cfg.Translation.Model = "" }},
+		{name: "taxonomy disabled", mutate: func(cfg *config.Config) { cfg.Taxonomy.ServiceURL = "" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := complete
+			tt.mutate(&cfg)
+
+			if got := taxonomyEmbeddingBacklogModel(&cfg); got != "" {
+				t.Fatalf("taxonomyEmbeddingBacklogModel() = %q, want disabled", got)
+			}
+		})
+	}
+}
+
 func TestSetupMetricsDisabled(t *testing.T) {
 	meterProvider, metrics, err := setupMetrics(&config.Config{})
 	if err != nil {

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -158,6 +158,21 @@ func run() int {
 		return exitSuccess
 	}
 
+	if *tenantID != "" {
+		tenantExists, tenantErr := embeddingsRepo.TenantExistsForEmbeddingBackfill(ctx, *tenantID)
+		if tenantErr != nil {
+			slog.Error("Backfill tenant validation failed", "error", tenantErr, "tenant_id", *tenantID)
+
+			return exitFailure
+		}
+
+		if !tenantExists {
+			slog.Error("No Hub data found for tenant; check -tenant-id", "tenant_id", *tenantID)
+
+			return exitFailure
+		}
+	}
+
 	if *countOnly {
 		var count int
 		if *tenantID == "" {

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -1,6 +1,6 @@
 // backfill-embeddings enqueues River embedding jobs for feedback records that have
 // non-empty value_text and null embedding. Run this when the API server is not
-// handling backfill (e.g. one-off or scheduled). Workers in the API process the jobs.
+// handling backfill (e.g. one-off or scheduled). hub-worker processes the jobs.
 //
 // With -prune-stale-models it instead deletes embedding rows left behind by previous
 // EMBEDDING_MODEL values. Run the prune only AFTER a model migration's backfill has
@@ -51,8 +51,23 @@ func run() int {
 			"(run only after a model migration's backfill has completed)")
 	taxonomyMode := flag.Bool("taxonomy", false,
 		"backfill taxonomy embeddings from translated text using TAXONOMY_EMBEDDING_MODEL or taxonomy:<EMBEDDING_MODEL>:translated-v1")
+	tenantID := flag.String("tenant-id", "", "restrict the backfill to one tenant ID")
+	countOnly := flag.Bool("count-only", false, "count eligible missing embeddings without enqueueing jobs")
+	maxRecords := flag.Int("max-records", 0, "maximum candidates to enqueue; 0 means unlimited")
 
 	flag.Parse()
+
+	if *maxRecords < 0 {
+		slog.Error("-max-records cannot be negative")
+
+		return exitFailure
+	}
+
+	if *pruneStaleModels && (*taxonomyMode || *tenantID != "" || *countOnly || *maxRecords != 0) {
+		slog.Error("-prune-stale-models cannot be combined with backfill scope or preview flags")
+
+		return exitFailure
+	}
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -128,12 +143,6 @@ func run() int {
 	embeddingsRepo := repository.NewEmbeddingsRepository(db)
 
 	if *pruneStaleModels {
-		if *taxonomyMode {
-			slog.Error("-taxonomy cannot be combined with -prune-stale-models")
-
-			return exitFailure
-		}
-
 		deleted, pruneErr := embeddingsRepo.DeleteEmbeddingsForOtherModels(
 			ctx, embeddingModelForDB, pruneBatchSize, taxonomyEmbeddingModel)
 		if pruneErr != nil {
@@ -145,6 +154,32 @@ func run() int {
 		slog.Info("Prune complete", "deleted", deleted, "kept_models", []string{embeddingModelForDB, taxonomyEmbeddingModel})
 		fmt.Printf("Deleted %d stale-model embedding row(s); kept models %q and %q.\n",
 			deleted, embeddingModelForDB, taxonomyEmbeddingModel)
+
+		return exitSuccess
+	}
+
+	if *countOnly {
+		var count int
+		if *tenantID == "" {
+			count, err = embeddingsRepo.CountFeedbackRecordsForBackfillByInputKind(ctx, targetModel, inputKind)
+		} else {
+			count, err = embeddingsRepo.CountTenantFeedbackRecordsForBackfillByInputKind(
+				ctx, *tenantID, targetModel, inputKind)
+		}
+
+		if err != nil {
+			slog.Error("Backfill count failed", "error", err)
+
+			return exitFailure
+		}
+
+		selected := count
+		if *maxRecords > 0 && selected > *maxRecords {
+			selected = *maxRecords
+		}
+
+		fmt.Printf("Found %d eligible missing embedding(s) for model %q; %d would be selected.\n",
+			count, targetModel, selected)
 
 		return exitSuccess
 	}
@@ -188,7 +223,15 @@ func run() int {
 
 	feedbackRecordsService.SetEmbeddingInserter(riverClient)
 
-	enqueued, err := feedbackRecordsService.BackfillEmbeddingsWithInputKind(ctx, targetModel, inputKind)
+	var enqueued int
+	if *tenantID == "" {
+		enqueued, err = feedbackRecordsService.BackfillEmbeddingsWithInputKindLimit(
+			ctx, targetModel, inputKind, *maxRecords)
+	} else {
+		enqueued, err = feedbackRecordsService.BackfillTenantEmbeddingsWithInputKind(
+			ctx, *tenantID, targetModel, inputKind, *maxRecords)
+	}
+
 	if err != nil {
 		slog.Error("Backfill failed", "error", err)
 
@@ -199,6 +242,8 @@ func run() int {
 		"enqueued", enqueued,
 		"model", targetModel,
 		"input_kind", inputKind,
+		"tenant_scoped", *tenantID != "",
+		"max_records", *maxRecords,
 	) // #nosec G706 -- enqueued is an int, not user input
 
 	fmt.Printf("Enqueued %d embedding job(s) for model %q.\n", enqueued, targetModel)

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -238,13 +238,18 @@ func run() int {
 		return exitFailure
 	}
 
-	slog.Info("Backfill complete",
+	logAttrs := []any{
 		"enqueued", enqueued,
 		"model", targetModel,
 		"input_kind", inputKind,
 		"tenant_scoped", *tenantID != "",
 		"max_records", *maxRecords,
-	) // #nosec G706 -- enqueued is an int, not user input
+	}
+	if *tenantID != "" {
+		logAttrs = append(logAttrs, "tenant_id", *tenantID)
+	}
+
+	slog.Info("Backfill complete", logAttrs...) // #nosec G706 -- values are structured log attributes
 
 	fmt.Printf("Enqueued %d embedding job(s) for model %q.\n", enqueued, targetModel)
 

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -25,6 +25,7 @@ type WorkerApp struct {
 	cfg            *config.Config
 	db             *pgxpool.Pool
 	river          *river.Client[pgx.Tx]
+	embeddingBatch *service.BatchingEmbeddingClient
 	meterProvider  *sdkmetric.MeterProvider
 	tracerProvider *sdktrace.TracerProvider
 }
@@ -102,7 +103,10 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		taxonomyEmbeddingEnqueueModel = ""
 	}
 
-	var translationRecordsService *service.FeedbackRecordsService
+	var (
+		translationRecordsService *service.FeedbackRecordsService
+		embeddingBatch            *service.BatchingEmbeddingClient
+	)
 
 	if providerName != "" {
 		embeddingCfg := service.EmbeddingClientConfig{
@@ -125,6 +129,28 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 			shutdownObservability(context.Background(), meterProvider, tracerProvider)
 
 			return nil, fmt.Errorf("create embedding client: %w", err)
+		}
+
+		if batchClient, enabled := service.NewBatchingEmbeddingClient(
+			embeddingClient,
+			service.EmbeddingBatchConfig{
+				BatchSize:   cfg.Embedding.BatchSize,
+				MaxWait:     time.Duration(cfg.Embedding.BatchMaxWaitMs) * time.Millisecond,
+				MaxInFlight: cfg.Embedding.BatchMaxInFlight,
+			},
+			embeddingMetrics,
+		); enabled {
+			embeddingClient = batchClient
+			embeddingBatch = batchClient
+
+			slog.Info("embedding document batching enabled",
+				"batch_size", cfg.Embedding.BatchSize,
+				"max_wait_ms", cfg.Embedding.BatchMaxWaitMs,
+				"max_in_flight", cfg.Embedding.BatchMaxInFlight,
+			)
+		} else if cfg.Embedding.BatchSize > 1 {
+			slog.Info("embedding document batching unavailable for provider; using single requests",
+				"provider", providerName)
 		}
 
 		feedbackRecordsRepo := repository.NewFeedbackRecordsRepository(db)
@@ -292,6 +318,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		cfg:            cfg,
 		db:             db,
 		river:          riverClient,
+		embeddingBatch: embeddingBatch,
 		meterProvider:  meterProvider,
 		tracerProvider: tracerProvider,
 	}, nil
@@ -349,6 +376,15 @@ func (a *WorkerApp) Run(ctx context.Context) error {
 
 	<-a.river.Stopped()
 
+	if a.embeddingBatch != nil {
+		batchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), a.cfg.Server.ShutdownTimeout.Duration())
+		defer cancel()
+
+		if err := a.embeddingBatch.Shutdown(batchCtx); err != nil {
+			return fmt.Errorf("embedding batch shutdown: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -372,6 +408,16 @@ func shutdownObservability(ctx context.Context, meter *sdkmetric.MeterProvider, 
 func (a *WorkerApp) Shutdown(ctx context.Context) (err error) {
 	if stopErr := a.river.Stop(ctx); stopErr != nil {
 		err = fmt.Errorf("river stop: %w", stopErr)
+	}
+
+	if a.embeddingBatch != nil {
+		if batchErr := a.embeddingBatch.Shutdown(ctx); batchErr != nil {
+			if err == nil {
+				err = fmt.Errorf("embedding batch shutdown: %w", batchErr)
+			} else {
+				slog.Error("shutdown embedding batcher", "error", batchErr)
+			}
+		}
 	}
 
 	if a.tracerProvider != nil {

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -377,7 +377,7 @@ func (a *WorkerApp) Run(ctx context.Context) error {
 	<-a.river.Stopped()
 
 	if a.embeddingBatch != nil {
-		batchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), a.cfg.Server.ShutdownTimeout.Duration())
+		batchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), embeddingBatchFlushTimeout)
 		defer cancel()
 
 		if err := a.embeddingBatch.Shutdown(batchCtx); err != nil {
@@ -391,6 +391,10 @@ func (a *WorkerApp) Run(ctx context.Context) error {
 // riverStopAndCancelTimeout bounds the escalated (job-cancelling) stop after the graceful stop
 // timed out; kept short so the pod exits within the orchestrator's termination grace period.
 const riverStopAndCancelTimeout = 5 * time.Second
+
+// embeddingBatchFlushTimeout bounds the one final partial-batch flush without extending River's
+// graceful shutdown by another full server shutdown period.
+const embeddingBatchFlushTimeout = 5 * time.Second
 
 func shutdownObservability(ctx context.Context, meter *sdkmetric.MeterProvider, tracer *sdktrace.TracerProvider) {
 	if tracer != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,9 @@ type EmbeddingConfig struct {
 	BaseURL             string `env:"EMBEDDING_BASE_URL"`
 	MaxConcurrent       int    `env:"EMBEDDING_MAX_CONCURRENT"        env-default:"5"`
 	MaxAttempts         int    `env:"EMBEDDING_MAX_ATTEMPTS"          env-default:"3"`
+	BatchSize           int    `env:"EMBEDDING_BATCH_SIZE"            env-default:"1"`
+	BatchMaxWaitMs      int    `env:"EMBEDDING_BATCH_MAX_WAIT_MS"     env-default:"25"`
+	BatchMaxInFlight    int    `env:"EMBEDDING_BATCH_MAX_IN_FLIGHT"   env-default:"1"`
 	Normalize           bool   `env:"EMBEDDING_NORMALIZE"             env-default:"false"`
 	GoogleCloudProject  string `env:"EMBEDDING_GOOGLE_CLOUD_PROJECT"`
 	GoogleCloudLocation string `env:"EMBEDDING_GOOGLE_CLOUD_LOCATION"`
@@ -414,6 +417,18 @@ func applyDefaults(cfg *Config) {
 		if *tunables.maxAttempts <= 0 {
 			*tunables.maxAttempts = 3
 		}
+	}
+
+	if cfg.Embedding.BatchSize <= 0 {
+		cfg.Embedding.BatchSize = 1
+	}
+
+	if cfg.Embedding.BatchMaxWaitMs <= 0 {
+		cfg.Embedding.BatchMaxWaitMs = 25
+	}
+
+	if cfg.Embedding.BatchMaxInFlight <= 0 {
+		cfg.Embedding.BatchMaxInFlight = 1
 	}
 
 	// Default the cache size only when the operator did not set it. An explicit 0 (or

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -364,7 +364,7 @@ func TestLoad_EmbeddingBaseURL(t *testing.T) {
 func TestLoad_EmbeddingBatchSettings(t *testing.T) {
 	t.Setenv("API_KEY", "test-api-key")
 	t.Setenv("EMBEDDING_BATCH_SIZE", "8")
-	t.Setenv("EMBEDDING_BATCH_MAX_WAIT_MS", "25")
+	t.Setenv("EMBEDDING_BATCH_MAX_WAIT_MS", "37")
 	t.Setenv("EMBEDDING_BATCH_MAX_IN_FLIGHT", "3")
 
 	cfg, err := Load()
@@ -376,8 +376,8 @@ func TestLoad_EmbeddingBatchSettings(t *testing.T) {
 		t.Errorf("Embedding.BatchSize = %d, want 8", cfg.Embedding.BatchSize)
 	}
 
-	if cfg.Embedding.BatchMaxWaitMs != 25 {
-		t.Errorf("Embedding.BatchMaxWaitMs = %d, want 25", cfg.Embedding.BatchMaxWaitMs)
+	if cfg.Embedding.BatchMaxWaitMs != 37 {
+		t.Errorf("Embedding.BatchMaxWaitMs = %d, want 37", cfg.Embedding.BatchMaxWaitMs)
 	}
 
 	if cfg.Embedding.BatchMaxInFlight != 3 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -361,6 +361,30 @@ func TestLoad_EmbeddingBaseURL(t *testing.T) {
 	}
 }
 
+func TestLoad_EmbeddingBatchSettings(t *testing.T) {
+	t.Setenv("API_KEY", "test-api-key")
+	t.Setenv("EMBEDDING_BATCH_SIZE", "8")
+	t.Setenv("EMBEDDING_BATCH_MAX_WAIT_MS", "25")
+	t.Setenv("EMBEDDING_BATCH_MAX_IN_FLIGHT", "3")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Embedding.BatchSize != 8 {
+		t.Errorf("Embedding.BatchSize = %d, want 8", cfg.Embedding.BatchSize)
+	}
+
+	if cfg.Embedding.BatchMaxWaitMs != 25 {
+		t.Errorf("Embedding.BatchMaxWaitMs = %d, want 25", cfg.Embedding.BatchMaxWaitMs)
+	}
+
+	if cfg.Embedding.BatchMaxInFlight != 3 {
+		t.Errorf("Embedding.BatchMaxInFlight = %d, want 3", cfg.Embedding.BatchMaxInFlight)
+	}
+}
+
 func TestLoad_EmbeddingBaseURLValidation(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -658,6 +682,11 @@ func TestApplyDefaults(t *testing.T) {
 
 	if cfg.Embedding.MaxAttempts != 3 {
 		t.Errorf("Embedding.MaxAttempts = %d, want 3", cfg.Embedding.MaxAttempts)
+	}
+
+	if cfg.Embedding.BatchSize != 1 || cfg.Embedding.BatchMaxWaitMs != 25 || cfg.Embedding.BatchMaxInFlight != 1 {
+		t.Errorf("Embedding batch defaults = (%d, %d, %d), want (1, 25, 1)",
+			cfg.Embedding.BatchSize, cfg.Embedding.BatchMaxWaitMs, cfg.Embedding.BatchMaxInFlight)
 	}
 }
 

--- a/internal/observability/embeddings.go
+++ b/internal/observability/embeddings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -46,10 +47,20 @@ type EmbeddingMetrics interface {
 	RecordEmbeddingOutcome(ctx context.Context, status string)
 	RecordWorkerError(ctx context.Context, reason string)
 	RecordEmbeddingDuration(ctx context.Context, duration time.Duration, status string)
+	RecordEmbeddingBatch(ctx context.Context, inputs int64, duration time.Duration, status string)
+	AddEmbeddingBatchInFlight(ctx context.Context, delta int64)
 }
 
 // embeddingMetrics adapts the shared impl to the EmbeddingMetrics outcome/duration names.
-type embeddingMetrics struct{ *enrichmentMetrics }
+type embeddingMetrics struct {
+	*enrichmentMetrics
+
+	batchSize     metric.Int64Histogram
+	batchInputs   metric.Int64Counter
+	batchRequests metric.Int64Counter
+	batchDuration metric.Float64Histogram
+	batchInFlight metric.Int64UpDownCounter
+}
 
 func (m embeddingMetrics) RecordEmbeddingOutcome(ctx context.Context, status string) {
 	m.recordOutcome(ctx, status)
@@ -57,6 +68,28 @@ func (m embeddingMetrics) RecordEmbeddingOutcome(ctx context.Context, status str
 
 func (m embeddingMetrics) RecordEmbeddingDuration(ctx context.Context, duration time.Duration, status string) {
 	m.recordDuration(ctx, duration, status)
+}
+
+func (m embeddingMetrics) RecordEmbeddingBatch(
+	ctx context.Context,
+	inputs int64,
+	duration time.Duration,
+	status string,
+) {
+	if status != "success" && status != "error" {
+		status = "other"
+	}
+
+	attrs := metric.WithAttributes(attribute.String(AttrStatus, status))
+
+	m.batchSize.Record(ctx, inputs)
+	m.batchInputs.Add(ctx, inputs)
+	m.batchRequests.Add(ctx, 1, attrs)
+	m.batchDuration.Record(ctx, duration.Seconds(), attrs)
+}
+
+func (m embeddingMetrics) AddEmbeddingBatchInFlight(ctx context.Context, delta int64) {
+	m.batchInFlight.Add(ctx, delta)
 }
 
 // NewEmbeddingMetrics creates EmbeddingMetrics. Returns (nil, nil) when meter is nil (metrics disabled).
@@ -78,5 +111,53 @@ func NewEmbeddingMetrics(meter metric.Meter) (EmbeddingMetrics, error) {
 		return nil, err
 	}
 
-	return embeddingMetrics{shared}, nil
+	batchSize, err := meter.Int64Histogram(
+		MetricNameEmbeddingBatchSize,
+		metric.WithDescription("Document inputs per embedding provider batch request"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEmbeddingBatchSize, err)
+	}
+
+	batchInputs, err := meter.Int64Counter(
+		MetricNameEmbeddingBatchInputs,
+		metric.WithDescription("Total document inputs sent in embedding batch requests"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEmbeddingBatchInputs, err)
+	}
+
+	batchRequests, err := meter.Int64Counter(
+		MetricNameEmbeddingBatchRequests,
+		metric.WithDescription("Total embedding batch requests by outcome"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEmbeddingBatchRequests, err)
+	}
+
+	batchDuration, err := meter.Float64Histogram(
+		MetricNameEmbeddingBatchDuration,
+		metric.WithDescription("Embedding batch provider request duration"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEmbeddingBatchDuration, err)
+	}
+
+	batchInFlight, err := meter.Int64UpDownCounter(
+		MetricNameEmbeddingBatchInFlight,
+		metric.WithDescription("Embedding batch provider requests currently in flight"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEmbeddingBatchInFlight, err)
+	}
+
+	return embeddingMetrics{
+		enrichmentMetrics: shared,
+		batchSize:         batchSize,
+		batchInputs:       batchInputs,
+		batchRequests:     batchRequests,
+		batchDuration:     batchDuration,
+		batchInFlight:     batchInFlight,
+	}, nil
 }

--- a/internal/observability/embeddings_test.go
+++ b/internal/observability/embeddings_test.go
@@ -3,9 +3,11 @@ package observability
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -14,6 +16,60 @@ func TestNewEmbeddingMetricsNilMeterDisabled(t *testing.T) {
 	metrics, err := NewEmbeddingMetrics(nil)
 	require.NoError(t, err)
 	assert.Nil(t, metrics, "a nil meter disables metrics")
+}
+
+func TestEmbeddingBatchMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := NewEmbeddingMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
+
+	ctx := context.Background()
+	metrics.RecordEmbeddingBatch(ctx, 8, 100*time.Millisecond, "success")
+	metrics.RecordEmbeddingBatch(ctx, 2, 50*time.Millisecond, "unexpected-status")
+	metrics.AddEmbeddingBatchInFlight(ctx, 1)
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &collected))
+
+	wantNames := map[string]bool{
+		MetricNameEmbeddingBatchSize:     false,
+		MetricNameEmbeddingBatchInputs:   false,
+		MetricNameEmbeddingBatchRequests: false,
+		MetricNameEmbeddingBatchDuration: false,
+		MetricNameEmbeddingBatchInFlight: false,
+	}
+	statuses := map[string]bool{}
+
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if _, wanted := wantNames[m.Name]; wanted {
+				wantNames[m.Name] = true
+			}
+
+			if m.Name != MetricNameEmbeddingBatchRequests {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+
+			for _, point := range sum.DataPoints {
+				status, present := point.Attributes.Value(attribute.Key(AttrStatus))
+				require.True(t, present)
+
+				statuses[status.AsString()] = true
+			}
+		}
+	}
+
+	for name, found := range wantNames {
+		assert.Truef(t, found, "batch metric %s was not collected", name)
+	}
+
+	assert.Equal(t, map[string]bool{"success": true, "other": true}, statuses,
+		"batch outcome labels must remain bounded")
 }
 
 // TestRegisterHNSWIterativeScanGauge verifies the observable gauge reports the latch state polled

--- a/internal/observability/enrichment_backlog.go
+++ b/internal/observability/enrichment_backlog.go
@@ -12,9 +12,10 @@ import (
 // Enrichment type label values for MetricNameEnrichmentPendingRecords — a fixed, bounded set that
 // keeps the gauge's cardinality low. Callers pass these to SetEnrichmentPending.
 const (
-	EnrichmentTypeTranslation = "translation"
-	EnrichmentTypeSentiment   = "sentiment"
-	EnrichmentTypeEmotions    = "emotions"
+	EnrichmentTypeTranslation       = "translation"
+	EnrichmentTypeSentiment         = "sentiment"
+	EnrichmentTypeEmotions          = "emotions"
+	EnrichmentTypeTaxonomyEmbedding = "taxonomy_embedding"
 )
 
 // EnrichmentBacklogMetrics reports the aggregate (cross-tenant) count of eligible-but-unenriched
@@ -61,7 +62,8 @@ func NewEnrichmentBacklogMetrics(meter metric.Meter) (EnrichmentBacklogMetrics, 
 		MetricNameEnrichmentPendingRecords,
 		metric.WithDescription(
 			"Eligible-but-unenriched feedback records per enrichment type (translation, sentiment, "+
-				"emotions), aggregated across all tenants. A data-derived backlog/completeness signal; "+
+				"emotions, taxonomy_embedding), aggregated across all tenants. A data-derived "+
+				"backlog/completeness signal; "+
 				"unlike the River queue depth it persists across queue drains.",
 		),
 		metric.WithUnit("1"),

--- a/internal/observability/enrichment_backlog_test.go
+++ b/internal/observability/enrichment_backlog_test.go
@@ -30,10 +30,12 @@ func TestEnrichmentBacklogMetricsGauge(t *testing.T) {
 	metrics.SetEnrichmentPending("translation", 12)
 	metrics.SetEnrichmentPending("sentiment", 5)
 	metrics.SetEnrichmentPending("emotions", 0)
+	metrics.SetEnrichmentPending(EnrichmentTypeTaxonomyEmbedding, 7)
 
 	assert.Equal(t, int64(12), backlogGaugeValue(t, reader, "translation"))
 	assert.Equal(t, int64(5), backlogGaugeValue(t, reader, "sentiment"))
 	assert.Equal(t, int64(0), backlogGaugeValue(t, reader, "emotions"))
+	assert.Equal(t, int64(7), backlogGaugeValue(t, reader, EnrichmentTypeTaxonomyEmbedding))
 
 	// A gauge reports the latest value, not a running sum.
 	metrics.SetEnrichmentPending("translation", 3)

--- a/internal/observability/names.go
+++ b/internal/observability/names.go
@@ -30,6 +30,11 @@ const (
 	MetricNameEmbeddingOutcomes       = "hub_embedding_outcomes_total"
 	MetricNameEmbeddingWorkerErrors   = "hub_embedding_worker_errors_total"
 	MetricNameEmbeddingDuration       = "hub_embedding_duration_seconds"
+	MetricNameEmbeddingBatchSize      = "hub_embedding_batch_size"
+	MetricNameEmbeddingBatchInputs    = "hub_embedding_batch_inputs_total"
+	MetricNameEmbeddingBatchRequests  = "hub_embedding_batch_requests_total"
+	MetricNameEmbeddingBatchDuration  = "hub_embedding_batch_request_duration_seconds"
+	MetricNameEmbeddingBatchInFlight  = "hub_embedding_batch_requests_in_flight"
 
 	// MetricNameTranslationJobsEnqueued and related translation pipeline metrics.
 	MetricNameTranslationJobsEnqueued   = "hub_translation_jobs_enqueued_total"

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -31,6 +32,12 @@ var (
 	ErrNoEmbeddingInResponse = errors.New("openai: no embedding in response")
 	// ErrDimensionMismatch is returned when the response embedding length does not match configured dimensions.
 	ErrDimensionMismatch = errors.New("openai: embedding dimension mismatch")
+	// ErrEmbeddingCountMismatch is returned when a batch response does not contain exactly one vector per input.
+	ErrEmbeddingCountMismatch = errors.New("openai: embedding response count mismatch")
+	// ErrEmbeddingIndexInvalid is returned when a batch response contains an out-of-range or duplicate index.
+	ErrEmbeddingIndexInvalid = errors.New("openai: embedding response index invalid")
+	// ErrEmbeddingValueInvalid is returned when a response vector contains NaN or infinity.
+	ErrEmbeddingValueInvalid = errors.New("openai: embedding value is not finite")
 	// ErrNoCompletionInResponse is returned when a chat completion response contains no usable text.
 	ErrNoCompletionInResponse = errors.New("openai: no completion in response")
 )
@@ -132,25 +139,91 @@ func (c *Client) CreateEmbedding(ctx context.Context, input string) ([]float32, 
 		return nil, wrapOpenAIError("openai embedding", err)
 	}
 
-	if len(resp.Data) == 0 {
+	vectors, err := c.decodeEmbeddingResponse(resp.Data, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return vectors[0], nil
+}
+
+// CreateEmbeddings returns one embedding per input. Results are reordered by the response index so
+// callers always receive vectors in input order, even when an OpenAI-compatible provider returns
+// data out of order.
+func (c *Client) CreateEmbeddings(ctx context.Context, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	trimmed := make([]string, len(inputs))
+	for i, input := range inputs {
+		trimmed[i] = strings.TrimSpace(input)
+		if trimmed[i] == "" {
+			return nil, fmt.Errorf("%w: input %d", ErrEmptyInput, i)
+		}
+	}
+
+	if c.dimensions <= 0 {
+		return nil, ErrInvalidDims
+	}
+
+	resp, err := c.sdk.Embeddings.New(ctx, openaisdk.EmbeddingNewParams{
+		Input: openaisdk.EmbeddingNewParamsInputUnion{
+			OfArrayOfStrings: trimmed,
+		},
+		Model:      c.model,
+		Dimensions: param.NewOpt(int64(c.dimensions)),
+	})
+	if err != nil {
+		return nil, wrapOpenAIError("openai embeddings batch", err)
+	}
+
+	return c.decodeEmbeddingResponse(resp.Data, len(trimmed))
+}
+
+func (c *Client) decodeEmbeddingResponse( //nolint:funcorder // shared decoder stays next to the embedding methods
+	data []openaisdk.Embedding,
+	expected int,
+) ([][]float32, error) {
+	if len(data) == 0 {
 		return nil, ErrNoEmbeddingInResponse
 	}
 
-	emb := resp.Data[0].Embedding
-	if len(emb) != c.dimensions {
-		return nil, fmt.Errorf("%w: got %d, want %d", ErrDimensionMismatch, len(emb), c.dimensions)
+	if len(data) != expected {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrEmbeddingCountMismatch, len(data), expected)
 	}
 
-	// SDK returns float64; convert to float32 so we match EmbeddingClient and the Google SDK (which already returns
-	// float32). Precision loss (64→32, and later 32→16 in the DB driver for halfvec) is acceptable for embeddings;
-	// similarity results are unchanged in practice.
-	out := make([]float32, len(emb))
-	for i := range emb {
-		out[i] = float32(emb[i])
-	}
+	out := make([][]float32, expected)
+	seen := make([]bool, expected)
 
-	if c.normalize {
-		embeddings.NormalizeL2(out)
+	for _, item := range data {
+		if item.Index < 0 || item.Index >= int64(expected) || seen[item.Index] {
+			return nil, fmt.Errorf("%w: %d", ErrEmbeddingIndexInvalid, item.Index)
+		}
+
+		if len(item.Embedding) != c.dimensions {
+			return nil, fmt.Errorf("%w: index %d got %d, want %d",
+				ErrDimensionMismatch, item.Index, len(item.Embedding), c.dimensions)
+		}
+
+		vector := make([]float32, len(item.Embedding))
+		for i, value := range item.Embedding {
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return nil, fmt.Errorf("%w: index %d dimension %d", ErrEmbeddingValueInvalid, item.Index, i)
+			}
+
+			vector[i] = float32(value)
+			if math.IsInf(float64(vector[i]), 0) {
+				return nil, fmt.Errorf("%w: index %d dimension %d", ErrEmbeddingValueInvalid, item.Index, i)
+			}
+		}
+
+		if c.normalize {
+			embeddings.NormalizeL2(vector)
+		}
+
+		out[item.Index] = vector
+		seen[item.Index] = true
 	}
 
 	return out, nil

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -3,12 +3,14 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	openaisdk "github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -104,6 +106,137 @@ func TestCreateEmbedding_UsesEnvironmentBaseURLWhenExplicitBaseURLIsUnset(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, []float32{3, 4}, embedding)
 	assert.Equal(t, int32(1), envHits.Load())
+}
+
+func TestCreateEmbeddingsMapsOutOfOrderResponseAndMatchesSingle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var request struct {
+			Input json.RawMessage `json:"input"`
+		}
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		var inputs []string
+		if request.Input[0] == '[' {
+			if !assert.NoError(t, json.Unmarshal(request.Input, &inputs)) {
+				w.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		} else {
+			var input string
+			if !assert.NoError(t, json.Unmarshal(request.Input, &input)) {
+				w.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+
+			inputs = []string{input}
+		}
+
+		data := make([]map[string]any, 0, len(inputs))
+		for i := len(inputs) - 1; i >= 0; i-- {
+			data = append(data, map[string]any{
+				"object": "embedding", "index": i, "embedding": []float64{float64(len(inputs[i])), float64(i + 1)},
+			})
+		}
+
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"object": "list", "data": data, "model": "test-model",
+			"usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithDimensions(2), WithModel("test-model"))
+	vectors, err := client.CreateEmbeddings(context.Background(), []string{"a", "longer"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 1}, {6, 2}}, vectors)
+
+	single, err := client.CreateEmbedding(context.Background(), "a")
+	require.NoError(t, err)
+	assert.Equal(t, vectors[0], single)
+}
+
+func TestCreateEmbeddingsRejectsMalformedResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		data []map[string]any
+		want error
+	}{
+		{name: "missing vector", data: []map[string]any{{"index": 0, "embedding": []float64{1, 2}}}, want: ErrEmbeddingCountMismatch},
+		{
+			name: "duplicate index",
+			data: []map[string]any{
+				{"index": 0, "embedding": []float64{1, 2}},
+				{"index": 0, "embedding": []float64{3, 4}},
+			},
+			want: ErrEmbeddingIndexInvalid,
+		},
+		{
+			name: "out of range index",
+			data: []map[string]any{
+				{"index": 0, "embedding": []float64{1, 2}},
+				{"index": 2, "embedding": []float64{3, 4}},
+			},
+			want: ErrEmbeddingIndexInvalid,
+		},
+		{
+			name: "dimension mismatch",
+			data: []map[string]any{
+				{"index": 0, "embedding": []float64{1}},
+				{"index": 1, "embedding": []float64{3, 4}},
+			},
+			want: ErrDimensionMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"object": "list", "data": tt.data, "model": "test-model",
+					"usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+				}))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithDimensions(2), WithModel("test-model"))
+			_, err := client.CreateEmbeddings(context.Background(), []string{"one", "two"})
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+func TestDecodeEmbeddingResponseRejectsNonFiniteValues(t *testing.T) {
+	client := NewClient("sk-test", WithDimensions(2), WithModel("test-model"))
+	for _, invalid := range []float64{math.Inf(1), math.NaN(), math.MaxFloat64} {
+		_, err := client.decodeEmbeddingResponse([]openaisdk.Embedding{
+			{Index: 0, Embedding: []float64{invalid, 2}},
+		}, 1)
+		require.ErrorIs(t, err, ErrEmbeddingValueInvalid)
+	}
+}
+
+func TestCreateEmbeddingsRateLimitReturnsRateLimitError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithModel("test-model"))
+	_, err := client.CreateEmbeddings(context.Background(), []string{"one", "two"})
+
+	var rateLimited *huberrors.RateLimitError
+	require.ErrorAs(t, err, &rateLimited)
+	assert.Equal(t, 7*time.Second, rateLimited.RetryAfter)
 }
 
 // newChatCompletionServer drives the real SDK against a stub /v1/chat/completions endpoint so

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -20,6 +20,8 @@ import (
 	"github.com/formbricks/hub/internal/models"
 )
 
+var errEmbeddingBackfillTenantRequired = errors.New("tenant id is required for tenant embedding backfill")
+
 const (
 	// hnswEfSearch increases HNSW graph traversal candidates (default 40); higher improves recall.
 	hnswEfSearch = 200
@@ -265,10 +267,55 @@ func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfillByInputKind(
 	afterID uuid.UUID,
 	limit int,
 ) ([]uuid.UUID, error) {
+	return r.listFeedbackRecordIDsForBackfillByInputKind(ctx, model, inputKind, "", false, afterID, limit)
+}
+
+// ListTenantFeedbackRecordIDsForBackfillByInputKind returns one tenant's feedback-record IDs that
+// are missing an embedding for model and eligible for the requested input kind.
+func (r *EmbeddingsRepository) ListTenantFeedbackRecordIDsForBackfillByInputKind(
+	ctx context.Context,
+	tenantID string,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	afterID uuid.UUID,
+	limit int,
+) ([]uuid.UUID, error) {
+	if tenantID == "" {
+		return nil, errEmbeddingBackfillTenantRequired
+	}
+
+	return r.listFeedbackRecordIDsForBackfillByInputKind(ctx, model, inputKind, tenantID, true, afterID, limit)
+}
+
+//nolint:funcorder // scoped helper stays with the public backfill methods
+func (r *EmbeddingsRepository) listFeedbackRecordIDsForBackfillByInputKind(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	tenantID string,
+	tenantScoped bool,
+	afterID uuid.UUID,
+	limit int,
+) ([]uuid.UUID, error) {
+	eligibility := `fr.value_text IS NOT NULL AND trim(fr.value_text) != ''`
+	if models.NormalizeEmbeddingInputKind(inputKind) == models.EmbeddingInputKindTaxonomyTranslated {
+		eligibility = `COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL`
+	}
+
+	tenantClause := ""
+	args := []any{model, afterID, limit}
+
+	if tenantScoped {
+		tenantClause = "AND fr.tenant_id = $4"
+
+		args = append(args, tenantID)
+	}
+
 	query := `
 		SELECT fr.id FROM feedback_records fr
-		WHERE fr.value_text IS NOT NULL AND trim(fr.value_text) != ''
+		WHERE ` + eligibility + `
 		  AND fr.id > $2
+		  ` + tenantClause + `
 		  AND NOT EXISTS (
 		    SELECT 1 FROM embeddings e
 		    WHERE e.feedback_record_id = fr.id AND e.model = $1
@@ -276,21 +323,8 @@ func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfillByInputKind(
 		ORDER BY fr.id
 		LIMIT $3
 	`
-	if models.NormalizeEmbeddingInputKind(inputKind) == models.EmbeddingInputKindTaxonomyTranslated {
-		query = `
-			SELECT fr.id FROM feedback_records fr
-			WHERE COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
-			  AND fr.id > $2
-			  AND NOT EXISTS (
-			    SELECT 1 FROM embeddings e
-			    WHERE e.feedback_record_id = fr.id AND e.model = $1
-			  )
-			ORDER BY fr.id
-			LIMIT $3
-		`
-	}
 
-	rows, err := r.db.Query(ctx, query, model, afterID, limit)
+	rows, err := r.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list feedback record ids for backfill: %w", err)
 	}
@@ -312,6 +346,69 @@ func (r *EmbeddingsRepository) ListFeedbackRecordIDsForBackfillByInputKind(
 	}
 
 	return ids, nil
+}
+
+// CountFeedbackRecordsForBackfillByInputKind counts globally eligible records missing model.
+func (r *EmbeddingsRepository) CountFeedbackRecordsForBackfillByInputKind(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+) (int, error) {
+	return r.countFeedbackRecordsForBackfillByInputKind(ctx, model, inputKind, "", false)
+}
+
+// CountTenantFeedbackRecordsForBackfillByInputKind counts one tenant's eligible records missing model.
+func (r *EmbeddingsRepository) CountTenantFeedbackRecordsForBackfillByInputKind(
+	ctx context.Context,
+	tenantID string,
+	model string,
+	inputKind models.EmbeddingInputKind,
+) (int, error) {
+	if tenantID == "" {
+		return 0, errEmbeddingBackfillTenantRequired
+	}
+
+	return r.countFeedbackRecordsForBackfillByInputKind(ctx, model, inputKind, tenantID, true)
+}
+
+//nolint:funcorder // scoped helper stays with the public backfill methods
+func (r *EmbeddingsRepository) countFeedbackRecordsForBackfillByInputKind(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	tenantID string,
+	tenantScoped bool,
+) (int, error) {
+	eligibility := `fr.value_text IS NOT NULL AND trim(fr.value_text) != ''`
+	if models.NormalizeEmbeddingInputKind(inputKind) == models.EmbeddingInputKindTaxonomyTranslated {
+		eligibility = `COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL`
+	}
+
+	tenantClause := ""
+	args := []any{model}
+
+	if tenantScoped {
+		tenantClause = "AND fr.tenant_id = $2"
+
+		args = append(args, tenantID)
+	}
+
+	query := `
+		SELECT count(*) FROM feedback_records fr
+		WHERE ` + eligibility + `
+		  ` + tenantClause + `
+		  AND NOT EXISTS (
+		    SELECT 1 FROM embeddings e
+		    WHERE e.feedback_record_id = fr.id AND e.model = $1
+		  )
+	`
+
+	var count int
+	if err := r.db.QueryRow(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count feedback records for embedding backfill: %w", err)
+	}
+
+	return count, nil
 }
 
 // ErrEmbeddingNotFound is returned when no embedding row exists for the given feedback record and model.

--- a/internal/repository/embeddings_repository.go
+++ b/internal/repository/embeddings_repository.go
@@ -371,6 +371,29 @@ func (r *EmbeddingsRepository) CountTenantFeedbackRecordsForBackfillByInputKind(
 	return r.countFeedbackRecordsForBackfillByInputKind(ctx, model, inputKind, tenantID, true)
 }
 
+// TenantExistsForEmbeddingBackfill reports whether Hub knows the tenant through feedback records
+// or tenant settings. Hub has no authoritative tenants table, so checking both data sources lets the
+// operator distinguish a likely typo from an existing tenant with no eligible missing embeddings.
+func (r *EmbeddingsRepository) TenantExistsForEmbeddingBackfill(ctx context.Context, tenantID string) (bool, error) {
+	if tenantID == "" {
+		return false, errEmbeddingBackfillTenantRequired
+	}
+
+	const query = `
+		SELECT EXISTS (
+			SELECT 1 FROM feedback_records WHERE tenant_id = $1
+			UNION ALL
+			SELECT 1 FROM tenant_settings WHERE tenant_id = $1
+		)`
+
+	var exists bool
+	if err := r.db.QueryRow(ctx, query, tenantID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check tenant for embedding backfill: %w", err)
+	}
+
+	return exists, nil
+}
+
 //nolint:funcorder // scoped helper stays with the public backfill methods
 func (r *EmbeddingsRepository) countFeedbackRecordsForBackfillByInputKind(
 	ctx context.Context,

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -27,12 +27,13 @@ func NewEnrichmentStatusRepository(db *pgxpool.Pool) *EnrichmentStatusRepository
 // switched on, translation only records with a resolvable effective target language. The
 // deployment-level (provider/model) gate is applied by the caller.
 type EnrichmentStatusCounts struct {
-	TranslationEligible int64
-	TranslationDone     int64
-	SentimentEligible   int64
-	SentimentDone       int64
-	EmotionsEligible    int64
-	EmotionsDone        int64
+	TranslationEligible      int64
+	TranslationDone          int64
+	SentimentEligible        int64
+	SentimentDone            int64
+	EmotionsEligible         int64
+	EmotionsDone             int64
+	TaxonomyEmbeddingPending int64
 }
 
 // enrichmentEligibleText is the data-level eligibility predicate: an open-text field with content.
@@ -123,6 +124,20 @@ const countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentC
 const countEnrichmentBacklogAggregateSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
 	WHERE fr.field_type = 'text'`
 
+// countTaxonomyEmbeddingBacklogAggregateSQL counts records eligible for the taxonomy-translated
+// input but still missing the exact configured taxonomy model. It deliberately mirrors the
+// taxonomy backfill eligibility predicate so the operational gauge and the repair command agree
+// about what remains. $1 = taxonomy embedding model.
+const countTaxonomyEmbeddingBacklogAggregateSQL = `
+	SELECT COUNT(*)
+	FROM feedback_records fr
+	WHERE COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
+	  AND NOT EXISTS (
+		SELECT 1
+		FROM embeddings e
+		WHERE e.feedback_record_id = fr.id AND e.model = $1
+	  )`
+
 // enrichmentBacklogLockKey names the advisory lock that elects the single backlog-poller process
 // across API replicas. Hashed with hashtextextended like the other advisory locks in this package.
 const enrichmentBacklogLockKey = "hub:enrichment-backlog-poller"
@@ -202,7 +217,7 @@ func NewEnrichmentBacklogLeader(pool *pgxpool.Pool) *EnrichmentBacklogLeader {
 // reports whether it did. Not being the leader is the normal steady state for all but one replica,
 // so it is signalled by a false second return rather than an error.
 func (l *EnrichmentBacklogLeader) CountIfLeader(
-	ctx context.Context, defaultLang string,
+	ctx context.Context, defaultLang, taxonomyEmbeddingModel string,
 ) (EnrichmentStatusCounts, bool, error) {
 	if l.conn == nil {
 		acquired, err := l.tryAcquire(ctx)
@@ -219,6 +234,16 @@ func (l *EnrichmentBacklogLeader) CountIfLeader(
 		l.release(ctx)
 
 		return EnrichmentStatusCounts{}, false, err
+	}
+
+	if taxonomyEmbeddingModel != "" {
+		if err := l.conn.QueryRow(
+			ctx, countTaxonomyEmbeddingBacklogAggregateSQL, taxonomyEmbeddingModel,
+		).Scan(&counts.TaxonomyEmbeddingPending); err != nil {
+			l.release(ctx)
+
+			return EnrichmentStatusCounts{}, false, fmt.Errorf("count taxonomy embedding backlog aggregate: %w", err)
+		}
 	}
 
 	return counts, true, nil

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -124,14 +124,16 @@ const countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentC
 const countEnrichmentBacklogAggregateSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
 	WHERE fr.field_type = 'text'`
 
-// countTaxonomyEmbeddingBacklogAggregateSQL counts records eligible for the taxonomy-translated
-// input but still missing the exact configured taxonomy model. It deliberately mirrors the
-// taxonomy backfill eligibility predicate so the operational gauge and the repair command agree
-// about what remains. $1 = taxonomy embedding model.
+// countTaxonomyEmbeddingBacklogAggregateSQL counts text records eligible for the
+// taxonomy-translated input but still missing the exact configured taxonomy model. field_type is
+// load-bearing here: only text records enter the live translation-to-taxonomy pipeline, so counting
+// categorical rows carrying value_text would create a permanent non-zero gauge floor. $1 = taxonomy
+// embedding model.
 const countTaxonomyEmbeddingBacklogAggregateSQL = `
 	SELECT COUNT(*)
 	FROM feedback_records fr
-	WHERE COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
+	WHERE fr.field_type = 'text'
+	  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
 	  AND NOT EXISTS (
 		SELECT 1
 		FROM embeddings e

--- a/internal/service/embedding_batcher.go
+++ b/internal/service/embedding_batcher.go
@@ -1,0 +1,314 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	// ErrEmbeddingBatcherClosed is returned after shutdown stops accepting document calls.
+	ErrEmbeddingBatcherClosed = errors.New("embedding batcher is closed")
+	// ErrEmbeddingBatchResultCount is returned when a batch provider violates one-result-per-input.
+	ErrEmbeddingBatchResultCount = errors.New("embedding batch result count mismatch")
+)
+
+const defaultEmbeddingBatchMaxWait = 25 * time.Millisecond
+
+// EmbeddingBatchMetrics is the bounded observability seam used by the batching client.
+type EmbeddingBatchMetrics interface {
+	RecordEmbeddingBatch(ctx context.Context, inputs int64, duration time.Duration, status string)
+	AddEmbeddingBatchInFlight(ctx context.Context, delta int64)
+}
+
+// EmbeddingBatchConfig controls document micro-batching. BatchSize <= 1 disables batching.
+type EmbeddingBatchConfig struct {
+	BatchSize   int
+	MaxWait     time.Duration
+	MaxInFlight int
+}
+
+type embeddingBatchRequest struct {
+	ctx    context.Context //nolint:containedctx // each coalesced request retains its own cancellation boundary
+	input  string
+	result chan embeddingBatchResult
+}
+
+type embeddingBatchResult struct {
+	vector []float32
+	err    error
+}
+
+// BatchingEmbeddingClient coalesces concurrent document calls while leaving query calls
+// synchronous. It is only constructed when the provider implements BatchEmbeddingClient.
+type BatchingEmbeddingClient struct {
+	client      EmbeddingClient
+	batchClient BatchEmbeddingClient
+	metrics     EmbeddingBatchMetrics
+	batchSize   int
+	maxWait     time.Duration
+	semaphore   chan struct{}
+
+	mu      sync.Mutex
+	pending []*embeddingBatchRequest
+	timer   *time.Timer
+	closed  bool
+	active  sync.WaitGroup
+
+	forceStop     chan struct{}
+	forceStopOnce sync.Once
+}
+
+// NewBatchingEmbeddingClient wraps client when batching is enabled and supported. The bool reports
+// whether a wrapper was created; callers should keep using client when it is false.
+func NewBatchingEmbeddingClient(
+	client EmbeddingClient,
+	cfg EmbeddingBatchConfig,
+	metrics EmbeddingBatchMetrics,
+) (*BatchingEmbeddingClient, bool) {
+	batchClient, ok := client.(BatchEmbeddingClient)
+	if !ok || cfg.BatchSize <= 1 {
+		return nil, false
+	}
+
+	if cfg.MaxWait <= 0 {
+		cfg.MaxWait = defaultEmbeddingBatchMaxWait
+	}
+
+	if cfg.MaxInFlight <= 0 {
+		cfg.MaxInFlight = 1
+	}
+
+	return &BatchingEmbeddingClient{
+		client:      client,
+		batchClient: batchClient,
+		metrics:     metrics,
+		batchSize:   cfg.BatchSize,
+		maxWait:     cfg.MaxWait,
+		semaphore:   make(chan struct{}, cfg.MaxInFlight),
+		forceStop:   make(chan struct{}),
+	}, true
+}
+
+// CreateEmbedding queues a document for the next micro-batch.
+func (b *BatchingEmbeddingClient) CreateEmbedding(ctx context.Context, input string) ([]float32, error) {
+	request := &embeddingBatchRequest{
+		ctx:    ctx,
+		input:  input,
+		result: make(chan embeddingBatchResult, 1),
+	}
+
+	var batch []*embeddingBatchRequest
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+
+		return nil, ErrEmbeddingBatcherClosed
+	}
+
+	b.pending = append(b.pending, request)
+	if len(b.pending) == 1 {
+		b.timer = time.AfterFunc(b.maxWait, b.flush)
+	}
+
+	if len(b.pending) >= b.batchSize {
+		batch = b.takePendingLocked()
+		b.active.Add(1)
+	}
+	b.mu.Unlock()
+
+	if len(batch) > 0 {
+		go b.dispatch(batch) //nolint:contextcheck // dispatch derives cancellation from every request in the batch
+	}
+
+	select {
+	case result := <-request.result:
+		return result.vector, result.err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("embedding batch request: %w", ctx.Err())
+	}
+}
+
+// CreateEmbeddingForQuery deliberately bypasses batching; query latency and the foreground API
+// path remain independent from background document throughput.
+func (b *BatchingEmbeddingClient) CreateEmbeddingForQuery(ctx context.Context, input string) ([]float32, error) {
+	vector, err := b.client.CreateEmbeddingForQuery(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("create query embedding: %w", err)
+	}
+
+	return vector, nil
+}
+
+// Shutdown stops accepting new work, flushes the final partial batch, and waits for provider
+// requests to finish. When ctx expires, in-flight provider requests are cancelled.
+func (b *BatchingEmbeddingClient) Shutdown(ctx context.Context) error {
+	b.mu.Lock()
+	b.closed = true
+
+	batch := b.takePendingLocked()
+	if len(batch) > 0 {
+		b.active.Add(1)
+	}
+	b.mu.Unlock()
+
+	if len(batch) > 0 {
+		go b.dispatch(batch) //nolint:contextcheck // dispatch derives cancellation from every request in the batch
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		b.active.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		b.forceStopOnce.Do(func() { close(b.forceStop) })
+
+		return fmt.Errorf("embedding batch shutdown: %w", ctx.Err())
+	}
+}
+
+func (b *BatchingEmbeddingClient) flush() {
+	b.mu.Lock()
+
+	batch := b.takePendingLocked()
+	if len(batch) > 0 {
+		b.active.Add(1)
+	}
+	b.mu.Unlock()
+
+	if len(batch) > 0 {
+		go b.dispatch(batch)
+	}
+}
+
+func (b *BatchingEmbeddingClient) takePendingLocked() []*embeddingBatchRequest {
+	if b.timer != nil {
+		b.timer.Stop()
+		b.timer = nil
+	}
+
+	batch := b.pending
+	b.pending = nil
+
+	return batch
+}
+
+func (b *BatchingEmbeddingClient) dispatch(batch []*embeddingBatchRequest) {
+	defer b.active.Done()
+
+	active := batch[:0]
+	for _, request := range batch {
+		if request.ctx.Err() == nil {
+			active = append(active, request)
+		}
+	}
+
+	if len(active) == 0 {
+		return
+	}
+
+	select {
+	case b.semaphore <- struct{}{}:
+		defer func() { <-b.semaphore }()
+	case <-b.forceStop:
+		b.deliver(active, nil, ErrEmbeddingBatcherClosed)
+
+		return
+	}
+
+	providerCtx, cancel, cleanupContext := b.providerContext(active)
+	defer cancel()
+	defer cleanupContext()
+
+	inputs := make([]string, len(active))
+	for i, request := range active {
+		inputs[i] = request.input
+	}
+
+	if b.metrics != nil {
+		b.metrics.AddEmbeddingBatchInFlight(providerCtx, 1)
+		defer b.metrics.AddEmbeddingBatchInFlight(context.WithoutCancel(providerCtx), -1)
+	}
+
+	started := time.Now()
+
+	vectors, err := b.batchClient.CreateEmbeddings(providerCtx, inputs)
+	if err == nil && len(vectors) != len(active) {
+		err = ErrEmbeddingBatchResultCount
+	}
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	if b.metrics != nil {
+		b.metrics.RecordEmbeddingBatch(context.WithoutCancel(providerCtx), int64(len(inputs)), time.Since(started), status)
+	}
+
+	b.deliver(active, vectors, err)
+}
+
+func (b *BatchingEmbeddingClient) providerContext(
+	requests []*embeddingBatchRequest,
+) (context.Context, context.CancelFunc, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	remaining := atomic.Int64{}
+	remaining.Store(int64(len(requests)))
+
+	stops := make([]func() bool, 0, len(requests)+1)
+	for _, request := range requests {
+		stops = append(stops, context.AfterFunc(request.ctx, func() {
+			if remaining.Add(-1) == 0 {
+				cancel()
+			}
+		}))
+	}
+
+	providerDone := make(chan struct{})
+
+	go func() {
+		select {
+		case <-b.forceStop:
+			cancel()
+		case <-providerDone:
+		}
+	}()
+
+	cleanup := func() {
+		close(providerDone)
+
+		for _, stop := range stops {
+			stop()
+		}
+	}
+
+	return ctx, cancel, cleanup
+}
+
+func (b *BatchingEmbeddingClient) deliver(
+	requests []*embeddingBatchRequest,
+	vectors [][]float32,
+	err error,
+) {
+	for i, request := range requests {
+		result := embeddingBatchResult{err: err}
+		if err == nil {
+			result.vector = vectors[i]
+		}
+
+		request.result <- result
+	}
+}
+
+var _ EmbeddingClient = (*BatchingEmbeddingClient)(nil)

--- a/internal/service/embedding_batcher.go
+++ b/internal/service/embedding_batcher.go
@@ -266,17 +266,24 @@ func (b *BatchingEmbeddingClient) dispatch(batch []*embeddingBatchRequest) {
 }
 
 // retryIndividually isolates a rejected input after a provider rejects the all-or-nothing batch.
-// Every request gets its own provider call so one invalid document cannot consume its peers' retries.
+// Every request gets its own concurrent provider call so one invalid document cannot consume its
+// peers' retries or hold the batch's in-flight slot for N sequential round trips.
 func (b *BatchingEmbeddingClient) retryIndividually(requests []*embeddingBatchRequest) {
+	var waitGroup sync.WaitGroup
+
 	for _, request := range requests {
-		providerCtx, cancel, cleanupContext := b.providerContext([]*embeddingBatchRequest{request})
-		vector, err := b.client.CreateEmbedding(providerCtx, request.input)
+		waitGroup.Go(func() {
+			providerCtx, cancel, cleanupContext := b.providerContext([]*embeddingBatchRequest{request})
+			vector, err := b.client.CreateEmbedding(providerCtx, request.input)
 
-		cancel()
-		cleanupContext()
+			cancel()
+			cleanupContext()
 
-		request.result <- embeddingBatchResult{vector: vector, err: err}
+			request.result <- embeddingBatchResult{vector: vector, err: err}
+		})
 	}
+
+	waitGroup.Wait()
 }
 
 func (b *BatchingEmbeddingClient) providerContext(

--- a/internal/service/embedding_batcher.go
+++ b/internal/service/embedding_batcher.go
@@ -256,7 +256,27 @@ func (b *BatchingEmbeddingClient) dispatch(batch []*embeddingBatchRequest) {
 		b.metrics.RecordEmbeddingBatch(context.WithoutCancel(providerCtx), int64(len(inputs)), time.Since(started), status)
 	}
 
+	if err != nil && len(active) > 1 {
+		b.retryIndividually(active)
+
+		return
+	}
+
 	b.deliver(active, vectors, err)
+}
+
+// retryIndividually isolates a rejected input after a provider rejects the all-or-nothing batch.
+// Every request gets its own provider call so one invalid document cannot consume its peers' retries.
+func (b *BatchingEmbeddingClient) retryIndividually(requests []*embeddingBatchRequest) {
+	for _, request := range requests {
+		providerCtx, cancel, cleanupContext := b.providerContext([]*embeddingBatchRequest{request})
+		vector, err := b.client.CreateEmbedding(providerCtx, request.input)
+
+		cancel()
+		cleanupContext()
+
+		request.result <- embeddingBatchResult{vector: vector, err: err}
+	}
 }
 
 func (b *BatchingEmbeddingClient) providerContext(

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -18,13 +18,18 @@ type batcherTestClient struct {
 	batchBlock  <-chan struct{}
 	queryCalls  int
 	singleCalls int
+	singleErrs  map[string]error
 }
 
 func (c *batcherTestClient) CreateEmbedding(_ context.Context, input string) ([]float32, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.singleCalls++
+	err := c.singleErrs[input]
+	c.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
 
 	return []float32{float32(len(input))}, nil
 }
@@ -128,26 +133,49 @@ func TestBatchingEmbeddingClientPartialBatchAndQueryBypass(t *testing.T) {
 	}
 }
 
-func TestBatchingEmbeddingClientProviderErrorReachesEveryRequest(t *testing.T) {
-	wantErr := errors.New("provider unavailable")
-	provider := &batcherTestClient{batchErr: wantErr}
+func TestBatchingEmbeddingClientProviderErrorRetriesRequestsIndividually(t *testing.T) {
+	batchErr := errors.New("batch rejected")
+	badInputErr := errors.New("input rejected")
+	provider := &batcherTestClient{
+		batchErr:   batchErr,
+		singleErrs: map[string]error{"bad": badInputErr},
+	}
 	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
-		BatchSize: 2, MaxWait: time.Second, MaxInFlight: 1,
+		BatchSize: 3, MaxWait: time.Second, MaxInFlight: 1,
 	}, nil)
 
-	errs := make(chan error, 2)
+	inputs := []string{"first", "bad", "third"}
+	results := make([][]float32, len(inputs))
+	errs := make([]error, len(inputs))
 
-	for _, input := range []string{"first", "second"} {
-		go func() {
-			_, err := batcher.CreateEmbedding(context.Background(), input)
-			errs <- err
-		}()
+	var waitGroup sync.WaitGroup
+	for i := range inputs {
+		waitGroup.Go(func() {
+			results[i], errs[i] = batcher.CreateEmbedding(context.Background(), inputs[i])
+		})
 	}
 
-	for range 2 {
-		if err := <-errs; !errors.Is(err, wantErr) {
-			t.Fatalf("error = %v, want provider error", err)
+	waitGroup.Wait()
+
+	for i := range inputs {
+		if inputs[i] == "bad" {
+			if !errors.Is(errs[i], badInputErr) {
+				t.Fatalf("bad input error = %v, want input rejection", errs[i])
+			}
+
+			continue
 		}
+
+		if errs[i] != nil || !reflect.DeepEqual(results[i], []float32{float32(len(inputs[i]))}) {
+			t.Fatalf("input %q result = %v, %v", inputs[i], results[i], errs[i])
+		}
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	if provider.singleCalls != len(inputs) {
+		t.Fatalf("single calls = %d, want %d", provider.singleCalls, len(inputs))
 	}
 }
 

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -1,0 +1,252 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type batcherTestClient struct {
+	mu          sync.Mutex
+	batches     [][]string
+	batchErr    error
+	batchBlock  <-chan struct{}
+	queryCalls  int
+	singleCalls int
+}
+
+func (c *batcherTestClient) CreateEmbedding(_ context.Context, input string) ([]float32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.singleCalls++
+
+	return []float32{float32(len(input))}, nil
+}
+
+func (c *batcherTestClient) CreateEmbeddingForQuery(_ context.Context, input string) ([]float32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.queryCalls++
+
+	return []float32{float32(len(input))}, nil
+}
+
+func (c *batcherTestClient) CreateEmbeddings(ctx context.Context, inputs []string) ([][]float32, error) {
+	if c.batchBlock != nil {
+		select {
+		case <-c.batchBlock:
+		case <-ctx.Done():
+			return nil, fmt.Errorf("test batch provider: %w", ctx.Err())
+		}
+	}
+
+	c.mu.Lock()
+	c.batches = append(c.batches, append([]string(nil), inputs...))
+	err := c.batchErr
+	c.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+
+	vectors := make([][]float32, len(inputs))
+	for i, input := range inputs {
+		vectors[i] = []float32{float32(len(input))}
+	}
+
+	return vectors, nil
+}
+
+func TestBatchingEmbeddingClientGroupsAndMapsResults(t *testing.T) {
+	provider := &batcherTestClient{}
+
+	batcher, ok := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 3, MaxWait: time.Second, MaxInFlight: 1,
+	}, nil)
+	if !ok {
+		t.Fatal("batch client was not enabled")
+	}
+
+	inputs := []string{"a", "bb", "ccc"}
+	results := make([][]float32, len(inputs))
+	errs := make([]error, len(inputs))
+
+	var waitGroup sync.WaitGroup
+	for i := range inputs {
+		waitGroup.Go(func() {
+			results[i], errs[i] = batcher.CreateEmbedding(context.Background(), inputs[i])
+		})
+	}
+
+	waitGroup.Wait()
+
+	for i := range inputs {
+		if errs[i] != nil {
+			t.Fatalf("input %d error = %v", i, errs[i])
+		}
+
+		if !reflect.DeepEqual(results[i], []float32{float32(len(inputs[i]))}) {
+			t.Fatalf("input %d result = %v", i, results[i])
+		}
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	if len(provider.batches) != 1 || len(provider.batches[0]) != 3 {
+		t.Fatalf("batches = %v, want one batch of 3", provider.batches)
+	}
+}
+
+func TestBatchingEmbeddingClientPartialBatchAndQueryBypass(t *testing.T) {
+	provider := &batcherTestClient{}
+	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 8, MaxWait: 5 * time.Millisecond, MaxInFlight: 1,
+	}, nil)
+
+	vector, err := batcher.CreateEmbedding(context.Background(), "document")
+	if err != nil || !reflect.DeepEqual(vector, []float32{8}) {
+		t.Fatalf("document result = %v, %v", vector, err)
+	}
+
+	if _, err := batcher.CreateEmbeddingForQuery(context.Background(), "query"); err != nil {
+		t.Fatalf("query error = %v", err)
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	if len(provider.batches) != 1 || provider.queryCalls != 1 || provider.singleCalls != 0 {
+		t.Fatalf("batches=%v query=%d single=%d", provider.batches, provider.queryCalls, provider.singleCalls)
+	}
+}
+
+func TestBatchingEmbeddingClientProviderErrorReachesEveryRequest(t *testing.T) {
+	wantErr := errors.New("provider unavailable")
+	provider := &batcherTestClient{batchErr: wantErr}
+	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 2, MaxWait: time.Second, MaxInFlight: 1,
+	}, nil)
+
+	errs := make(chan error, 2)
+
+	for _, input := range []string{"first", "second"} {
+		go func() {
+			_, err := batcher.CreateEmbedding(context.Background(), input)
+			errs <- err
+		}()
+	}
+
+	for range 2 {
+		if err := <-errs; !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want provider error", err)
+		}
+	}
+}
+
+func TestBatchingEmbeddingClientCancellationDoesNotPoisonPeers(t *testing.T) {
+	provider := &batcherTestClient{}
+	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 8, MaxWait: 20 * time.Millisecond, MaxInFlight: 1,
+	}, nil)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancelledDone := make(chan error, 1)
+
+	go func() {
+		_, err := batcher.CreateEmbedding(cancelledCtx, "cancelled")
+		cancelledDone <- err
+	}()
+
+	cancel()
+
+	peer, err := batcher.CreateEmbedding(context.Background(), "peer")
+	if err != nil || !reflect.DeepEqual(peer, []float32{4}) {
+		t.Fatalf("peer result = %v, %v", peer, err)
+	}
+
+	if err := <-cancelledDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled error = %v", err)
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	if len(provider.batches) != 1 || !reflect.DeepEqual(provider.batches[0], []string{"peer"}) {
+		t.Fatalf("provider batches = %v, want only active peer", provider.batches)
+	}
+}
+
+func TestBatchingEmbeddingClientShutdownFlushesAndCloses(t *testing.T) {
+	provider := &batcherTestClient{}
+	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 8, MaxWait: time.Hour, MaxInFlight: 1,
+	}, nil)
+
+	done := make(chan error, 1)
+
+	go func() {
+		_, err := batcher.CreateEmbedding(context.Background(), "pending")
+		done <- err
+	}()
+
+	deadline := time.Now().Add(time.Second)
+
+	for {
+		batcher.mu.Lock()
+		pending := len(batcher.pending)
+		batcher.mu.Unlock()
+
+		if pending == 1 {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("request did not enter the pending batch")
+		}
+
+		runtime.Gosched()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := batcher.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("pending request error = %v", err)
+	}
+
+	if _, err := batcher.CreateEmbedding(context.Background(), "late"); !errors.Is(err, ErrEmbeddingBatcherClosed) {
+		t.Fatalf("late request error = %v, want closed", err)
+	}
+}
+
+type singleOnlyEmbeddingClient struct{}
+
+func (singleOnlyEmbeddingClient) CreateEmbedding(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (singleOnlyEmbeddingClient) CreateEmbeddingForQuery(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func TestNewBatchingEmbeddingClientFallback(t *testing.T) {
+	if _, ok := NewBatchingEmbeddingClient(singleOnlyEmbeddingClient{}, EmbeddingBatchConfig{BatchSize: 8}, nil); ok {
+		t.Fatal("non-batch provider must retain single-request behavior")
+	}
+
+	if _, ok := NewBatchingEmbeddingClient(&batcherTestClient{}, EmbeddingBatchConfig{BatchSize: 1}, nil); ok {
+		t.Fatal("batch size 1 must disable batching")
+	}
+}

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -19,13 +19,27 @@ type batcherTestClient struct {
 	queryCalls  int
 	singleCalls int
 	singleErrs  map[string]error
+	singleBlock <-chan struct{}
+	singleStart chan<- string
 }
 
-func (c *batcherTestClient) CreateEmbedding(_ context.Context, input string) ([]float32, error) {
+func (c *batcherTestClient) CreateEmbedding(ctx context.Context, input string) ([]float32, error) {
 	c.mu.Lock()
 	c.singleCalls++
 	err := c.singleErrs[input]
 	c.mu.Unlock()
+
+	if c.singleStart != nil {
+		c.singleStart <- input
+	}
+
+	if c.singleBlock != nil {
+		select {
+		case <-c.singleBlock:
+		case <-ctx.Done():
+			return nil, fmt.Errorf("test single provider: %w", ctx.Err())
+		}
+	}
 
 	if err != nil {
 		return nil, err
@@ -136,9 +150,13 @@ func TestBatchingEmbeddingClientPartialBatchAndQueryBypass(t *testing.T) {
 func TestBatchingEmbeddingClientProviderErrorRetriesRequestsIndividually(t *testing.T) {
 	batchErr := errors.New("batch rejected")
 	badInputErr := errors.New("input rejected")
+	singleBlock := make(chan struct{})
+	singleStart := make(chan string, 3)
 	provider := &batcherTestClient{
-		batchErr:   batchErr,
-		singleErrs: map[string]error{"bad": badInputErr},
+		batchErr:    batchErr,
+		singleErrs:  map[string]error{"bad": badInputErr},
+		singleBlock: singleBlock,
+		singleStart: singleStart,
 	}
 	batcher, _ := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
 		BatchSize: 3, MaxWait: time.Second, MaxInFlight: 1,
@@ -154,6 +172,20 @@ func TestBatchingEmbeddingClientProviderErrorRetriesRequestsIndividually(t *test
 			results[i], errs[i] = batcher.CreateEmbedding(context.Background(), inputs[i])
 		})
 	}
+
+	deadline := time.After(time.Second)
+
+	for range inputs {
+		select {
+		case <-singleStart:
+		case <-deadline:
+			close(singleBlock)
+			waitGroup.Wait()
+			t.Fatal("individual retries did not start concurrently")
+		}
+	}
+
+	close(singleBlock)
 
 	waitGroup.Wait()
 

--- a/internal/service/embedding_client.go
+++ b/internal/service/embedding_client.go
@@ -12,7 +12,8 @@ type EmbeddingClient interface {
 
 // BatchEmbeddingClient is an optional provider capability for embedding multiple documents in one
 // request. Workers use it when batching is enabled; providers that do not implement it continue to
-// receive one request per document.
+// receive one request per document. Implementations must return exactly one vector per input in the
+// same order as inputs.
 type BatchEmbeddingClient interface {
 	CreateEmbeddings(ctx context.Context, inputs []string) ([][]float32, error)
 }

--- a/internal/service/embedding_client.go
+++ b/internal/service/embedding_client.go
@@ -9,3 +9,10 @@ type EmbeddingClient interface {
 	CreateEmbedding(ctx context.Context, input string) ([]float32, error)
 	CreateEmbeddingForQuery(ctx context.Context, input string) ([]float32, error)
 }
+
+// BatchEmbeddingClient is an optional provider capability for embedding multiple documents in one
+// request. Workers use it when batching is enabled; providers that do not implement it continue to
+// receive one request per document.
+type BatchEmbeddingClient interface {
+	CreateEmbeddings(ctx context.Context, inputs []string) ([][]float32, error)
+}

--- a/internal/service/feedback_records_service.go
+++ b/internal/service/feedback_records_service.go
@@ -89,6 +89,9 @@ type EmbeddingsRepository interface {
 	ListFeedbackRecordIDsForBackfillByInputKind(
 		ctx context.Context, model string, inputKind models.EmbeddingInputKind, afterID uuid.UUID, limit int,
 	) ([]uuid.UUID, error)
+	ListTenantFeedbackRecordIDsForBackfillByInputKind(
+		ctx context.Context, tenantID, model string, inputKind models.EmbeddingInputKind, afterID uuid.UUID, limit int,
+	) ([]uuid.UUID, error)
 }
 
 // EnrichmentClearMetrics records enrichment outputs nulled by an edit's eager-clear, labeled by
@@ -598,6 +601,51 @@ func (s *FeedbackRecordsService) BackfillEmbeddingsWithInputKind(
 	model string,
 	inputKind models.EmbeddingInputKind,
 ) (int, error) {
+	return s.BackfillEmbeddingsWithInputKindLimit(ctx, model, inputKind, 0)
+}
+
+// BackfillEmbeddingsWithInputKindLimit enqueues global missing embedding jobs, stopping after
+// maxRecords candidates when maxRecords is positive. Zero means unlimited.
+func (s *FeedbackRecordsService) BackfillEmbeddingsWithInputKindLimit(
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	maxRecords int,
+) (int, error) {
+	return s.backfillEmbeddingsWithInputKind(ctx, model, inputKind, maxRecords,
+		func(ctx context.Context, afterID uuid.UUID, limit int) ([]uuid.UUID, error) {
+			return s.embeddingsRepo.ListFeedbackRecordIDsForBackfillByInputKind(
+				ctx, model, inputKind, afterID, limit)
+		})
+}
+
+// BackfillTenantEmbeddingsWithInputKind enqueues one tenant's missing embedding jobs, stopping
+// after maxRecords candidates when maxRecords is positive. Zero means unlimited.
+func (s *FeedbackRecordsService) BackfillTenantEmbeddingsWithInputKind(
+	ctx context.Context,
+	tenantID string,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	maxRecords int,
+) (int, error) {
+	if tenantID == "" {
+		return 0, ErrMissingTenantID
+	}
+
+	return s.backfillEmbeddingsWithInputKind(ctx, model, inputKind, maxRecords,
+		func(ctx context.Context, afterID uuid.UUID, limit int) ([]uuid.UUID, error) {
+			return s.embeddingsRepo.ListTenantFeedbackRecordIDsForBackfillByInputKind(
+				ctx, tenantID, model, inputKind, afterID, limit)
+		})
+}
+
+func (s *FeedbackRecordsService) backfillEmbeddingsWithInputKind( //nolint:funcorder // shared helper stays with public backfill entrypoints
+	ctx context.Context,
+	model string,
+	inputKind models.EmbeddingInputKind,
+	maxRecords int,
+	listPage func(context.Context, uuid.UUID, int) ([]uuid.UUID, error),
+) (int, error) {
 	if s.embeddingInserter == nil || s.embeddingQueueName == "" {
 		return 0, ErrEmbeddingBackfillNotConfigured
 	}
@@ -612,11 +660,20 @@ func (s *FeedbackRecordsService) BackfillEmbeddingsWithInputKind(
 
 	enqueued := 0
 	skipped := 0
+	processed := 0
 	afterID := uuid.Nil
 
 	for {
-		ids, err := s.embeddingsRepo.ListFeedbackRecordIDsForBackfillByInputKind(
-			ctx, model, inputKind, afterID, embeddingBackfillPageSize)
+		pageSize := embeddingBackfillPageSize
+		if maxRecords > 0 && maxRecords-processed < pageSize {
+			pageSize = maxRecords - processed
+		}
+
+		if pageSize <= 0 {
+			break
+		}
+
+		ids, err := listPage(ctx, afterID, pageSize)
 		if err != nil {
 			return enqueued, fmt.Errorf("list ids for embedding backfill: %w", err)
 		}
@@ -626,6 +683,8 @@ func (s *FeedbackRecordsService) BackfillEmbeddingsWithInputKind(
 		}
 
 		for _, id := range ids {
+			processed++
+
 			res, err := s.embeddingInserter.Insert(ctx, FeedbackEmbeddingArgs{
 				FeedbackRecordID: id,
 				Model:            model,

--- a/internal/workers/feedback_embedding_test.go
+++ b/internal/workers/feedback_embedding_test.go
@@ -38,6 +38,9 @@ func (m *countingEmbeddingMetrics) RecordWorkerError(_ context.Context, reason s
 }
 
 func (m *countingEmbeddingMetrics) RecordEmbeddingDuration(context.Context, time.Duration, string) {}
+func (m *countingEmbeddingMetrics) RecordEmbeddingBatch(context.Context, int64, time.Duration, string) {
+}
+func (m *countingEmbeddingMetrics) AddEmbeddingBatchInFlight(context.Context, int64) {}
 
 var _ observability.EmbeddingMetrics = (*countingEmbeddingMetrics)(nil)
 

--- a/tests/embedding_backfill_test.go
+++ b/tests/embedding_backfill_test.go
@@ -234,6 +234,14 @@ func TestTenantEmbeddingBackfillStaysInsideTenant(t *testing.T) {
 	}
 	bID := create(tenantB, "other tenant")
 
+	exists, err := embeddingsRepo.TenantExistsForEmbeddingBackfill(ctx, tenantA)
+	require.NoError(t, err)
+	assert.True(t, exists, "a tenant with feedback records is known to the backfill command")
+
+	exists, err = embeddingsRepo.TenantExistsForEmbeddingBackfill(ctx, uuid.NewString())
+	require.NoError(t, err)
+	assert.False(t, exists, "an unknown tenant ID is distinguishable from a fully backfilled tenant")
+
 	count, err := embeddingsRepo.CountTenantFeedbackRecordsForBackfillByInputKind(
 		ctx, tenantA, model, models.EmbeddingInputKindTaxonomyTranslated)
 	require.NoError(t, err)

--- a/tests/embedding_backfill_test.go
+++ b/tests/embedding_backfill_test.go
@@ -203,6 +203,67 @@ func TestBackfillEmbeddings_TaxonomyInputKind(t *testing.T) {
 	assert.True(t, found, "taxonomy backfill should enqueue the created record")
 }
 
+// TestTenantEmbeddingBackfillStaysInsideTenant verifies the operator-facing tenant scope at both
+// repository and enqueue boundaries. A global backfill may see both tenants, but the tenant path
+// must never return or enqueue the other tenant's records.
+func TestTenantEmbeddingBackfillStaysInsideTenant(t *testing.T) {
+	ctx := context.Background()
+	feedbackRepo, embeddingsRepo := embeddingBackfillRepos(t)
+
+	model := "tenant-backfill-" + uuid.NewString()
+	tenantA := uuid.NewString()
+	tenantB := uuid.NewString()
+
+	create := func(tenantID, value string) uuid.UUID {
+		record, err := feedbackRepo.Create(ctx, &models.CreateFeedbackRecordRequest{
+			SourceType:   "formbricks",
+			SubmissionID: uuid.NewString(),
+			TenantID:     tenantID,
+			FieldID:      "q1",
+			FieldType:    models.FieldTypeText,
+			ValueText:    &value,
+		})
+		require.NoError(t, err)
+
+		return record.ID
+	}
+
+	aIDs := map[uuid.UUID]bool{
+		create(tenantA, "one"): true,
+		create(tenantA, "two"): true,
+	}
+	bID := create(tenantB, "other tenant")
+
+	count, err := embeddingsRepo.CountTenantFeedbackRecordsForBackfillByInputKind(
+		ctx, tenantA, model, models.EmbeddingInputKindTaxonomyTranslated)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	page, err := embeddingsRepo.ListTenantFeedbackRecordIDsForBackfillByInputKind(
+		ctx, tenantA, model, models.EmbeddingInputKindTaxonomyTranslated, uuid.Nil, 10)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+
+	for _, id := range page {
+		assert.Truef(t, aIDs[id], "tenant-scoped repository returned foreign id %s", id)
+		assert.NotEqual(t, bID, id)
+	}
+
+	inserter := &countingEmbeddingInserter{}
+	svc := service.NewFeedbackRecordsService(feedbackRepo, embeddingsRepo, model, nil, inserter, "embeddings", 3, "")
+	enqueued, err := svc.BackfillTenantEmbeddingsWithInputKind(
+		ctx, tenantA, model, models.EmbeddingInputKindTaxonomyTranslated, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, enqueued, "maxRecords must bound the canary")
+	require.Len(t, inserter.ids, 1)
+	assert.True(t, aIDs[inserter.ids[0]], "tenant-scoped service must enqueue only tenant A")
+	assert.NotEqual(t, bID, inserter.ids[0])
+
+	_, err = svc.BackfillTenantEmbeddingsWithInputKind(
+		ctx, "", model, models.EmbeddingInputKindTaxonomyTranslated, 0)
+	require.ErrorIs(t, err, service.ErrMissingTenantID)
+}
+
 // TestEmbeddingsUpsert_StaleWriteGuard locks the concurrent-jobs guard: an upsert (or clear)
 // whose stillCurrent check fails against the record's current content is skipped with
 // ErrEmbeddingSuperseded, so a slower job that read older content can never clobber the vector

--- a/tests/enrichment_status_test.go
+++ b/tests/enrichment_status_test.go
@@ -305,7 +305,6 @@ func TestCountEnrichmentBacklogAggregateIfLeader(t *testing.T) {
 	leaderOne := repository.NewEnrichmentBacklogLeader(dbLeader)
 	leaderTwo := repository.NewEnrichmentBacklogLeader(dbRival)
 	fallbackRepo := repository.NewFeedbackRecordsRepository(dbLeader)
-	seedEnrichmentRecord(t, fallbackRepo, testTenantID("taxonomy-backlog"), models.FieldTypeText, "taxonomy pending")
 
 	taxonomyModel := "taxonomy:leader-test:translated-v1"
 
@@ -315,17 +314,25 @@ func TestCountEnrichmentBacklogAggregateIfLeader(t *testing.T) {
 	defer leaderOne.Close(ctx)
 	defer leaderTwo.Close(ctx)
 
-	// First replica wins leadership and gets real counts.
-	counts, isLeader, err := leaderOne.CountIfLeader(ctx, "", taxonomyModel)
+	// First replica wins leadership and establishes the existing taxonomy backlog baseline.
+	before, isLeader, err := leaderOne.CountIfLeader(ctx, "", taxonomyModel)
 	require.NoError(t, err)
 	require.True(t, isLeader, "the first replica to poll becomes the leader")
+
+	seedEnrichmentRecord(t, fallbackRepo, testTenantID("taxonomy-backlog-text"), models.FieldTypeText, "taxonomy pending")
+	seedEnrichmentRecord(
+		t, fallbackRepo, testTenantID("taxonomy-backlog-categorical"), models.FieldTypeCategorical, "not enrichable")
+
+	counts, isLeader, err := leaderOne.CountIfLeader(ctx, "", taxonomyModel)
+	require.NoError(t, err)
+	require.True(t, isLeader)
+	assert.Equal(t, before.TaxonomyEmbeddingPending+1, counts.TaxonomyEmbeddingPending,
+		"only the text record enters the live translation-to-taxonomy backlog")
 
 	// Prove the leader returns the real aggregate, not a zero value.
 	want, err := repository.NewEnrichmentStatusRepository(dbLeader).CountEnrichmentBacklogAggregate(ctx, "")
 	require.NoError(t, err)
 	assert.Equal(t, want.SentimentEligible, counts.SentimentEligible, "leader returns the true aggregate")
-	assert.Positive(t, counts.TaxonomyEmbeddingPending,
-		"the leader reports records missing the configured taxonomy embedding model")
 
 	// The second replica is denied — a normal skip, not an error — and must NOT publish counts.
 	zero, isLeader, err := leaderTwo.CountIfLeader(ctx, "", "")

--- a/tests/enrichment_status_test.go
+++ b/tests/enrichment_status_test.go
@@ -304,6 +304,10 @@ func TestCountEnrichmentBacklogAggregateIfLeader(t *testing.T) {
 
 	leaderOne := repository.NewEnrichmentBacklogLeader(dbLeader)
 	leaderTwo := repository.NewEnrichmentBacklogLeader(dbRival)
+	fallbackRepo := repository.NewFeedbackRecordsRepository(dbLeader)
+	seedEnrichmentRecord(t, fallbackRepo, testTenantID("taxonomy-backlog"), models.FieldTypeText, "taxonomy pending")
+
+	taxonomyModel := "taxonomy:leader-test:translated-v1"
 
 	// Release leadership before the pools close. Close is idempotent, and without this an early
 	// require failure would unwind into pgxpool.Close with the leader's connection still checked
@@ -312,7 +316,7 @@ func TestCountEnrichmentBacklogAggregateIfLeader(t *testing.T) {
 	defer leaderTwo.Close(ctx)
 
 	// First replica wins leadership and gets real counts.
-	counts, isLeader, err := leaderOne.CountIfLeader(ctx, "")
+	counts, isLeader, err := leaderOne.CountIfLeader(ctx, "", taxonomyModel)
 	require.NoError(t, err)
 	require.True(t, isLeader, "the first replica to poll becomes the leader")
 
@@ -320,27 +324,29 @@ func TestCountEnrichmentBacklogAggregateIfLeader(t *testing.T) {
 	want, err := repository.NewEnrichmentStatusRepository(dbLeader).CountEnrichmentBacklogAggregate(ctx, "")
 	require.NoError(t, err)
 	assert.Equal(t, want.SentimentEligible, counts.SentimentEligible, "leader returns the true aggregate")
+	assert.Positive(t, counts.TaxonomyEmbeddingPending,
+		"the leader reports records missing the configured taxonomy embedding model")
 
 	// The second replica is denied — a normal skip, not an error — and must NOT publish counts.
-	zero, isLeader, err := leaderTwo.CountIfLeader(ctx, "")
+	zero, isLeader, err := leaderTwo.CountIfLeader(ctx, "", "")
 	require.NoError(t, err, "losing the leader election is not an error")
 	assert.False(t, isLeader, "a second replica must not scan or export the global gauge")
 	assert.Equal(t, repository.EnrichmentStatusCounts{}, zero, "non-leader returns no counts to publish")
 
 	// Leadership is STICKY: unlike a scan-scoped lock, it persists across polls, so the same
 	// replica keeps exporting the series instead of it flapping between replicas.
-	_, stillLeader, err := leaderOne.CountIfLeader(ctx, "")
+	_, stillLeader, err := leaderOne.CountIfLeader(ctx, "", "")
 	require.NoError(t, err)
 	assert.True(t, stillLeader, "leadership is held for the process lifetime, not per scan")
 
-	_, stillDenied, err := leaderTwo.CountIfLeader(ctx, "")
+	_, stillDenied, err := leaderTwo.CountIfLeader(ctx, "", "")
 	require.NoError(t, err)
 	assert.False(t, stillDenied, "the follower stays a follower while the leader lives")
 
 	// Releasing hands leadership over promptly rather than waiting for a session timeout.
 	leaderOne.Close(ctx)
 
-	_, promoted, err := leaderTwo.CountIfLeader(ctx, "")
+	_, promoted, err := leaderTwo.CountIfLeader(ctx, "", "")
 	require.NoError(t, err)
 	assert.True(t, promoted, "a follower is promoted once the leader releases")
 
@@ -389,7 +395,7 @@ func TestEnrichmentBacklogLeaderLeavesNoSessionState(t *testing.T) {
 	// connection or db.Close() would block on it and wedge the suite. Close is idempotent.
 	defer leader.Close(ctx)
 
-	_, isLeader, err := leader.CountIfLeader(ctx, "")
+	_, isLeader, err := leader.CountIfLeader(ctx, "", "")
 	require.NoError(t, err)
 	require.True(t, isLeader, "single-connection pool must win leadership")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Hub-side throughput bottleneck that sent one TEI request per embedding job and left operators without a safe way to resume a stranded taxonomy backfill.

- adds optional OpenAI-compatible array embedding requests with strict response count, index, dimension, and finite-value validation
- coalesces worker document requests into bounded micro-batches while keeping one River job, freshness check, retry, and database write per record
- keeps query embeddings synchronous and preserves single-request fallback for non-batch providers
- adds batch throughput, outcome, duration, and in-flight metrics
- packages `backfill-embeddings` in the production image and adds tenant, count-only, and max-record controls
- publishes a durable `taxonomy_embedding` missing-record gauge so an empty embedding queue with remaining records is alertable

There is no external HTTP API or database-schema change. The new batch settings default to disabled behavior (`EMBEDDING_BATCH_SIZE=1`).

## How should this be tested?

- `make build` ✅
- `make lint GOLANGCI_LINT=/Users/bhagya/work/bin/golangci-lint` ✅ — 0 issues
- `go test -race ./internal/openai ./internal/service ./internal/observability ./internal/workers ./internal/config ./cmd/api ./cmd/worker ./cmd/backfill-embeddings` ✅
- `DATABASE_URL=postgres://postgres:postgres@localhost:55432/test_db?sslmode=disable API_KEY=test-api-key-for-ci go test ./tests/... -count=1 -timeout=120s` ✅ against an isolated `pgvector/pgvector:pg18` database
- Verify a worker configured with batch size 8 emits one ordered vector per River job and query requests remain single.
- Run `backfill-embeddings --taxonomy --count-only --tenant-id <tenant>`, then a bounded `--max-records` canary, before an unlimited enqueue.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran integration tests in `tests/`
- [x] Ran formatter and full linter; no warnings
- [x] Removed debug prints / temporary logging
- [x] Branch contains the latest `origin/main`
- [x] No database schema change

### Appreciated

- [x] No external API/OpenAPI change
- [x] Updated environment-variable documentation
