### PR TITLE
feat: add a records-scoped tenant purge endpoint (ENG-2129)

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -370,6 +370,11 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	tenantDataService := service.NewTenantDataService(tenantDataRepo)
 	tenantDataHandler := handlers.NewTenantDataHandler(tenantDataService)
 
+	// The API only ever enqueues the feedback-records purge; hub-worker performs it. The repo is
+	// still wired in because the service owns both halves, but this process never reaches Purge.
+	feedbackRecordsPurgeService := service.NewFeedbackRecordsPurgeService(tenantDataRepo, riverClient)
+	feedbackRecordsPurgeHandler := handlers.NewFeedbackRecordsPurgeHandler(feedbackRecordsPurgeService)
+
 	tenantSettingsHandler := handlers.NewTenantSettingsHandler(tenantSettingsService)
 
 	// Translation, sentiment, and emotion enqueue providers all resolve a per-tenant setting on
@@ -484,7 +489,8 @@ func NewApp(cfg *config.Config, db *pgxpool.Pool) (*App, error) {
 	}
 
 	server := newHTTPServer(
-		cfg, healthHandler, openapiHandler, feedbackRecordsHandler, webhooksHandler, tenantDataHandler,
+		cfg, healthHandler, openapiHandler, feedbackRecordsHandler, feedbackRecordsPurgeHandler,
+		webhooksHandler, tenantDataHandler,
 		tenantSettingsHandler, searchHandler,
 		taxonomyHandler, taxonomyInternalHandler, enrichmentStatusHandler,
 		meterProvider, tracerProvider,
@@ -511,6 +517,7 @@ func newHTTPServer(
 	health *handlers.HealthHandler,
 	openapi *handlers.OpenAPIHandler,
 	feedback *handlers.FeedbackRecordsHandler,
+	feedbackPurge *handlers.FeedbackRecordsPurgeHandler,
 	webhooks *handlers.WebhooksHandler,
 	tenantData *handlers.TenantDataHandler,
 	tenantSettings *handlers.TenantSettingsHandler,
@@ -534,6 +541,9 @@ func newHTTPServer(
 	protected.HandleFunc("PATCH /v1/feedback-records/{id}", feedback.Update)
 	protected.HandleFunc("DELETE /v1/feedback-records/{id}", feedback.Delete)
 	protected.HandleFunc("DELETE /v1/feedback-records", feedback.DeleteByUser)
+	// Literal segment, so it takes precedence over /v1/feedback-records/{id} rather than shadowing
+	// it. Kept off the collection DELETE deliberately — see FeedbackRecordsPurgeHandler.Purge.
+	protected.HandleFunc("POST /v1/feedback-records/purge", feedbackPurge.Purge)
 
 	protected.HandleFunc("POST /v1/webhooks", webhooks.Create)
 	protected.HandleFunc("GET /v1/webhooks", webhooks.List)

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -541,9 +541,6 @@ func newHTTPServer(
 	protected.HandleFunc("PATCH /v1/feedback-records/{id}", feedback.Update)
 	protected.HandleFunc("DELETE /v1/feedback-records/{id}", feedback.Delete)
 	protected.HandleFunc("DELETE /v1/feedback-records", feedback.DeleteByUser)
-	// Literal segment, so it takes precedence over /v1/feedback-records/{id} rather than shadowing
-	// it. Kept off the collection DELETE deliberately — see FeedbackRecordsPurgeHandler.Purge.
-	protected.HandleFunc("POST /v1/feedback-records/purge", feedbackPurge.Purge)
 
 	protected.HandleFunc("POST /v1/webhooks", webhooks.Create)
 	protected.HandleFunc("GET /v1/webhooks", webhooks.List)
@@ -551,6 +548,9 @@ func newHTTPServer(
 	protected.HandleFunc("PATCH /v1/webhooks/{id}", webhooks.Update)
 	protected.HandleFunc("DELETE /v1/webhooks/{id}", webhooks.Delete)
 	protected.HandleFunc("DELETE /v1/tenants/{tenant_id}/data", tenantData.Delete)
+	// Under /v1/tenants (which the gateway does not route publicly) rather than beside the
+	// feedback-records collection — see FeedbackRecordsPurgeHandler.Purge.
+	protected.HandleFunc("DELETE /v1/tenants/{tenant_id}/feedback-records", feedbackPurge.Purge)
 	protected.HandleFunc("GET /v1/tenants/{tenant_id}/settings", tenantSettings.Get)
 	protected.HandleFunc("PUT /v1/tenants/{tenant_id}/settings", tenantSettings.Update)
 	protected.HandleFunc("PATCH /v1/tenants/{tenant_id}/settings", tenantSettings.Patch)

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -547,6 +547,7 @@ func newTestHTTPServerWithConfig(t *testing.T, publicBaseURL string, taxonomy co
 		handlers.NewHealthHandler(),
 		newTestOpenAPIHandler(t, publicBaseURL),
 		handlers.NewFeedbackRecordsHandler(nil),
+		handlers.NewFeedbackRecordsPurgeHandler(nil),
 		handlers.NewWebhooksHandler(nil),
 		handlers.NewTenantDataHandler(nil),
 		handlers.NewTenantSettingsHandler(nil),

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -86,11 +86,18 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 	webhookSender := service.NewWebhookSenderImpl(
 		webhooksRepo, webhookMetrics, cfg.Webhook.URLBlacklist, cfg.Webhook.HTTPTimeout.Duration(), nil)
 
+	// hub-worker performs feedback-records purges; it never enqueues them (the API does), so the
+	// service is built without an inserter.
+	tenantDataRepo := repository.NewTenantDataRepository(db, cfg.TenantData.PurgeLockTimeout.Duration())
+	feedbackRecordsPurgeService := service.NewFeedbackRecordsPurgeService(tenantDataRepo, nil)
+
 	deps := workers.RiverDeps{
 		WebhooksRepo:       webhooksRepo,
 		WebhookSender:      webhookSender,
 		WebhookHTTPTimeout: cfg.Webhook.HTTPTimeout.Duration(),
 		WebhookMetrics:     webhookMetrics,
+
+		FeedbackRecordsPurgeService: feedbackRecordsPurgeService,
 	}
 
 	providerName, embeddingModel := embeddingProviderAndModel(cfg)

--- a/internal/api/handlers/feedback_records_purge_handler.go
+++ b/internal/api/handlers/feedback_records_purge_handler.go
@@ -24,28 +24,27 @@ func NewFeedbackRecordsPurgeHandler(service FeedbackRecordsPurgeService) *Feedba
 	return &FeedbackRecordsPurgeHandler{service: service}
 }
 
-// Purge handles POST /v1/feedback-records/purge.
+// Purge handles DELETE /v1/tenants/{tenant_id}/feedback-records.
 //
-// The tenant is taken from the body and is required. This is deliberately its own path rather than
-// a tenant_id filter on DELETE /v1/feedback-records: that collection delete erases one data
-// subject's records (GDPR) and is reachable by callers who should never be able to empty a whole
-// dataset, and a filter that widens the blast radius when omitted is the classic accidental
-// mass-deletion shape. A distinct path cannot be reached by dropping a parameter.
+// Sits under /v1/tenants/ rather than /v1/feedback-records/ for two reasons, both about blast
+// radius. The gateway publicly routes the /v1/feedback-records prefix and injects Hub credentials
+// into it, so an endpoint there is exposed to the internet and defended only by the ext_authz route
+// allowlist; nothing routes /v1/tenants, which is why the offboarding purge lives there too. And
+// taking the tenant as a required path segment means it cannot be omitted: drop it and the request
+// routes somewhere else entirely, rather than widening into "every tenant" the way a missing filter
+// on a collection delete would.
 //
 // Responds 202: the purge is unbounded and runs as a background job, so acceptance is all that can
-// honestly be reported here. Callers observe completion by polling GET /v1/feedback-records/count
-// for the tenant.
+// honestly be reported here. Callers observe completion by polling
+// GET /v1/feedback-records/count?tenant_id=... for the tenant.
 func (h *FeedbackRecordsPurgeHandler) Purge(w http.ResponseWriter, r *http.Request) {
-	req := &models.FeedbackRecordsPurgeRequest{}
-	if !decodeRecordBody(w, r, req) {
-		return
-	}
+	tenantID := r.PathValue("tenant_id")
 
-	accepted, err := h.service.Enqueue(r.Context(), req.TenantID)
+	accepted, err := h.service.Enqueue(r.Context(), tenantID)
 	if err != nil {
 		response.RespondErrorWithLogAttrs(w, r, err,
-			"tenant_id_present", req.TenantID != "",
-			"tenant_id_length", len(req.TenantID),
+			"tenant_id_present", tenantID != "",
+			"tenant_id_length", len(tenantID),
 		)
 
 		return

--- a/internal/api/handlers/feedback_records_purge_handler.go
+++ b/internal/api/handlers/feedback_records_purge_handler.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/formbricks/hub/internal/api/response"
+	"github.com/formbricks/hub/internal/models"
+)
+
+// FeedbackRecordsPurgeService defines the interface for accepting a tenant feedback-records purge.
+// Only the enqueue half lives here; performing the purge is hub-worker's job.
+type FeedbackRecordsPurgeService interface {
+	Enqueue(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error)
+}
+
+// FeedbackRecordsPurgeHandler handles tenant feedback-records purge requests.
+type FeedbackRecordsPurgeHandler struct {
+	service FeedbackRecordsPurgeService
+}
+
+// NewFeedbackRecordsPurgeHandler creates a new feedback-records purge handler.
+func NewFeedbackRecordsPurgeHandler(service FeedbackRecordsPurgeService) *FeedbackRecordsPurgeHandler {
+	return &FeedbackRecordsPurgeHandler{service: service}
+}
+
+// Purge handles POST /v1/feedback-records/purge.
+//
+// The tenant is taken from the body and is required. This is deliberately its own path rather than
+// a tenant_id filter on DELETE /v1/feedback-records: that collection delete erases one data
+// subject's records (GDPR) and is reachable by callers who should never be able to empty a whole
+// dataset, and a filter that widens the blast radius when omitted is the classic accidental
+// mass-deletion shape. A distinct path cannot be reached by dropping a parameter.
+//
+// Responds 202: the purge is unbounded and runs as a background job, so acceptance is all that can
+// honestly be reported here. Callers observe completion by polling GET /v1/feedback-records/count
+// for the tenant.
+func (h *FeedbackRecordsPurgeHandler) Purge(w http.ResponseWriter, r *http.Request) {
+	req := &models.FeedbackRecordsPurgeRequest{}
+	if !decodeRecordBody(w, r, req) {
+		return
+	}
+
+	accepted, err := h.service.Enqueue(r.Context(), req.TenantID)
+	if err != nil {
+		response.RespondErrorWithLogAttrs(w, r, err,
+			"tenant_id_present", req.TenantID != "",
+			"tenant_id_length", len(req.TenantID),
+		)
+
+		return
+	}
+
+	response.RespondJSON(w, http.StatusAccepted, accepted)
+}

--- a/internal/api/handlers/feedback_records_purge_handler_test.go
+++ b/internal/api/handlers/feedback_records_purge_handler_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -112,20 +113,26 @@ func TestFeedbackRecordsPurgeHandler_Purge(t *testing.T) {
 		assert.Zero(t, mock.calls)
 	})
 
-	t.Run("a tenant write conflict surfaces as a retryable 409", func(t *testing.T) {
+	// Accepting a purge takes no tenant lock — the exclusive lock is taken by the worker — so this
+	// endpoint has no 409, and the spec documents none. A failure to schedule must not read as
+	// success, because the caller's next signal is the record count, which would look unchanged for
+	// a purge that was never queued.
+	t.Run("a scheduling failure is an error, not an accepted purge", func(t *testing.T) {
 		mock := &mockFeedbackRecordsPurgeService{
 			enqueueFunc: func(_ context.Context, _ string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
-				return nil, huberrors.NewTenantWriteConflictError("tenant data purge in progress for this tenant; retry later")
+				return nil, errors.New("queue unavailable")
 			},
 		}
 
 		rec := httptest.NewRecorder()
 		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123"}`))
 
-		require.Equal(t, http.StatusConflict, rec.Code)
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.NotEqual(t, http.StatusAccepted, rec.Code)
 
 		var problem map[string]any
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &problem))
-		assert.Equal(t, "tenant_write_conflict", problem["code"])
+		// The internal failure reason is never relayed to the caller.
+		assert.NotContains(t, problem["detail"], "queue unavailable")
 	})
 }

--- a/internal/api/handlers/feedback_records_purge_handler_test.go
+++ b/internal/api/handlers/feedback_records_purge_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +17,13 @@ import (
 
 type mockFeedbackRecordsPurgeService struct {
 	enqueueFunc func(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error)
-	calls       int
+	tenantIDs   []string
 }
 
 func (m *mockFeedbackRecordsPurgeService) Enqueue(
 	ctx context.Context, tenantID string,
 ) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
-	m.calls++
+	m.tenantIDs = append(m.tenantIDs, tenantID)
 
 	if m.enqueueFunc != nil {
 		return m.enqueueFunc(ctx, tenantID)
@@ -36,11 +35,14 @@ func (m *mockFeedbackRecordsPurgeService) Enqueue(
 	}, nil
 }
 
-func purgeRequest(body string) *http.Request {
+// The handler reads the tenant from the path value, not the URL, so the URL stays fixed — a raw
+// blank tenant in the path would not even be a parseable request line.
+func purgeRequest(tenantID string) *http.Request {
 	req := httptest.NewRequestWithContext(
-		context.Background(), http.MethodPost, "http://test/v1/feedback-records/purge", strings.NewReader(body),
+		context.Background(), http.MethodDelete,
+		"http://test/v1/tenants/tenant/feedback-records", http.NoBody,
 	)
-	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("tenant_id", tenantID)
 
 	return req
 }
@@ -49,20 +51,19 @@ func TestFeedbackRecordsPurgeHandler_Purge(t *testing.T) {
 	t.Run("accepted returns 202 and does not report a deleted count", func(t *testing.T) {
 		mock := &mockFeedbackRecordsPurgeService{
 			enqueueFunc: func(_ context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
-				assert.Equal(t, "org-123", tenantID)
-
 				return &models.FeedbackRecordsPurgeAcceptedResponse{
-					TenantID: "org-123",
+					TenantID: tenantID,
 					Status:   models.FeedbackRecordsPurgeStatusAccepted,
-					Message:  "Feedback records purge accepted for org-123",
+					Message:  "Feedback records purge accepted for " + tenantID,
 				}, nil
 			},
 		}
 
 		rec := httptest.NewRecorder()
-		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123"}`))
+		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest("org-123"))
 
 		require.Equal(t, http.StatusAccepted, rec.Code)
+		assert.Equal(t, []string{"org-123"}, mock.tenantIDs)
 
 		var body map[string]any
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
@@ -72,46 +73,28 @@ func TestFeedbackRecordsPurgeHandler_Purge(t *testing.T) {
 		assert.NotContains(t, body, "deleted_count")
 	})
 
-	// A missing or empty tenant_id must fail, never fall back to a wider scope.
+	// The tenant is a path segment, so it cannot be omitted — the request would route elsewhere.
+	// An empty or blank value still has to be rejected rather than treated as "all tenants".
 	for _, testCase := range []struct {
-		name string
-		body string
+		name     string
+		tenantID string
 	}{
-		{name: "missing tenant_id", body: `{}`},
-		{name: "empty tenant_id", body: `{"tenant_id":""}`},
-		{name: "blank tenant_id", body: `{"tenant_id":"   "}`},
+		{name: "empty tenant", tenantID: ""},
+		{name: "blank tenant", tenantID: "   "},
 	} {
-		t.Run(testCase.name+" is rejected without enqueueing", func(t *testing.T) {
+		t.Run(testCase.name+" is rejected", func(t *testing.T) {
 			mock := &mockFeedbackRecordsPurgeService{
-				enqueueFunc: func(_ context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
-					// Reached only for values that pass body validation; the service still
-					// normalizes, so a blank value is rejected here instead.
-					if strings.TrimSpace(tenantID) == "" {
-						return nil, huberrors.NewValidationError("tenant_id", "tenant_id is required")
-					}
-
-					return &models.FeedbackRecordsPurgeAcceptedResponse{TenantID: tenantID}, nil
+				enqueueFunc: func(_ context.Context, _ string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+					return nil, huberrors.NewValidationError("tenant_id", "tenant_id is required")
 				},
 			}
 
 			rec := httptest.NewRecorder()
-			NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(testCase.body))
+			NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(testCase.tenantID))
 
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		})
 	}
-
-	t.Run("unknown fields are rejected", func(t *testing.T) {
-		mock := &mockFeedbackRecordsPurgeService{}
-
-		rec := httptest.NewRecorder()
-		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123","user_id":"u-1"}`))
-
-		// A caller narrowing the purge with a filter the endpoint does not honor must get an error,
-		// not a silently wider deletion than they asked for.
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		assert.Zero(t, mock.calls)
-	})
 
 	// Accepting a purge takes no tenant lock — the exclusive lock is taken by the worker — so this
 	// endpoint has no 409, and the spec documents none. A failure to schedule must not read as
@@ -125,10 +108,9 @@ func TestFeedbackRecordsPurgeHandler_Purge(t *testing.T) {
 		}
 
 		rec := httptest.NewRecorder()
-		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123"}`))
+		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest("org-123"))
 
 		require.Equal(t, http.StatusInternalServerError, rec.Code)
-		assert.NotEqual(t, http.StatusAccepted, rec.Code)
 
 		var problem map[string]any
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &problem))

--- a/internal/api/handlers/feedback_records_purge_handler_test.go
+++ b/internal/api/handlers/feedback_records_purge_handler_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+)
+
+type mockFeedbackRecordsPurgeService struct {
+	enqueueFunc func(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error)
+	calls       int
+}
+
+func (m *mockFeedbackRecordsPurgeService) Enqueue(
+	ctx context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+	m.calls++
+
+	if m.enqueueFunc != nil {
+		return m.enqueueFunc(ctx, tenantID)
+	}
+
+	return &models.FeedbackRecordsPurgeAcceptedResponse{
+		TenantID: tenantID,
+		Status:   models.FeedbackRecordsPurgeStatusAccepted,
+	}, nil
+}
+
+func purgeRequest(body string) *http.Request {
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, "http://test/v1/feedback-records/purge", strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	return req
+}
+
+func TestFeedbackRecordsPurgeHandler_Purge(t *testing.T) {
+	t.Run("accepted returns 202 and does not report a deleted count", func(t *testing.T) {
+		mock := &mockFeedbackRecordsPurgeService{
+			enqueueFunc: func(_ context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+				assert.Equal(t, "org-123", tenantID)
+
+				return &models.FeedbackRecordsPurgeAcceptedResponse{
+					TenantID: "org-123",
+					Status:   models.FeedbackRecordsPurgeStatusAccepted,
+					Message:  "Feedback records purge accepted for org-123",
+				}, nil
+			},
+		}
+
+		rec := httptest.NewRecorder()
+		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123"}`))
+
+		require.Equal(t, http.StatusAccepted, rec.Code)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(t, "org-123", body["tenant_id"])
+		assert.Equal(t, models.FeedbackRecordsPurgeStatusAccepted, body["status"])
+		// The purge has not run yet, so any count here would be a promise the endpoint cannot keep.
+		assert.NotContains(t, body, "deleted_count")
+	})
+
+	// A missing or empty tenant_id must fail, never fall back to a wider scope.
+	for _, testCase := range []struct {
+		name string
+		body string
+	}{
+		{name: "missing tenant_id", body: `{}`},
+		{name: "empty tenant_id", body: `{"tenant_id":""}`},
+		{name: "blank tenant_id", body: `{"tenant_id":"   "}`},
+	} {
+		t.Run(testCase.name+" is rejected without enqueueing", func(t *testing.T) {
+			mock := &mockFeedbackRecordsPurgeService{
+				enqueueFunc: func(_ context.Context, tenantID string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+					// Reached only for values that pass body validation; the service still
+					// normalizes, so a blank value is rejected here instead.
+					if strings.TrimSpace(tenantID) == "" {
+						return nil, huberrors.NewValidationError("tenant_id", "tenant_id is required")
+					}
+
+					return &models.FeedbackRecordsPurgeAcceptedResponse{TenantID: tenantID}, nil
+				},
+			}
+
+			rec := httptest.NewRecorder()
+			NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(testCase.body))
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+
+	t.Run("unknown fields are rejected", func(t *testing.T) {
+		mock := &mockFeedbackRecordsPurgeService{}
+
+		rec := httptest.NewRecorder()
+		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123","user_id":"u-1"}`))
+
+		// A caller narrowing the purge with a filter the endpoint does not honor must get an error,
+		// not a silently wider deletion than they asked for.
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Zero(t, mock.calls)
+	})
+
+	t.Run("a tenant write conflict surfaces as a retryable 409", func(t *testing.T) {
+		mock := &mockFeedbackRecordsPurgeService{
+			enqueueFunc: func(_ context.Context, _ string) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+				return nil, huberrors.NewTenantWriteConflictError("tenant data purge in progress for this tenant; retry later")
+			},
+		}
+
+		rec := httptest.NewRecorder()
+		NewFeedbackRecordsPurgeHandler(mock).Purge(rec, purgeRequest(`{"tenant_id":"org-123"}`))
+
+		require.Equal(t, http.StatusConflict, rec.Code)
+
+		var problem map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &problem))
+		assert.Equal(t, "tenant_write_conflict", problem["code"])
+	})
+}

--- a/internal/models/feedback_records_purge.go
+++ b/internal/models/feedback_records_purge.go
@@ -1,0 +1,43 @@
+package models
+
+// FeedbackRecordsPurgeCounts is the repository result for a tenant's feedback-records purge.
+//
+// Deliberately narrower than TenantDataDeleteCounts: this purge removes the tenant's feedback
+// records and the data derived from them, and leaves the tenant's taxonomy structure, webhooks and
+// settings in place. Cluster memberships are counted because they are derived per record (a
+// membership is "this record belongs to that cluster"); the clusters, nodes and runs themselves
+// survive.
+type FeedbackRecordsPurgeCounts struct {
+	DeletedFeedbackRecords int64
+	DeletedEmbeddings      int64
+
+	// DeletedTaxonomyClusterMemberships counts the record→cluster links dropped with the records.
+	// The clusters keep existing; they simply end up with no members.
+	DeletedTaxonomyClusterMemberships int64
+}
+
+// FeedbackRecordsPurgeRequest is the body for POST /v1/feedback-records/purge.
+//
+// tenant_id is required and lives in the body rather than being an optional filter on the
+// collection delete: an omitted or empty value must never widen a narrower deletion into a
+// tenant-wide one.
+type FeedbackRecordsPurgeRequest struct {
+	TenantID string `json:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
+}
+
+// FeedbackRecordsPurgeAcceptedResponse is the 202 body for POST /v1/feedback-records/purge.
+//
+// The purge runs as a background job, so there is no deleted count to report: the work has been
+// accepted, not done. Callers observe progress from the data instead, by polling
+// GET /v1/feedback-records/count for the tenant until it reaches zero. Deliberately no count is
+// echoed here — one taken at enqueue time is stale the moment ingestion continues, and would read
+// as a promise about how much this purge will remove.
+type FeedbackRecordsPurgeAcceptedResponse struct {
+	TenantID string `json:"tenant_id"`
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+}
+
+// FeedbackRecordsPurgeStatusAccepted is the only status POST /v1/feedback-records/purge reports.
+// The purge is fire-and-forget from the API's point of view; completion is observed from the data.
+const FeedbackRecordsPurgeStatusAccepted = "accepted"

--- a/internal/models/feedback_records_purge.go
+++ b/internal/models/feedback_records_purge.go
@@ -16,16 +16,8 @@ type FeedbackRecordsPurgeCounts struct {
 	DeletedTaxonomyClusterMemberships int64
 }
 
-// FeedbackRecordsPurgeRequest is the body for POST /v1/feedback-records/purge.
-//
-// tenant_id is required and lives in the body rather than being an optional filter on the
-// collection delete: an omitted or empty value must never widen a narrower deletion into a
-// tenant-wide one.
-type FeedbackRecordsPurgeRequest struct {
-	TenantID string `json:"tenant_id" validate:"required,no_null_bytes,min=1,max=255"`
-}
-
-// FeedbackRecordsPurgeAcceptedResponse is the 202 body for POST /v1/feedback-records/purge.
+// FeedbackRecordsPurgeAcceptedResponse is the 202 body for
+// DELETE /v1/tenants/{tenant_id}/feedback-records.
 //
 // The purge runs as a background job, so there is no deleted count to report: the work has been
 // accepted, not done. Callers observe progress from the data instead, by polling
@@ -38,6 +30,6 @@ type FeedbackRecordsPurgeAcceptedResponse struct {
 	Message  string `json:"message"`
 }
 
-// FeedbackRecordsPurgeStatusAccepted is the only status POST /v1/feedback-records/purge reports.
-// The purge is fire-and-forget from the API's point of view; completion is observed from the data.
+// FeedbackRecordsPurgeStatusAccepted is the only status the purge endpoint reports. The purge is
+// fire-and-forget from the API's point of view; completion is observed from the data.
 const FeedbackRecordsPurgeStatusAccepted = "accepted"

--- a/internal/models/feedback_records_purge.go
+++ b/internal/models/feedback_records_purge.go
@@ -2,18 +2,18 @@ package models
 
 // FeedbackRecordsPurgeCounts is the repository result for a tenant's feedback-records purge.
 //
-// Deliberately narrower than TenantDataDeleteCounts: this purge removes the tenant's feedback
-// records and the data derived from them, and leaves the tenant's taxonomy structure, webhooks and
-// settings in place. Cluster memberships are counted because they are derived per record (a
-// membership is "this record belongs to that cluster"); the clusters, nodes and runs themselves
-// survive.
+// Narrower than TenantDataDeleteCounts in exactly one respect: this purge removes the tenant's
+// feedback records, everything derived from them, and the taxonomy built on them, but leaves the
+// tenant's *configuration* — its webhooks and its settings — alone.
 type FeedbackRecordsPurgeCounts struct {
+	// The taxonomy goes with the records it describes. Keeping it would leave a tree whose nodes
+	// all count zero while the run header still reported its original record_count, and which the
+	// dashboard hides behind its minimum-records gate anyway — so it would be neither usable nor
+	// visible, only misleading if the dataset later refilled.
+	TenantTaxonomyDeleteCounts
+
 	DeletedFeedbackRecords int64
 	DeletedEmbeddings      int64
-
-	// DeletedTaxonomyClusterMemberships counts the record→cluster links dropped with the records.
-	// The clusters keep existing; they simply end up with no members.
-	DeletedTaxonomyClusterMemberships int64
 }
 
 // FeedbackRecordsPurgeAcceptedResponse is the 202 body for

--- a/internal/models/tenant_data.go
+++ b/internal/models/tenant_data.go
@@ -1,5 +1,17 @@
 package models
 
+// TenantTaxonomyDeleteCounts is the per-table result of removing a tenant's taxonomy artifacts.
+// Shared by both purges — the offboarding purge and the narrower feedback-records purge each take
+// the whole taxonomy, so they report the same numbers.
+type TenantTaxonomyDeleteCounts struct {
+	Runs               int64
+	Clusters           int64
+	ClusterMemberships int64
+	Nodes              int64
+	ActiveRuns         int64
+	NodeEvents         int64
+}
+
 // TenantDataDeleteCounts is the repository result for a tenant data purge.
 type TenantDataDeleteCounts struct {
 	DeletedFeedbackRecords int64

--- a/internal/repository/feedback_records_purge_repository_test.go
+++ b/internal/repository/feedback_records_purge_repository_test.go
@@ -46,8 +46,8 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("DeletedEmbeddings = %d, want 1512", counts.DeletedEmbeddings)
 		}
 
-		if counts.DeletedTaxonomyClusterMemberships != 308 {
-			t.Fatalf("DeletedTaxonomyClusterMemberships = %d, want 308", counts.DeletedTaxonomyClusterMemberships)
+		if counts.ClusterMemberships != 308 {
+			t.Fatalf("DeletedTaxonomyClusterMemberships = %d, want 308", counts.ClusterMemberships)
 		}
 	})
 
@@ -94,14 +94,18 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			}
 		}
 
-		if lockAcquisitions != 2 {
-			t.Fatalf("exclusive lock taken %d times, want once per batch (2)", lockAcquisitions)
+		// One per record batch (2 here, the second returning zero) plus one for the final taxonomy
+		// transaction.
+		if lockAcquisitions != 3 {
+			t.Fatalf("exclusive lock taken %d times, want one per batch plus the taxonomy pass (3)", lockAcquisitions)
 		}
 	})
 
-	// The purge must stay narrower than the offboarding purge. If it ever starts deleting the
-	// taxonomy structure, webhooks or settings, a purged dataset silently loses its topic tree.
-	t.Run("touches only records and rows derived from them", func(t *testing.T) {
+	// The line this purge draws: it takes the data AND the taxonomy built on that data, but never the
+	// tenant's configuration. Deleting webhooks would destroy integrator setup (including signing keys
+	// that reads never return); deleting tenant_settings would silently revert enrichment opt-outs to
+	// enabled. Both are the offboarding purge's job, not this one's.
+	t.Run("takes the records and the taxonomy but never the configuration", func(t *testing.T) {
 		transaction := purgeBatches([]int64{10, 5, 3}, []int64{0, 0, 0})
 
 		if _, err := newRecordsPurgeRepo(transaction).
@@ -109,26 +113,54 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
-		statements := strings.Join(transaction.purgeBatchQueries, "\n")
-		for _, table := range []string{
-			"taxonomy_runs",
-			"taxonomy_clusters",
-			"taxonomy_nodes",
-			"taxonomy_active_runs",
-			"taxonomy_node_events",
-			"webhooks",
-			"tenant_settings",
-		} {
-			if strings.Contains(statements, "DELETE FROM "+table+"\n") ||
-				strings.Contains(statements, "DELETE FROM "+table+" ") {
-				t.Fatalf("purge deleted from %q; it must only remove records and rows derived from them", table)
+		statements := strings.Join(append(append([]string{}, transaction.purgeBatchQueries...), transaction.queries...), "\n")
+
+		for _, table := range []string{"webhooks", "tenant_settings"} {
+			if strings.Contains(statements, "DELETE FROM "+table) {
+				t.Fatalf("purge deleted from %q; that is tenant configuration, not tenant data", table)
 			}
 		}
 
-		for _, want := range []string{"DELETE FROM embeddings", "DELETE FROM taxonomy_cluster_memberships", "DELETE FROM feedback_records"} {
+		for _, want := range []string{
+			"DELETE FROM embeddings",
+			"DELETE FROM feedback_records",
+			"DELETE FROM taxonomy_cluster_memberships",
+			"DELETE FROM taxonomy_node_events",
+			"DELETE FROM taxonomy_nodes",
+			"DELETE FROM taxonomy_clusters",
+			"DELETE FROM taxonomy_active_runs",
+			"DELETE FROM taxonomy_runs",
+		} {
 			if !strings.Contains(statements, want) {
 				t.Fatalf("purge statement missing %q", want)
 			}
+		}
+	})
+
+	// The taxonomy goes last: a purge interrupted midway should leave records missing but the tree
+	// standing, never a tree describing records that are already gone.
+	t.Run("removes the taxonomy only after the records", func(t *testing.T) {
+		transaction := purgeBatches([]int64{10, 0, 0}, []int64{0, 0, 0})
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		if len(transaction.purgeBatchQueries) == 0 {
+			t.Fatal("no record batches ran")
+		}
+
+		taxonomyStarted := false
+
+		for _, query := range transaction.queries {
+			if strings.Contains(query, "DELETE FROM taxonomy_runs") {
+				taxonomyStarted = true
+			}
+		}
+
+		if !taxonomyStarted {
+			t.Fatal("taxonomy was never removed")
 		}
 	})
 

--- a/internal/repository/feedback_records_purge_repository_test.go
+++ b/internal/repository/feedback_records_purge_repository_test.go
@@ -1,0 +1,206 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/formbricks/hub/internal/huberrors"
+)
+
+// recordsPurgeDeleteTags returns command tags for the three DELETE statements
+// purgeFeedbackRecordsInTx issues, in execution order, each with a distinct row count so the
+// per-table count mapping is pinned rather than coincidentally correct.
+func recordsPurgeDeleteTags() []pgconn.CommandTag {
+	return []pgconn.CommandTag{
+		pgconn.NewCommandTag("DELETE 2"),  // embeddings
+		pgconn.NewCommandTag("DELETE 12"), // taxonomy_cluster_memberships
+		pgconn.NewCommandTag("DELETE 30"), // feedback_records
+	}
+}
+
+func newRecordsPurgeRepo(transaction *fakeTenantWriteTx) *TenantDataRepository {
+	return &TenantDataRepository{db: &fakeTenantWriteDB{tx: transaction}, purgeLockTimeout: 5 * time.Second}
+}
+
+func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
+	t.Run("locks tenant exclusively, commits, and returns per-table counts", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		counts, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123")
+		if err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		if counts.DeletedEmbeddings != 2 {
+			t.Fatalf("DeletedEmbeddings = %d, want 2", counts.DeletedEmbeddings)
+		}
+
+		if counts.DeletedTaxonomyClusterMemberships != 12 {
+			t.Fatalf("DeletedTaxonomyClusterMemberships = %d, want 12", counts.DeletedTaxonomyClusterMemberships)
+		}
+
+		if counts.DeletedFeedbackRecords != 30 {
+			t.Fatalf("DeletedFeedbackRecords = %d, want 30", counts.DeletedFeedbackRecords)
+		}
+
+		if !transaction.committed {
+			t.Fatal("transaction was not committed")
+		}
+
+		if len(transaction.queries) != 6 {
+			t.Fatalf("queries = %d, want 6 (3 lock statements + 3 deletes)", len(transaction.queries))
+		}
+
+		// The purge holds the tenant write lock exclusively, same as the full tenant purge: an
+		// unbounded tenant-wide delete must not race concurrent ingestion.
+		assertQueryContains(t, transaction.queries[0], "set_config('lock_timeout', $1, true)")
+		assertQueryContains(t, transaction.queries[1], "pg_advisory_xact_lock(hashtextextended($1, 0))")
+		assertQueryContains(t, transaction.queries[2], "set_config('lock_timeout', '0', true)")
+
+		if len(transaction.args[1]) != 1 || transaction.args[1][0] != TenantWriteLockKey("org-123") {
+			t.Fatalf("lock args = %#v, want tenant write lock key", transaction.args[1])
+		}
+	})
+
+	// Children before parents, so each count is exact rather than swallowed by a cascade.
+	t.Run("deletes derived rows before the records they hang off", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		assertQueryContains(t, transaction.queries[3], "DELETE FROM embeddings")
+		assertQueryContains(t, transaction.queries[4], "DELETE FROM taxonomy_cluster_memberships")
+		assertQueryContains(t, transaction.queries[5], "DELETE FROM feedback_records")
+	})
+
+	// The whole point of this purge is that it is narrower than DeleteByTenant. If it ever starts
+	// touching the tenant's taxonomy structure, webhooks or settings, the dataset stops being usable
+	// after a purge and the endpoint has silently become the offboarding purge.
+	t.Run("leaves taxonomy structure, webhooks and settings untouched", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		for _, table := range []string{
+			"taxonomy_runs",
+			"taxonomy_clusters",
+			"taxonomy_nodes",
+			"taxonomy_active_runs",
+			"taxonomy_node_events",
+			"webhooks",
+			"tenant_settings",
+		} {
+			for _, query := range transaction.queries {
+				if strings.Contains(query, "DELETE FROM "+table) {
+					t.Fatalf("purge deleted from %q; it must only remove records and rows derived from them", table)
+				}
+			}
+		}
+	})
+
+	// Every statement is scoped by the tenant. An unscoped delete here would empty the table.
+	t.Run("scopes every delete to the tenant", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		for i, query := range transaction.queries[3:] {
+			if !strings.Contains(query, "tenant_id = $1") {
+				t.Fatalf("delete %d is not tenant-scoped: %s", i, query)
+			}
+
+			args := transaction.args[i+3]
+			if len(args) != 1 || args[0] != "org-123" {
+				t.Fatalf("delete %d args = %#v, want the tenant id", i, args)
+			}
+		}
+	})
+
+	t.Run("lock timeout returns a retryable conflict without deleting", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags:       purgeLockTags(),
+				errAtQuery: 2,
+				err:        &pgconn.PgError{Code: lockNotAvailableSQLState},
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		counts, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123")
+		if !errors.Is(err, huberrors.ErrTenantWriteConflict) {
+			t.Fatalf("error = %v, want tenant write conflict", err)
+		}
+
+		if counts != nil {
+			t.Fatalf("counts = %+v, want nil", counts)
+		}
+
+		if transaction.committed {
+			t.Fatal("transaction was committed despite the lock conflict")
+		}
+
+		if len(transaction.queries) != 2 {
+			t.Fatalf("queries = %d, want 2 (lock attempt only, no deletes)", len(transaction.queries))
+		}
+	})
+
+	t.Run("a failed delete rolls back rather than committing a partial purge", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{
+				tags:       append(purgeLockTags(), recordsPurgeDeleteTags()...),
+				errAtQuery: 5, // the taxonomy_cluster_memberships delete
+			},
+			rollbackErr: pgx.ErrTxClosed,
+		}
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err == nil {
+			t.Fatal("PurgeFeedbackRecordsByTenant() error = nil, want the delete failure")
+		}
+
+		if transaction.committed {
+			t.Fatal("transaction was committed despite a failed delete")
+		}
+
+		if !transaction.rolledBack {
+			t.Fatal("deferred rollback was not called")
+		}
+	})
+}

--- a/internal/repository/feedback_records_purge_repository_test.go
+++ b/internal/repository/feedback_records_purge_repository_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -21,8 +22,11 @@ func newRecordsPurgeRepo(transaction *fakeTenantWriteTx) *TenantDataRepository {
 // each entry is one batch's (records, embeddings, memberships) counts, and a zero-record batch ends
 // the purge.
 func purgeBatches(batches ...[]int64) *fakeTenantWriteTx {
+	highWaterMark := uuid.New()
+
 	return &fakeTenantWriteTx{
 		fakeTenantDataExecutor: fakeTenantDataExecutor{tags: purgeLockTags()},
+		highWaterMark:          &highWaterMark,
 		purgeBatchRows:         batches,
 		rollbackErr:            pgx.ErrTxClosed,
 	}
@@ -138,7 +142,8 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 	})
 
 	// The taxonomy goes last: a purge interrupted midway should leave records missing but the tree
-	// standing, never a tree describing records that are already gone.
+	// standing, never a tree describing records that are already gone. Asserted against the single
+	// ordered statement log — comparing the per-phase slices would pass with the phases swapped.
 	t.Run("removes the taxonomy only after the records", func(t *testing.T) {
 		transaction := purgeBatches([]int64{10, 0, 0}, []int64{0, 0, 0})
 
@@ -147,20 +152,29 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
-		if len(transaction.purgeBatchQueries) == 0 {
-			t.Fatal("no record batches ran")
-		}
+		lastBatch, firstTaxonomy := -1, -1
 
-		taxonomyStarted := false
+		for i, statement := range transaction.statements {
+			if strings.Contains(statement, "WITH victims") {
+				lastBatch = i
+			}
 
-		for _, query := range transaction.queries {
-			if strings.Contains(query, "DELETE FROM taxonomy_runs") {
-				taxonomyStarted = true
+			if firstTaxonomy == -1 && strings.Contains(statement, "DELETE FROM taxonomy_runs") {
+				firstTaxonomy = i
 			}
 		}
 
-		if !taxonomyStarted {
+		if lastBatch == -1 {
+			t.Fatal("no record batches ran")
+		}
+
+		if firstTaxonomy == -1 {
 			t.Fatal("taxonomy was never removed")
+		}
+
+		if firstTaxonomy < lastBatch {
+			t.Fatalf("taxonomy removed at statement %d, before the last record batch at %d",
+				firstTaxonomy, lastBatch)
 		}
 	})
 
@@ -179,13 +193,78 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("batch is not tenant-scoped: %s", statement)
 		}
 
-		if !strings.Contains(statement, "LIMIT $2") {
+		if !strings.Contains(statement, "LIMIT $3") {
 			t.Fatalf("batch is not bounded: %s", statement)
 		}
 
+		if !strings.Contains(statement, "id <= $2") {
+			t.Fatalf("batch is not bounded to the records that existed at purge start: %s", statement)
+		}
+
 		args := transaction.purgeBatchArgs[0]
-		if len(args) != 2 || args[0] != "org-123" || args[1] != feedbackRecordsPurgeBatchSize {
-			t.Fatalf("batch args = %#v, want tenant + batch size", args)
+		if len(args) != 3 || args[0] != "org-123" || args[2] != feedbackRecordsPurgeBatchSize {
+			t.Fatalf("batch args = %#v, want tenant + high-water mark + batch size", args)
+		}
+
+		if args[1] != *transaction.highWaterMark {
+			t.Fatalf("batch high-water mark = %v, want the ceiling read at purge start", args[1])
+		}
+	})
+
+	// Without a ceiling, a tenant that keeps ingesting keeps feeding the loop: the purge might never
+	// reach a zero batch, and it would delete feedback that arrived after the operator asked to empty
+	// the dataset.
+	t.Run("reads the ceiling once, before any batch", func(t *testing.T) {
+		transaction := purgeBatches([]int64{10, 0, 0}, []int64{0, 0, 0})
+
+		if _, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		if transaction.highWaterMarkReads != 1 {
+			t.Fatalf("high-water mark read %d times, want exactly once", transaction.highWaterMarkReads)
+		}
+
+		for _, args := range transaction.purgeBatchArgs {
+			if args[1] != *transaction.highWaterMark {
+				t.Fatalf("a batch used a different ceiling: %v", args[1])
+			}
+		}
+	})
+
+	// A tenant with no records at all must not run a batch, but must still clear any taxonomy left
+	// behind by an earlier run.
+	t.Run("skips the record loop when the tenant has none", func(t *testing.T) {
+		transaction := &fakeTenantWriteTx{
+			fakeTenantDataExecutor: fakeTenantDataExecutor{tags: purgeLockTags()},
+			rollbackErr:            pgx.ErrTxClosed,
+		}
+
+		counts, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123")
+		if err != nil {
+			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
+		}
+
+		if len(transaction.purgeBatchQueries) != 0 {
+			t.Fatalf("ran %d batches for a tenant with no records", len(transaction.purgeBatchQueries))
+		}
+
+		if counts.DeletedFeedbackRecords != 0 {
+			t.Fatalf("DeletedFeedbackRecords = %d, want 0", counts.DeletedFeedbackRecords)
+		}
+
+		taxonomyRan := false
+
+		for _, query := range transaction.queries {
+			if strings.Contains(query, "DELETE FROM taxonomy_runs") {
+				taxonomyRan = true
+			}
+		}
+
+		if !taxonomyRan {
+			t.Fatal("taxonomy was not cleared for a tenant with no records")
 		}
 	})
 

--- a/internal/repository/feedback_records_purge_repository_test.go
+++ b/internal/repository/feedback_records_purge_repository_test.go
@@ -13,29 +13,24 @@ import (
 	"github.com/formbricks/hub/internal/huberrors"
 )
 
-// recordsPurgeDeleteTags returns command tags for the three DELETE statements
-// purgeFeedbackRecordsInTx issues, in execution order, each with a distinct row count so the
-// per-table count mapping is pinned rather than coincidentally correct.
-func recordsPurgeDeleteTags() []pgconn.CommandTag {
-	return []pgconn.CommandTag{
-		pgconn.NewCommandTag("DELETE 2"),  // embeddings
-		pgconn.NewCommandTag("DELETE 12"), // taxonomy_cluster_memberships
-		pgconn.NewCommandTag("DELETE 30"), // feedback_records
-	}
-}
-
 func newRecordsPurgeRepo(transaction *fakeTenantWriteTx) *TenantDataRepository {
 	return &TenantDataRepository{db: &fakeTenantWriteDB{tx: transaction}, purgeLockTimeout: 5 * time.Second}
 }
 
+// The batch statement is a single QueryRow, so the fake transaction's row results drive the loop:
+// each entry is one batch's (records, embeddings, memberships) counts, and a zero-record batch ends
+// the purge.
+func purgeBatches(batches ...[]int64) *fakeTenantWriteTx {
+	return &fakeTenantWriteTx{
+		fakeTenantDataExecutor: fakeTenantDataExecutor{tags: purgeLockTags()},
+		purgeBatchRows:         batches,
+		rollbackErr:            pgx.ErrTxClosed,
+	}
+}
+
 func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
-	t.Run("locks tenant exclusively, commits, and returns per-table counts", func(t *testing.T) {
-		transaction := &fakeTenantWriteTx{
-			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
-			},
-			rollbackErr: pgx.ErrTxClosed,
-		}
+	t.Run("sums the batches and stops on an empty one", func(t *testing.T) {
+		transaction := purgeBatches([]int64{2000, 1500, 300}, []int64{40, 12, 8}, []int64{0, 0, 0})
 
 		counts, err := newRecordsPurgeRepo(transaction).
 			PurgeFeedbackRecordsByTenant(context.Background(), "org-123")
@@ -43,72 +38,78 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
-		if counts.DeletedEmbeddings != 2 {
-			t.Fatalf("DeletedEmbeddings = %d, want 2", counts.DeletedEmbeddings)
+		if counts.DeletedFeedbackRecords != 2040 {
+			t.Fatalf("DeletedFeedbackRecords = %d, want 2040", counts.DeletedFeedbackRecords)
 		}
 
-		if counts.DeletedTaxonomyClusterMemberships != 12 {
-			t.Fatalf("DeletedTaxonomyClusterMemberships = %d, want 12", counts.DeletedTaxonomyClusterMemberships)
+		if counts.DeletedEmbeddings != 1512 {
+			t.Fatalf("DeletedEmbeddings = %d, want 1512", counts.DeletedEmbeddings)
 		}
 
-		if counts.DeletedFeedbackRecords != 30 {
-			t.Fatalf("DeletedFeedbackRecords = %d, want 30", counts.DeletedFeedbackRecords)
-		}
-
-		if !transaction.committed {
-			t.Fatal("transaction was not committed")
-		}
-
-		if len(transaction.queries) != 6 {
-			t.Fatalf("queries = %d, want 6 (3 lock statements + 3 deletes)", len(transaction.queries))
-		}
-
-		// The purge holds the tenant write lock exclusively, same as the full tenant purge: an
-		// unbounded tenant-wide delete must not race concurrent ingestion.
-		assertQueryContains(t, transaction.queries[0], "set_config('lock_timeout', $1, true)")
-		assertQueryContains(t, transaction.queries[1], "pg_advisory_xact_lock(hashtextextended($1, 0))")
-		assertQueryContains(t, transaction.queries[2], "set_config('lock_timeout', '0', true)")
-
-		if len(transaction.args[1]) != 1 || transaction.args[1][0] != TenantWriteLockKey("org-123") {
-			t.Fatalf("lock args = %#v, want tenant write lock key", transaction.args[1])
+		if counts.DeletedTaxonomyClusterMemberships != 308 {
+			t.Fatalf("DeletedTaxonomyClusterMemberships = %d, want 308", counts.DeletedTaxonomyClusterMemberships)
 		}
 	})
 
-	// Children before parents, so each count is exact rather than swallowed by a cascade.
-	t.Run("deletes derived rows before the records they hang off", func(t *testing.T) {
-		transaction := &fakeTenantWriteTx{
-			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
-			},
-			rollbackErr: pgx.ErrTxClosed,
+	// The whole point of batching: each batch is its own transaction, so a purge that dies partway
+	// keeps what it deleted and the retry resumes. A single transaction would roll everything back
+	// on every rescue, and a tenant too large for one attempt could never be purged at all.
+	t.Run("commits every batch so progress survives a failure", func(t *testing.T) {
+		transaction := purgeBatches([]int64{2000, 0, 0}, []int64{2000, 0, 0})
+		transaction.purgeBatchErrAt = 3 // the third batch fails
+
+		counts, err := newRecordsPurgeRepo(transaction).
+			PurgeFeedbackRecordsByTenant(context.Background(), "org-123")
+		if err == nil {
+			t.Fatal("PurgeFeedbackRecordsByTenant() error = nil, want the batch failure")
 		}
+
+		if counts == nil || counts.DeletedFeedbackRecords != 4000 {
+			t.Fatalf("counts = %+v, want the 4000 records already committed", counts)
+		}
+
+		if transaction.commits != 2 {
+			t.Fatalf("commits = %d, want 2 (one per successful batch)", transaction.commits)
+		}
+	})
+
+	t.Run("locks the tenant exclusively for every batch", func(t *testing.T) {
+		transaction := purgeBatches([]int64{10, 0, 0}, []int64{0, 0, 0})
 
 		if _, err := newRecordsPurgeRepo(transaction).
 			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
-		assertQueryContains(t, transaction.queries[3], "DELETE FROM embeddings")
-		assertQueryContains(t, transaction.queries[4], "DELETE FROM taxonomy_cluster_memberships")
-		assertQueryContains(t, transaction.queries[5], "DELETE FROM feedback_records")
+		lockAcquisitions := 0
+
+		for i, query := range transaction.queries {
+			if strings.Contains(query, "pg_advisory_xact_lock(hashtextextended($1, 0))") {
+				lockAcquisitions++
+
+				args := transaction.args[i]
+				if len(args) != 1 || args[0] != TenantWriteLockKey("org-123") {
+					t.Fatalf("lock args = %#v, want the tenant write lock key", args)
+				}
+			}
+		}
+
+		if lockAcquisitions != 2 {
+			t.Fatalf("exclusive lock taken %d times, want once per batch (2)", lockAcquisitions)
+		}
 	})
 
-	// The whole point of this purge is that it is narrower than DeleteByTenant. If it ever starts
-	// touching the tenant's taxonomy structure, webhooks or settings, the dataset stops being usable
-	// after a purge and the endpoint has silently become the offboarding purge.
-	t.Run("leaves taxonomy structure, webhooks and settings untouched", func(t *testing.T) {
-		transaction := &fakeTenantWriteTx{
-			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
-			},
-			rollbackErr: pgx.ErrTxClosed,
-		}
+	// The purge must stay narrower than the offboarding purge. If it ever starts deleting the
+	// taxonomy structure, webhooks or settings, a purged dataset silently loses its topic tree.
+	t.Run("touches only records and rows derived from them", func(t *testing.T) {
+		transaction := purgeBatches([]int64{10, 5, 3}, []int64{0, 0, 0})
 
 		if _, err := newRecordsPurgeRepo(transaction).
 			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
+		statements := strings.Join(transaction.purgeBatchQueries, "\n")
 		for _, table := range []string{
 			"taxonomy_runs",
 			"taxonomy_clusters",
@@ -118,37 +119,41 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			"webhooks",
 			"tenant_settings",
 		} {
-			for _, query := range transaction.queries {
-				if strings.Contains(query, "DELETE FROM "+table) {
-					t.Fatalf("purge deleted from %q; it must only remove records and rows derived from them", table)
-				}
+			if strings.Contains(statements, "DELETE FROM "+table+"\n") ||
+				strings.Contains(statements, "DELETE FROM "+table+" ") {
+				t.Fatalf("purge deleted from %q; it must only remove records and rows derived from them", table)
+			}
+		}
+
+		for _, want := range []string{"DELETE FROM embeddings", "DELETE FROM taxonomy_cluster_memberships", "DELETE FROM feedback_records"} {
+			if !strings.Contains(statements, want) {
+				t.Fatalf("purge statement missing %q", want)
 			}
 		}
 	})
 
-	// Every statement is scoped by the tenant. An unscoped delete here would empty the table.
-	t.Run("scopes every delete to the tenant", func(t *testing.T) {
-		transaction := &fakeTenantWriteTx{
-			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags: append(purgeLockTags(), recordsPurgeDeleteTags()...),
-			},
-			rollbackErr: pgx.ErrTxClosed,
-		}
+	// Every delete is scoped by the tenant, and the batch is bounded — an unscoped or unbounded
+	// statement here would empty the table or hold the lock indefinitely.
+	t.Run("scopes and bounds every batch", func(t *testing.T) {
+		transaction := purgeBatches([]int64{0, 0, 0})
 
 		if _, err := newRecordsPurgeRepo(transaction).
 			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err != nil {
 			t.Fatalf("PurgeFeedbackRecordsByTenant() error = %v", err)
 		}
 
-		for i, query := range transaction.queries[3:] {
-			if !strings.Contains(query, "tenant_id = $1") {
-				t.Fatalf("delete %d is not tenant-scoped: %s", i, query)
-			}
+		statement := transaction.purgeBatchQueries[0]
+		if !strings.Contains(statement, "tenant_id = $1") {
+			t.Fatalf("batch is not tenant-scoped: %s", statement)
+		}
 
-			args := transaction.args[i+3]
-			if len(args) != 1 || args[0] != "org-123" {
-				t.Fatalf("delete %d args = %#v, want the tenant id", i, args)
-			}
+		if !strings.Contains(statement, "LIMIT $2") {
+			t.Fatalf("batch is not bounded: %s", statement)
+		}
+
+		args := transaction.purgeBatchArgs[0]
+		if len(args) != 2 || args[0] != "org-123" || args[1] != feedbackRecordsPurgeBatchSize {
+			t.Fatalf("batch args = %#v, want tenant + batch size", args)
 		}
 	})
 
@@ -168,39 +173,36 @@ func TestTenantDataRepository_PurgeFeedbackRecordsByTenant(t *testing.T) {
 			t.Fatalf("error = %v, want tenant write conflict", err)
 		}
 
-		if counts != nil {
-			t.Fatalf("counts = %+v, want nil", counts)
+		if counts == nil || counts.DeletedFeedbackRecords != 0 {
+			t.Fatalf("counts = %+v, want zero deletions", counts)
 		}
 
-		if transaction.committed {
+		if transaction.commits != 0 {
 			t.Fatal("transaction was committed despite the lock conflict")
 		}
 
-		if len(transaction.queries) != 2 {
-			t.Fatalf("queries = %d, want 2 (lock attempt only, no deletes)", len(transaction.queries))
+		if len(transaction.purgeBatchQueries) != 0 {
+			t.Fatal("a batch ran despite the lock conflict")
 		}
 	})
 
-	t.Run("a failed delete rolls back rather than committing a partial purge", func(t *testing.T) {
-		transaction := &fakeTenantWriteTx{
-			fakeTenantDataExecutor: fakeTenantDataExecutor{
-				tags:       append(purgeLockTags(), recordsPurgeDeleteTags()...),
-				errAtQuery: 5, // the taxonomy_cluster_memberships delete
-			},
-			rollbackErr: pgx.ErrTxClosed,
+	// A cancelled context must stop the loop rather than spinning; the committed batches stand.
+	t.Run("stops on a cancelled context and keeps committed progress", func(t *testing.T) {
+		transaction := purgeBatches([]int64{2000, 0, 0}, []int64{2000, 0, 0}, []int64{0, 0, 0})
+		ctx, cancel := context.WithCancel(context.Background())
+		transaction.afterBatch = func(batches int) {
+			if batches == 1 {
+				cancel()
+			}
 		}
 
-		if _, err := newRecordsPurgeRepo(transaction).
-			PurgeFeedbackRecordsByTenant(context.Background(), "org-123"); err == nil {
-			t.Fatal("PurgeFeedbackRecordsByTenant() error = nil, want the delete failure")
+		counts, err := newRecordsPurgeRepo(transaction).PurgeFeedbackRecordsByTenant(ctx, "org-123")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
 		}
 
-		if transaction.committed {
-			t.Fatal("transaction was committed despite a failed delete")
-		}
-
-		if !transaction.rolledBack {
-			t.Fatal("deferred rollback was not called")
+		if counts.DeletedFeedbackRecords != 2000 {
+			t.Fatalf("DeletedFeedbackRecords = %d, want the 2000 already committed", counts.DeletedFeedbackRecords)
 		}
 	})
 }

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/formbricks/hub/internal/huberrors"
 	"github.com/formbricks/hub/internal/models"
 )
 
@@ -56,6 +58,15 @@ func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID stri
 // released between batches instead of being held for the whole delete.
 const feedbackRecordsPurgeBatchSize = 2000
 
+// feedbackRecordsPurgeBatchPause is how long the purge yields between batches.
+//
+// Tenant-owned writes take the write lock with a non-blocking try-acquire, so they are rejected the
+// moment an exclusive acquisition is queued. Without a pause the purge re-queues immediately after
+// each batch commits, and a long purge rejects that tenant's ingestion more or less continuously —
+// across every workspace the dataset is shared with. Yielding briefly leaves a window in which
+// writers actually win the lock. It costs a few seconds per 100k records.
+const feedbackRecordsPurgeBatchPause = 50 * time.Millisecond
+
 // PurgeFeedbackRecordsByTenant deletes every feedback record for a tenant, everything derived from
 // those records, and the taxonomy built on them, returning exact per-table counts. Unlike
 // DeleteByTenant it leaves the tenant's *configuration* — webhooks and settings — intact, so the
@@ -66,6 +77,12 @@ const feedbackRecordsPurgeBatchSize = 2000
 // ones actually achieved even on a partial failure. Taxonomy artifacts are bounded by the number of
 // runs, so once the records are gone they are removed in one final transaction.
 //
+// Bounded to the records that existed when the purge started, via a high-water mark on the uuidv7
+// id. Two reasons, both load-bearing: the exclusive lock is released between batches, so without a
+// bound a tenant that keeps ingesting keeps feeding the loop and the purge may never reach a zero
+// batch; and an operator asked to empty what they saw, not to delete feedback that arrived
+// afterwards.
+//
 // Ordering matters: the taxonomy phase runs last so that a purge interrupted midway leaves records
 // missing but the tree still standing, rather than the reverse — a tree with no records is the
 // misleading state, and it is exactly what the final phase removes.
@@ -74,16 +91,18 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 ) (*models.FeedbackRecordsPurgeCounts, error) {
 	total := &models.FeedbackRecordsPurgeCounts{}
 
-	for {
+	highWaterMark, hasRecords, err := r.feedbackRecordsHighWaterMark(ctx, tenantID)
+	if err != nil {
+		return total, err
+	}
+
+	for hasRecords {
 		if err := ctx.Err(); err != nil {
 			// Report the progress already committed; the retry resumes from here.
 			return total, fmt.Errorf("purge feedback records for tenant: %w", err)
 		}
 
-		batch, err := withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge",
-			func(ctx context.Context, tx tenantWriteTx, tenantID string) (*models.FeedbackRecordsPurgeCounts, error) {
-				return purgeFeedbackRecordsBatchInTx(ctx, tx, tenantID, feedbackRecordsPurgeBatchSize)
-			})
+		batch, err := r.purgeFeedbackRecordsBatch(ctx, tenantID, highWaterMark)
 		if err != nil {
 			return total, err
 		}
@@ -91,11 +110,20 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 		total.DeletedFeedbackRecords += batch.DeletedFeedbackRecords
 		total.DeletedEmbeddings += batch.DeletedEmbeddings
 		// Memberships are removed per batch alongside the records they belong to, so they are summed
-		// across both phases; the final taxonomy pass finds none left and adds zero.
+		// across both phases. The taxonomy pass usually finds none left, but it can still delete some:
+		// the lock is released between phases, so a record ingested and clustered in that window
+		// contributes memberships that only the final pass reaches.
 		total.ClusterMemberships += batch.ClusterMemberships
 
 		if batch.DeletedFeedbackRecords == 0 {
 			break
+		}
+
+		// Let the tenant's writers through before queueing the next exclusive acquisition.
+		select {
+		case <-ctx.Done():
+			return total, fmt.Errorf("purge feedback records for tenant: %w", ctx.Err())
+		case <-time.After(feedbackRecordsPurgeBatchPause):
 		}
 	}
 
@@ -117,6 +145,84 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 	return total, nil
 }
 
+// feedbackRecordsPurgeBatchLockAttempts bounds how many times a single batch re-tries a lock
+// conflict before giving up and failing the job.
+//
+// A purge takes the exclusive tenant lock once per batch, so a large tenant acquires it hundreds of
+// times, each acquisition bounded by the configured purge lock timeout. Without an in-loop retry a
+// single slow writer anywhere in that sequence fails the whole attempt, and River's fixed retry
+// budget is consumed by transient contention rather than real faults — a big, actively-written
+// tenant could exhaust every attempt while making progress each time.
+const feedbackRecordsPurgeBatchLockAttempts = 5
+
+// purgeFeedbackRecordsBatch runs one batch, re-trying a tenant write conflict rather than failing
+// the whole purge. Any other error is returned immediately: only lock contention is transient.
+func (r *TenantDataRepository) purgeFeedbackRecordsBatch(
+	ctx context.Context, tenantID string, highWaterMark uuid.UUID,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	var lastErr error
+
+	for range feedbackRecordsPurgeBatchLockAttempts {
+		batch, err := withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge",
+			func(ctx context.Context, tx tenantWriteTx, tenantID string) (*models.FeedbackRecordsPurgeCounts, error) {
+				return purgeFeedbackRecordsBatchInTx(ctx, tx, tenantID, highWaterMark, feedbackRecordsPurgeBatchSize)
+			})
+		if err == nil {
+			return batch, nil
+		}
+
+		if !errors.Is(err, huberrors.ErrTenantWriteConflict) {
+			return nil, err
+		}
+
+		lastErr = err
+
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("purge feedback records batch: %w", ctxErr)
+		}
+	}
+
+	return nil, lastErr
+}
+
+// feedbackRecordsHighWaterMark returns the newest record id the purge should remove, and whether the
+// tenant has any records at all. Bounding on the id works because it is uuidv7, and therefore
+// time-ordered.
+func (r *TenantDataRepository) feedbackRecordsHighWaterMark(
+	ctx context.Context, tenantID string,
+) (uuid.UUID, bool, error) {
+	dbTx, err := r.db.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return uuid.Nil, false, fmt.Errorf("begin feedback records high-water mark transaction: %w", err)
+	}
+
+	defer func() {
+		if err := dbTx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) && ctx.Err() == nil {
+			slog.Error("feedback records purge: high-water mark rollback failed",
+				"tenant_id_present", tenantID != "",
+				"tenant_id_length", len(tenantID),
+				"error", err,
+			)
+		}
+	}()
+
+	// ORDER BY id DESC rather than max(id): Postgres has no max() aggregate for uuid. This is the
+	// largest id by definition, which is what the batches must not exceed.
+	var highWaterMark uuid.UUID
+	if err := dbTx.QueryRow(ctx, `
+		SELECT id FROM feedback_records WHERE tenant_id = $1 ORDER BY id DESC LIMIT 1`, tenantID,
+	).Scan(&highWaterMark); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// No records: the loop is skipped entirely and only the taxonomy pass runs.
+			return uuid.Nil, false, nil
+		}
+
+		return uuid.Nil, false, fmt.Errorf("read feedback records high-water mark: %w", err)
+	}
+
+	return highWaterMark, true, nil
+}
+
 // purgeFeedbackRecordsBatchInTx removes up to limit of a tenant's feedback records and the rows
 // derived from them, returning exact per-table counts for the batch. Returns zero records deleted
 // when the tenant has none left, which is what ends the loop.
@@ -135,13 +241,17 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 // data. Enrichment output (sentiment, emotions, translations) needs no statement of its own — it
 // lives in columns on feedback_records and goes with the row.
 func purgeFeedbackRecordsBatchInTx(
-	ctx context.Context, tx tenantWriteTx, tenantID string, limit int,
+	ctx context.Context, transaction tenantWriteTx, tenantID string, highWaterMark uuid.UUID, limit int,
 ) (*models.FeedbackRecordsPurgeCounts, error) {
 	counts := &models.FeedbackRecordsPurgeCounts{}
 
-	err := tx.QueryRow(ctx, `
+	// Deliberately unordered: the rows are being deleted, so any `limit` of them make progress, and
+	// there is no (tenant_id, id) index — an ORDER BY makes every batch sort the tenant's entire
+	// remaining set to keep 2000, which is quadratic over exactly the large tenants batching exists
+	// for.
+	err := transaction.QueryRow(ctx, `
 		WITH victims AS (
-			SELECT id FROM feedback_records WHERE tenant_id = $1 ORDER BY id LIMIT $2
+			SELECT id FROM feedback_records WHERE tenant_id = $1 AND id <= $2 LIMIT $3
 		),
 		deleted_embeddings AS (
 			DELETE FROM embeddings
@@ -161,7 +271,7 @@ func purgeFeedbackRecordsBatchInTx(
 		SELECT
 			(SELECT count(*) FROM deleted_records),
 			(SELECT count(*) FROM deleted_embeddings),
-			(SELECT count(*) FROM deleted_memberships)`, tenantID, limit,
+			(SELECT count(*) FROM deleted_memberships)`, tenantID, highWaterMark, limit,
 	).Scan(&counts.DeletedFeedbackRecords, &counts.DeletedEmbeddings, &counts.ClusterMemberships)
 	if err != nil {
 		return nil, fmt.Errorf("purge tenant feedback records batch: %w", err)

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -56,17 +56,19 @@ func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID stri
 // released between batches instead of being held for the whole delete.
 const feedbackRecordsPurgeBatchSize = 2000
 
-// PurgeFeedbackRecordsByTenant deletes every feedback record for a tenant, plus the data derived
-// from those records, and returns exact per-table counts. Unlike DeleteByTenant it leaves the
-// tenant's taxonomy structure, webhooks and settings intact, so the dataset stays usable.
+// PurgeFeedbackRecordsByTenant deletes every feedback record for a tenant, everything derived from
+// those records, and the taxonomy built on them, returning exact per-table counts. Unlike
+// DeleteByTenant it leaves the tenant's *configuration* — webhooks and settings — intact, so the
+// dataset stays usable and any integrator setup survives.
 //
-// Runs as a sequence of committed batches (see feedbackRecordsPurgeBatchSize), so it is resumable
-// and reports the counts it actually achieved even when it fails partway.
+// Two phases, because the two halves have different shapes. Records are unbounded, so they go in
+// committed batches (see feedbackRecordsPurgeBatchSize): resumable, and the counts reported are the
+// ones actually achieved even on a partial failure. Taxonomy artifacts are bounded by the number of
+// runs, so once the records are gone they are removed in one final transaction.
 //
-// Scoped to the records that existed when the purge started: the id column is uuidv7, so a
-// high-water mark bounds the work to a fixed set. Without it a tenant still receiving feedback
-// could keep the loop running indefinitely, and records submitted *after* the operator asked to
-// empty the dataset would be deleted without ever having been part of what they saw.
+// Ordering matters: the taxonomy phase runs last so that a purge interrupted midway leaves records
+// missing but the tree still standing, rather than the reverse — a tree with no records is the
+// misleading state, and it is exactly what the final phase removes.
 func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 	ctx context.Context, tenantID string,
 ) (*models.FeedbackRecordsPurgeCounts, error) {
@@ -88,12 +90,31 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 
 		total.DeletedFeedbackRecords += batch.DeletedFeedbackRecords
 		total.DeletedEmbeddings += batch.DeletedEmbeddings
-		total.DeletedTaxonomyClusterMemberships += batch.DeletedTaxonomyClusterMemberships
+		// Memberships are removed per batch alongside the records they belong to, so they are summed
+		// across both phases; the final taxonomy pass finds none left and adds zero.
+		total.ClusterMemberships += batch.ClusterMemberships
 
 		if batch.DeletedFeedbackRecords == 0 {
-			return total, nil
+			break
 		}
 	}
+
+	taxonomy, err := withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge taxonomy",
+		func(ctx context.Context, tx tenantWriteTx, tenantID string) (*models.TenantTaxonomyDeleteCounts, error) {
+			return deleteTenantTaxonomyInTx(ctx, tx, tenantID)
+		})
+	if err != nil {
+		return total, err
+	}
+
+	total.Runs = taxonomy.Runs
+	total.Clusters = taxonomy.Clusters
+	total.Nodes = taxonomy.Nodes
+	total.ActiveRuns = taxonomy.ActiveRuns
+	total.NodeEvents = taxonomy.NodeEvents
+	total.ClusterMemberships += taxonomy.ClusterMemberships
+
+	return total, nil
 }
 
 // purgeFeedbackRecordsBatchInTx removes up to limit of a tenant's feedback records and the rows
@@ -108,16 +129,11 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 // equivalent, not additional. embeddings carries no tenant_id of its own, but every victim id comes
 // from a tenant-scoped select, so the delete stays inside the tenant boundary.
 //
-// What is deliberately NOT touched, and why:
-//   - taxonomy runs, clusters and nodes — the topic structure is the point of keeping this purge
-//     narrow. The clusters simply end up with no members, and per-node record counts are derived
-//     from memberships at read time, so those fall to zero on their own. The stored counters
-//     (taxonomy_clusters.size, taxonomy_runs.record_count) are left alone deliberately: they record
-//     what a run processed, and rewriting them would falsify the run's history. Note this means
-//     taxonomy run reads still report the original record_count after a purge.
-//   - webhooks and tenant_settings — tenant configuration, not tenant data.
-//   - enrichment output (sentiment, emotions, translations) needs no statement of its own: it lives
-//     in columns on feedback_records and goes with the row.
+// The rest of the taxonomy (runs, clusters, nodes, active-run pointers, node events) is removed by
+// the caller's final phase once the records are gone — see PurgeFeedbackRecordsByTenant. What this
+// purge never touches is webhooks and tenant_settings: those are tenant configuration, not tenant
+// data. Enrichment output (sentiment, emotions, translations) needs no statement of its own — it
+// lives in columns on feedback_records and goes with the row.
 func purgeFeedbackRecordsBatchInTx(
 	ctx context.Context, tx tenantWriteTx, tenantID string, limit int,
 ) (*models.FeedbackRecordsPurgeCounts, error) {
@@ -146,7 +162,7 @@ func purgeFeedbackRecordsBatchInTx(
 			(SELECT count(*) FROM deleted_records),
 			(SELECT count(*) FROM deleted_embeddings),
 			(SELECT count(*) FROM deleted_memberships)`, tenantID, limit,
-	).Scan(&counts.DeletedFeedbackRecords, &counts.DeletedEmbeddings, &counts.DeletedTaxonomyClusterMemberships)
+	).Scan(&counts.DeletedFeedbackRecords, &counts.DeletedEmbeddings, &counts.ClusterMemberships)
 	if err != nil {
 		return nil, fmt.Errorf("purge tenant feedback records batch: %w", err)
 	}
@@ -227,58 +243,9 @@ func deleteTenantDataInTx(
 		return nil, fmt.Errorf("delete tenant embeddings: %w", err)
 	}
 
-	// Taxonomy generation artifacts are run-scoped Hub data. Deleting
-	// feedback_records only cascades cluster memberships (via the membership ->
-	// feedback_records FK), leaving runs, clusters, nodes, active-run rows, and
-	// node events orphaned. Remove every taxonomy table explicitly here, children
-	// before parents, so each delete count is exact and the purge never relies on
-	// cascades. Ordering rules:
-	//   - node_events and cluster_memberships reference runs/nodes/clusters, so
-	//     they go first.
-	//   - taxonomy_clusters and taxonomy_nodes have no tenant_id column; they are
-	//     scoped through their run via a taxonomy_runs subquery, which means
-	//     taxonomy_runs MUST be deleted last (after nodes and clusters) or the
-	//     subquery would match nothing and orphan them.
-	taxonomyNodeEventsTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_node_events
-		WHERE tenant_id = $1`, tenantID)
+	taxonomy, err := deleteTenantTaxonomyInTx(ctx, exec, tenantID)
 	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy node events: %w", err)
-	}
-
-	taxonomyClusterMembershipsTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_cluster_memberships
-		WHERE tenant_id = $1`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy cluster memberships: %w", err)
-	}
-
-	taxonomyNodesTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_nodes
-		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy nodes: %w", err)
-	}
-
-	taxonomyClustersTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_clusters
-		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy clusters: %w", err)
-	}
-
-	taxonomyActiveRunsTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_active_runs
-		WHERE tenant_id = $1`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy active runs: %w", err)
-	}
-
-	taxonomyRunsTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_runs
-		WHERE tenant_id = $1`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("delete tenant taxonomy runs: %w", err)
+		return nil, err
 	}
 
 	feedbackRecordsTag, err := exec.Exec(ctx, `
@@ -288,6 +255,11 @@ func deleteTenantDataInTx(
 		return nil, fmt.Errorf("delete tenant feedback records: %w", err)
 	}
 
+	// Configuration, not data — and the only thing this purge removes that the narrower
+	// feedback-records purge deliberately keeps. Webhooks are integrator-configured directly against
+	// the Hub (including a signing_key that reads never return), and tenant_settings holds
+	// enrichment opt-outs that silently revert to "enabled" once the row is gone. Both are
+	// appropriate to drop when a tenant is being deprovisioned, and only then.
 	webhooksTag, err := exec.Exec(ctx, `
 		DELETE FROM webhooks
 		WHERE tenant_id = $1`, tenantID)
@@ -295,8 +267,7 @@ func deleteTenantDataInTx(
 		return nil, fmt.Errorf("delete tenant webhooks: %w", err)
 	}
 
-	// tenant_settings is tenant-owned, so a purge must remove it too. The count is
-	// not surfaced (at most one row per tenant), mirroring the taxonomy_runs delete.
+	// The count is not surfaced (at most one row per tenant), mirroring the taxonomy_runs delete.
 	if _, err = exec.Exec(ctx, `
 		DELETE FROM tenant_settings
 		WHERE tenant_id = $1`, tenantID); err != nil {
@@ -307,11 +278,78 @@ func deleteTenantDataInTx(
 		DeletedFeedbackRecords:            feedbackRecordsTag.RowsAffected(),
 		DeletedEmbeddings:                 embeddingTag.RowsAffected(),
 		DeletedWebhooks:                   webhooksTag.RowsAffected(),
-		DeletedTaxonomyRuns:               taxonomyRunsTag.RowsAffected(),
-		DeletedTaxonomyClusters:           taxonomyClustersTag.RowsAffected(),
-		DeletedTaxonomyClusterMemberships: taxonomyClusterMembershipsTag.RowsAffected(),
-		DeletedTaxonomyNodes:              taxonomyNodesTag.RowsAffected(),
-		DeletedTaxonomyActiveRuns:         taxonomyActiveRunsTag.RowsAffected(),
-		DeletedTaxonomyNodeEvents:         taxonomyNodeEventsTag.RowsAffected(),
+		DeletedTaxonomyRuns:               taxonomy.Runs,
+		DeletedTaxonomyClusters:           taxonomy.Clusters,
+		DeletedTaxonomyClusterMemberships: taxonomy.ClusterMemberships,
+		DeletedTaxonomyNodes:              taxonomy.Nodes,
+		DeletedTaxonomyActiveRuns:         taxonomy.ActiveRuns,
+		DeletedTaxonomyNodeEvents:         taxonomy.NodeEvents,
+	}, nil
+}
+
+// deleteTenantTaxonomyInTx removes every taxonomy artifact for a tenant and returns exact per-table
+// counts. Shared by both purges: the offboarding purge and the narrower feedback-records purge both
+// take the taxonomy, and this is the one place the ordering below is encoded.
+//
+// Taxonomy generation artifacts are run-scoped Hub data. Deleting feedback_records only cascades
+// cluster memberships (via the membership -> feedback_records FK), leaving runs, clusters, nodes,
+// active-run rows and node events orphaned. Every table is removed explicitly, children before
+// parents, so each count is exact and the purge never relies on cascades. Ordering rules:
+//   - node_events and cluster_memberships reference runs/nodes/clusters, so they go first.
+//   - taxonomy_clusters and taxonomy_nodes have no tenant_id column; they are scoped through their
+//     run via a taxonomy_runs subquery, which means taxonomy_runs MUST be deleted last (after nodes
+//     and clusters) or the subquery would match nothing and orphan them.
+func deleteTenantTaxonomyInTx(
+	ctx context.Context, exec tenantDataExecutor, tenantID string,
+) (*models.TenantTaxonomyDeleteCounts, error) {
+	nodeEventsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_node_events
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy node events: %w", err)
+	}
+
+	clusterMembershipsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_cluster_memberships
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy cluster memberships: %w", err)
+	}
+
+	nodesTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_nodes
+		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy nodes: %w", err)
+	}
+
+	clustersTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_clusters
+		WHERE run_id IN (SELECT id FROM taxonomy_runs WHERE tenant_id = $1)`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy clusters: %w", err)
+	}
+
+	activeRunsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_active_runs
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy active runs: %w", err)
+	}
+
+	runsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_runs
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy runs: %w", err)
+	}
+
+	return &models.TenantTaxonomyDeleteCounts{
+		Runs:               runsTag.RowsAffected(),
+		Clusters:           clustersTag.RowsAffected(),
+		ClusterMemberships: clusterMembershipsTag.RowsAffected(),
+		Nodes:              nodesTag.RowsAffected(),
+		ActiveRuns:         activeRunsTag.RowsAffected(),
+		NodeEvents:         nodeEventsTag.RowsAffected(),
 	}, nil
 }

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -40,68 +40,118 @@ func NewTenantDataRepository(db *pgxpool.Pool, purgeLockTimeout time.Duration) *
 
 // DeleteByTenant deletes all Hub-owned data for a tenant and returns per-resource counts.
 func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID string) (*models.TenantDataDeleteCounts, error) {
-	return withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "tenant data delete", deleteTenantDataInTx)
+	return withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "tenant data delete",
+		func(ctx context.Context, tx tenantWriteTx, tenantID string) (*models.TenantDataDeleteCounts, error) {
+			// deleteTenantDataInTx needs only Exec; the adapter keeps its narrower signature (and its
+			// tests) unchanged now that the shared helper hands over the full transaction.
+			return deleteTenantDataInTx(ctx, tx, tenantID)
+		})
 }
+
+// feedbackRecordsPurgeBatchSize bounds how many records one purge transaction deletes. Batching is
+// what makes a purge resumable: a tenant's record count is unbounded, so a single transaction can
+// outlive the worker's timeout, and on a rescue that transaction rolls back — deleting nothing, for
+// every attempt, forever. Committing per batch means a killed purge keeps the progress it made and
+// the retry continues from there. It also chunks the ingestion block: the exclusive tenant lock is
+// released between batches instead of being held for the whole delete.
+const feedbackRecordsPurgeBatchSize = 2000
 
 // PurgeFeedbackRecordsByTenant deletes every feedback record for a tenant, plus the data derived
 // from those records, and returns exact per-table counts. Unlike DeleteByTenant it leaves the
 // tenant's taxonomy structure, webhooks and settings intact, so the dataset stays usable.
+//
+// Runs as a sequence of committed batches (see feedbackRecordsPurgeBatchSize), so it is resumable
+// and reports the counts it actually achieved even when it fails partway.
+//
+// Scoped to the records that existed when the purge started: the id column is uuidv7, so a
+// high-water mark bounds the work to a fixed set. Without it a tenant still receiving feedback
+// could keep the loop running indefinitely, and records submitted *after* the operator asked to
+// empty the dataset would be deleted without ever having been part of what they saw.
 func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 	ctx context.Context, tenantID string,
 ) (*models.FeedbackRecordsPurgeCounts, error) {
-	return withTenantPurgeTx(
-		ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge", purgeFeedbackRecordsInTx,
-	)
+	total := &models.FeedbackRecordsPurgeCounts{}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			// Report the progress already committed; the retry resumes from here.
+			return total, fmt.Errorf("purge feedback records for tenant: %w", err)
+		}
+
+		batch, err := withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge",
+			func(ctx context.Context, tx tenantWriteTx, tenantID string) (*models.FeedbackRecordsPurgeCounts, error) {
+				return purgeFeedbackRecordsBatchInTx(ctx, tx, tenantID, feedbackRecordsPurgeBatchSize)
+			})
+		if err != nil {
+			return total, err
+		}
+
+		total.DeletedFeedbackRecords += batch.DeletedFeedbackRecords
+		total.DeletedEmbeddings += batch.DeletedEmbeddings
+		total.DeletedTaxonomyClusterMemberships += batch.DeletedTaxonomyClusterMemberships
+
+		if batch.DeletedFeedbackRecords == 0 {
+			return total, nil
+		}
+	}
 }
 
-// purgeFeedbackRecordsInTx removes a tenant's feedback records and their derived rows.
+// purgeFeedbackRecordsBatchInTx removes up to limit of a tenant's feedback records and the rows
+// derived from them, returning exact per-table counts for the batch. Returns zero records deleted
+// when the tenant has none left, which is what ends the loop.
 //
-// Both derived tables would be removed by ON DELETE CASCADE from feedback_records anyway
-// (embeddings via migration 004, taxonomy_cluster_memberships via the composite
-// (feedback_record_id, tenant_id) FK in migration 010). They are deleted explicitly, children
-// first, for the same reason the full tenant purge does it: a cascade reports no row count, and
-// callers need exact numbers. Deleting them here is equivalent, not additional.
+// One statement so the three deletes share a snapshot and a single round trip. The derived tables
+// would be removed by ON DELETE CASCADE from feedback_records anyway (embeddings via migration 004,
+// taxonomy_cluster_memberships via the composite (feedback_record_id, tenant_id) FK in migration
+// 010); they are deleted explicitly, children first, for the same reason the full tenant purge does
+// it — a cascade reports no row count and callers need exact numbers. Deleting them here is
+// equivalent, not additional. embeddings carries no tenant_id of its own, but every victim id comes
+// from a tenant-scoped select, so the delete stays inside the tenant boundary.
 //
 // What is deliberately NOT touched, and why:
 //   - taxonomy runs, clusters and nodes — the topic structure is the point of keeping this purge
-//     narrow. The clusters simply end up with no members; per-node record counts are derived from
-//     memberships at read time, so they fall to zero on their own. taxonomy_clusters.size and
-//     taxonomy_runs.record_count are write-only provenance of what a run produced (nothing reads
-//     them back), so rewriting them would be falsifying history rather than fixing a stale count.
+//     narrow. The clusters simply end up with no members, and per-node record counts are derived
+//     from memberships at read time, so those fall to zero on their own. The stored counters
+//     (taxonomy_clusters.size, taxonomy_runs.record_count) are left alone deliberately: they record
+//     what a run processed, and rewriting them would falsify the run's history. Note this means
+//     taxonomy run reads still report the original record_count after a purge.
 //   - webhooks and tenant_settings — tenant configuration, not tenant data.
 //   - enrichment output (sentiment, emotions, translations) needs no statement of its own: it lives
 //     in columns on feedback_records and goes with the row.
-func purgeFeedbackRecordsInTx(
-	ctx context.Context, exec tenantDataExecutor, tenantID string,
+func purgeFeedbackRecordsBatchInTx(
+	ctx context.Context, tx tenantWriteTx, tenantID string, limit int,
 ) (*models.FeedbackRecordsPurgeCounts, error) {
-	embeddingsTag, err := exec.Exec(ctx, `
-		DELETE FROM embeddings e
-		USING feedback_records fr
-		WHERE e.feedback_record_id = fr.id
-			AND fr.tenant_id = $1`, tenantID)
+	counts := &models.FeedbackRecordsPurgeCounts{}
+
+	err := tx.QueryRow(ctx, `
+		WITH victims AS (
+			SELECT id FROM feedback_records WHERE tenant_id = $1 ORDER BY id LIMIT $2
+		),
+		deleted_embeddings AS (
+			DELETE FROM embeddings
+			WHERE feedback_record_id IN (SELECT id FROM victims)
+			RETURNING 1
+		),
+		deleted_memberships AS (
+			DELETE FROM taxonomy_cluster_memberships
+			WHERE tenant_id = $1 AND feedback_record_id IN (SELECT id FROM victims)
+			RETURNING 1
+		),
+		deleted_records AS (
+			DELETE FROM feedback_records
+			WHERE tenant_id = $1 AND id IN (SELECT id FROM victims)
+			RETURNING 1
+		)
+		SELECT
+			(SELECT count(*) FROM deleted_records),
+			(SELECT count(*) FROM deleted_embeddings),
+			(SELECT count(*) FROM deleted_memberships)`, tenantID, limit,
+	).Scan(&counts.DeletedFeedbackRecords, &counts.DeletedEmbeddings, &counts.DeletedTaxonomyClusterMemberships)
 	if err != nil {
-		return nil, fmt.Errorf("purge tenant feedback record embeddings: %w", err)
+		return nil, fmt.Errorf("purge tenant feedback records batch: %w", err)
 	}
 
-	membershipsTag, err := exec.Exec(ctx, `
-		DELETE FROM taxonomy_cluster_memberships
-		WHERE tenant_id = $1`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("purge tenant taxonomy cluster memberships: %w", err)
-	}
-
-	recordsTag, err := exec.Exec(ctx, `
-		DELETE FROM feedback_records
-		WHERE tenant_id = $1`, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("purge tenant feedback records: %w", err)
-	}
-
-	return &models.FeedbackRecordsPurgeCounts{
-		DeletedFeedbackRecords:            recordsTag.RowsAffected(),
-		DeletedEmbeddings:                 embeddingsTag.RowsAffected(),
-		DeletedTaxonomyClusterMemberships: membershipsTag.RowsAffected(),
-	}, nil
+	return counts, nil
 }
 
 // withTenantPurgeTx runs purge in a transaction holding the tenant write lock exclusively, so the
@@ -118,7 +168,7 @@ func withTenantPurgeTx[T any](
 	tenantID string,
 	lockTimeout time.Duration,
 	opName string,
-	purge func(ctx context.Context, exec tenantDataExecutor, tenantID string) (T, error),
+	purge func(ctx context.Context, tx tenantWriteTx, tenantID string) (T, error),
 ) (T, error) {
 	var zero T
 

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -40,9 +40,91 @@ func NewTenantDataRepository(db *pgxpool.Pool, purgeLockTimeout time.Duration) *
 
 // DeleteByTenant deletes all Hub-owned data for a tenant and returns per-resource counts.
 func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID string) (*models.TenantDataDeleteCounts, error) {
-	dbTx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	return withTenantPurgeTx(ctx, r.db, tenantID, r.purgeLockTimeout, "tenant data delete", deleteTenantDataInTx)
+}
+
+// PurgeFeedbackRecordsByTenant deletes every feedback record for a tenant, plus the data derived
+// from those records, and returns exact per-table counts. Unlike DeleteByTenant it leaves the
+// tenant's taxonomy structure, webhooks and settings intact, so the dataset stays usable.
+func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
+	ctx context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	return withTenantPurgeTx(
+		ctx, r.db, tenantID, r.purgeLockTimeout, "feedback records purge", purgeFeedbackRecordsInTx,
+	)
+}
+
+// purgeFeedbackRecordsInTx removes a tenant's feedback records and their derived rows.
+//
+// Both derived tables would be removed by ON DELETE CASCADE from feedback_records anyway
+// (embeddings via migration 004, taxonomy_cluster_memberships via the composite
+// (feedback_record_id, tenant_id) FK in migration 010). They are deleted explicitly, children
+// first, for the same reason the full tenant purge does it: a cascade reports no row count, and
+// callers need exact numbers. Deleting them here is equivalent, not additional.
+//
+// What is deliberately NOT touched, and why:
+//   - taxonomy runs, clusters and nodes — the topic structure is the point of keeping this purge
+//     narrow. The clusters simply end up with no members; per-node record counts are derived from
+//     memberships at read time, so they fall to zero on their own. taxonomy_clusters.size and
+//     taxonomy_runs.record_count are write-only provenance of what a run produced (nothing reads
+//     them back), so rewriting them would be falsifying history rather than fixing a stale count.
+//   - webhooks and tenant_settings — tenant configuration, not tenant data.
+//   - enrichment output (sentiment, emotions, translations) needs no statement of its own: it lives
+//     in columns on feedback_records and goes with the row.
+func purgeFeedbackRecordsInTx(
+	ctx context.Context, exec tenantDataExecutor, tenantID string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	embeddingsTag, err := exec.Exec(ctx, `
+		DELETE FROM embeddings e
+		USING feedback_records fr
+		WHERE e.feedback_record_id = fr.id
+			AND fr.tenant_id = $1`, tenantID)
 	if err != nil {
-		return nil, fmt.Errorf("begin tenant data delete transaction: %w", err)
+		return nil, fmt.Errorf("purge tenant feedback record embeddings: %w", err)
+	}
+
+	membershipsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_cluster_memberships
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("purge tenant taxonomy cluster memberships: %w", err)
+	}
+
+	recordsTag, err := exec.Exec(ctx, `
+		DELETE FROM feedback_records
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("purge tenant feedback records: %w", err)
+	}
+
+	return &models.FeedbackRecordsPurgeCounts{
+		DeletedFeedbackRecords:            recordsTag.RowsAffected(),
+		DeletedEmbeddings:                 embeddingsTag.RowsAffected(),
+		DeletedTaxonomyClusterMemberships: membershipsTag.RowsAffected(),
+	}, nil
+}
+
+// withTenantPurgeTx runs purge in a transaction holding the tenant write lock exclusively, so the
+// purge is serialized against tenant-owned writes (which hold the same lock in shared mode): the
+// exclusive acquisition waits for in-flight writes to drain (bounded by lockTimeout) and rejects
+// new ones the moment it is queued.
+//
+// Shared by every tenant purge variant — the full tenant offboarding purge and the narrower
+// feedback-records purge — so they cannot drift on locking, rollback or commit handling. opName
+// only labels log lines.
+func withTenantPurgeTx[T any](
+	ctx context.Context,
+	db tenantWriteTxBeginner,
+	tenantID string,
+	lockTimeout time.Duration,
+	opName string,
+	purge func(ctx context.Context, exec tenantDataExecutor, tenantID string) (T, error),
+) (T, error) {
+	var zero T
+
+	dbTx, err := db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return zero, fmt.Errorf("begin %s transaction: %w", opName, err)
 	}
 
 	defer func() {
@@ -52,7 +134,7 @@ func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID stri
 		// when the ctx is already done — that rollback error is expected, not a fault.
 		if err := dbTx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) && ctx.Err() == nil {
 			slog.Error(
-				"tenant data delete: rollback failed",
+				opName+": rollback failed",
 				"tenant_id_present", tenantID != "",
 				"tenant_id_length", len(tenantID),
 				"error", err,
@@ -60,31 +142,27 @@ func (r *TenantDataRepository) DeleteByTenant(ctx context.Context, tenantID stri
 		}
 	}()
 
-	// Serialize against tenant-owned writes: writers hold the tenant write lock
-	// in shared mode, so the exclusive acquisition waits for in-flight writes to
-	// drain (bounded by purgeLockTimeout) and rejects new ones the moment it is
-	// queued.
-	if err := acquireTenantPurgeLock(ctx, dbTx, tenantID, r.purgeLockTimeout); err != nil {
-		return nil, err
+	if err := acquireTenantPurgeLock(ctx, dbTx, tenantID, lockTimeout); err != nil {
+		return zero, err
 	}
 
-	counts, err := deleteTenantDataInTx(ctx, dbTx, tenantID)
+	result, err := purge(ctx, dbTx, tenantID)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	if err := dbTx.Commit(ctx); err != nil {
 		slog.Error(
-			"tenant data delete: commit failed",
+			opName+": commit failed",
 			"tenant_id_present", tenantID != "",
 			"tenant_id_length", len(tenantID),
 			"error", err,
 		)
 
-		return nil, fmt.Errorf("commit tenant data delete transaction: %w", err)
+		return zero, fmt.Errorf("commit %s transaction: %w", opName, err)
 	}
 
-	return counts, nil
+	return result, nil
 }
 
 func deleteTenantDataInTx(

--- a/internal/repository/tenant_data_repository_test.go
+++ b/internal/repository/tenant_data_repository_test.go
@@ -18,6 +18,9 @@ import (
 // fakeTenantWriteTx (see tenant_write_lock_test.go); the purge tests below
 // drive that same fake transaction, which satisfies tenantWriteTxBeginner.
 type fakeTenantDataExecutor struct {
+	// statements is the ordered Exec log; fakeTenantWriteTx merges its QueryRow statements into the
+	// same sequence so ordering across the purge's two phases is assertable.
+	statements []string
 	tags       []pgconn.CommandTag
 	errAtQuery int
 	err        error
@@ -28,6 +31,7 @@ type fakeTenantDataExecutor struct {
 func (f *fakeTenantDataExecutor) Exec(
 	_ context.Context, sql string, arguments ...any,
 ) (pgconn.CommandTag, error) {
+	f.statements = append(f.statements, sql)
 	f.queries = append(f.queries, sql)
 	f.args = append(f.args, arguments)
 

--- a/internal/repository/tenant_write_lock_test.go
+++ b/internal/repository/tenant_write_lock_test.go
@@ -42,13 +42,53 @@ type fakeTenantWriteTx struct {
 	rollbackErr error
 	committed   bool
 	rolledBack  bool
+
+	// Batched-purge support. The purge runs one committed transaction per batch, so the fake is
+	// reused across batches: purgeBatchRows supplies each batch's
+	// (records, embeddings, memberships) counts, commits counts the successful transactions, and
+	// afterBatch lets a test interfere (e.g. cancel the context) between batches.
+	purgeBatchRows    [][]int64
+	purgeBatchErrAt   int
+	purgeBatchQueries []string
+	purgeBatchArgs    [][]any
+	commits           int
+	afterBatch        func(batches int)
+}
+
+// fakeTenantPurgeBatchRow returns one batch's three counts, or an error.
+type fakeTenantPurgeBatchRow struct {
+	counts  []int64
+	scanErr error
+}
+
+func (r fakeTenantPurgeBatchRow) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+
+	for i, d := range dest {
+		target, ok := d.(*int64)
+		if !ok {
+			return errors.New("unexpected scan target in purge batch fake")
+		}
+
+		if i < len(r.counts) {
+			*target = r.counts[i]
+		}
+	}
+
+	return nil
 }
 
 func (f *fakeTenantWriteTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
 	return nil, errors.New("query not implemented in fake")
 }
 
-func (f *fakeTenantWriteTx) QueryRow(_ context.Context, _ string, args ...any) pgx.Row {
+func (f *fakeTenantWriteTx) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	if len(args) == 2 {
+		return f.queryRowPurgeBatch(sql, args)
+	}
+
 	if len(args) == 1 {
 		if key, ok := args[0].(string); ok {
 			f.lockKeys = append(f.lockKeys, key)
@@ -68,15 +108,43 @@ func (f *fakeTenantWriteTx) QueryRow(_ context.Context, _ string, args ...any) p
 }
 
 func (f *fakeTenantWriteTx) Commit(context.Context) error {
-	f.committed = true
+	if f.commitErr != nil {
+		return f.commitErr
+	}
 
-	return f.commitErr
+	f.committed = true
+	f.commits++
+
+	return nil
 }
 
 func (f *fakeTenantWriteTx) Rollback(context.Context) error {
 	f.rolledBack = true
 
 	return f.rollbackErr
+}
+
+// queryRowPurgeBatch serves the purge's batch statement, which is the only QueryRow taking two
+// arguments (tenant id + batch size); the advisory-lock query takes one.
+func (f *fakeTenantWriteTx) queryRowPurgeBatch(sql string, args []any) pgx.Row {
+	f.purgeBatchQueries = append(f.purgeBatchQueries, sql)
+	f.purgeBatchArgs = append(f.purgeBatchArgs, args)
+
+	batchIndex := len(f.purgeBatchQueries) - 1
+
+	if f.afterBatch != nil {
+		defer f.afterBatch(len(f.purgeBatchQueries))
+	}
+
+	if f.purgeBatchErrAt == len(f.purgeBatchQueries) {
+		return fakeTenantPurgeBatchRow{scanErr: errors.New("batch failed")}
+	}
+
+	if batchIndex < len(f.purgeBatchRows) {
+		return fakeTenantPurgeBatchRow{counts: f.purgeBatchRows[batchIndex]}
+	}
+
+	return fakeTenantPurgeBatchRow{counts: []int64{0, 0, 0}}
 }
 
 type fakeTenantWriteDB struct {

--- a/internal/repository/tenant_write_lock_test.go
+++ b/internal/repository/tenant_write_lock_test.go
@@ -3,9 +3,11 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -47,12 +49,41 @@ type fakeTenantWriteTx struct {
 	// reused across batches: purgeBatchRows supplies each batch's
 	// (records, embeddings, memberships) counts, commits counts the successful transactions, and
 	// afterBatch lets a test interfere (e.g. cancel the context) between batches.
+	// highWaterMark is the ceiling the purge reads before its first batch; nil means the tenant has
+	// no records and the loop never runs.
+	highWaterMark      *uuid.UUID
+	highWaterMarkReads int
+
 	purgeBatchRows    [][]int64
 	purgeBatchErrAt   int
 	purgeBatchQueries []string
 	purgeBatchArgs    [][]any
 	commits           int
 	afterBatch        func(batches int)
+}
+
+// fakeTenantHighWaterMarkRow serves the purge's ceiling read.
+type fakeTenantHighWaterMarkRow struct {
+	id *uuid.UUID
+}
+
+func (r fakeTenantHighWaterMarkRow) Scan(dest ...any) error {
+	if r.id == nil {
+		return pgx.ErrNoRows
+	}
+
+	if len(dest) != 1 {
+		return errors.New("unexpected scan targets for the high-water mark")
+	}
+
+	target, ok := dest[0].(*uuid.UUID)
+	if !ok {
+		return errors.New("unexpected scan target type for the high-water mark")
+	}
+
+	*target = *r.id
+
+	return nil
 }
 
 // fakeTenantPurgeBatchRow returns one batch's three counts, or an error.
@@ -85,7 +116,15 @@ func (f *fakeTenantWriteTx) Query(context.Context, string, ...any) (pgx.Rows, er
 }
 
 func (f *fakeTenantWriteTx) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
-	if len(args) == 2 {
+	// Routed by statement rather than by argument count: the purge issues three different QueryRows
+	// (advisory lock, high-water mark, batch delete) and two of them take a single argument.
+	if strings.Contains(sql, "ORDER BY id DESC LIMIT 1") {
+		f.highWaterMarkReads++
+
+		return fakeTenantHighWaterMarkRow{id: f.highWaterMark}
+	}
+
+	if strings.Contains(sql, "WITH victims") {
 		return f.queryRowPurgeBatch(sql, args)
 	}
 
@@ -127,6 +166,9 @@ func (f *fakeTenantWriteTx) Rollback(context.Context) error {
 // queryRowPurgeBatch serves the purge's batch statement, which is the only QueryRow taking two
 // arguments (tenant id + batch size); the advisory-lock query takes one.
 func (f *fakeTenantWriteTx) queryRowPurgeBatch(sql string, args []any) pgx.Row {
+	// Into the embedded executor's log too, so batch and taxonomy statements share one ordered
+	// sequence and their relative ordering is assertable.
+	f.statements = append(f.statements, sql)
 	f.purgeBatchQueries = append(f.purgeBatchQueries, sql)
 	f.purgeBatchArgs = append(f.purgeBatchArgs, args)
 

--- a/internal/service/feedback_records_purge_job_args.go
+++ b/internal/service/feedback_records_purge_job_args.go
@@ -1,0 +1,41 @@
+package service
+
+import "github.com/riverqueue/river"
+
+const (
+	feedbackRecordsPurgeKind = "feedback_records_purge"
+	// FeedbackRecordsPurgeQueueName is the River queue for tenant feedback-record purges. It is
+	// kept separate from the enrichment queues so a large purge cannot starve live ingestion
+	// throughput, mirroring TranslationBackfillsQueueName.
+	FeedbackRecordsPurgeQueueName = "feedback_records_purges"
+	// FeedbackRecordsPurgeMaxAttempts is the retry budget for a purge. There is no config knob for
+	// it: the purge is idempotent and tenant-scoped, so a retry is always safe and always makes
+	// progress, and the failures worth retrying (a lock timeout while writes drain, a rescued job)
+	// clear on their own within a few attempts.
+	FeedbackRecordsPurgeMaxAttempts = 5
+)
+
+// FeedbackRecordsPurgeArgs deletes every feedback record for one tenant, plus the data derived
+// from those records, leaving the tenant's taxonomy structure, webhooks and settings intact.
+//
+// The purge runs as a job rather than on the request path because it is unbounded: feedback_records
+// has no per-tenant cap, and the API server's write timeout would cut the response long before a
+// large tenant finished deleting.
+//
+// Uniqueness is by TenantID across the default (in-flight) states — the enqueue site sets ByArgs
+// without a ByPeriod — so a second purge request while one is already running collapses into it,
+// while a purge requested after the previous one completed runs again. ByPeriod must not be added:
+// River's default unique states include `completed` and cannot be narrowed, so a period-based
+// dedupe would silently swallow a legitimate later purge (the same trap documented on the
+// enrichment event path).
+//
+// The worker re-reads the tenant from these args and scopes every statement by it; nothing about
+// the purge is resolved at enqueue time.
+type FeedbackRecordsPurgeArgs struct {
+	TenantID string `json:"tenant_id" river:"unique"`
+}
+
+// Kind returns the River job kind.
+func (FeedbackRecordsPurgeArgs) Kind() string { return feedbackRecordsPurgeKind }
+
+var _ river.JobArgs = FeedbackRecordsPurgeArgs{}

--- a/internal/service/feedback_records_purge_job_args.go
+++ b/internal/service/feedback_records_purge_job_args.go
@@ -18,8 +18,9 @@ const (
 	FeedbackRecordsPurgeMaxAttempts = 5
 )
 
-// FeedbackRecordsPurgeArgs deletes every feedback record for one tenant, plus the data derived
-// from those records, leaving the tenant's taxonomy structure, webhooks and settings intact.
+// FeedbackRecordsPurgeArgs deletes every feedback record for one tenant, everything derived from
+// those records, and the taxonomy built on them — leaving the tenant's configuration (its webhooks
+// and its settings) intact.
 //
 // The purge runs as a job rather than on the request path because it is unbounded: feedback_records
 // has no per-tenant cap, and the API server's write timeout would cut the response long before a
@@ -39,13 +40,21 @@ type FeedbackRecordsPurgeArgs struct {
 	TenantID string `json:"tenant_id" river:"unique"`
 }
 
-// feedbackRecordsPurgeUniqueStates is the in-flight state set the purge dedupes across. These four
-// are exactly the states River requires ByState to contain, so this is the narrowest legal set —
-// and, crucially, it excludes `completed`.
+// feedbackRecordsPurgeUniqueStates is the in-flight state set the purge dedupes across: the four
+// states River requires ByState to contain, plus `retryable`.
+//
+// `retryable` is included so a request arriving while a purge sits in backoff between attempts
+// collapses into it, like every other in-flight state. Without it that request inserts a second
+// purge job, and the two then contend for the same exclusive tenant lock — each one's timeouts
+// eating the other's retry budget.
+//
+// `completed` is the one that must stay out: River's default set includes it, and with no ByPeriod
+// the window is unbounded, so the first purge of a tenant would be the only one that ever ran.
 func feedbackRecordsPurgeUniqueStates() []rivertype.JobState {
 	return []rivertype.JobState{
 		rivertype.JobStateAvailable,
 		rivertype.JobStatePending,
+		rivertype.JobStateRetryable,
 		rivertype.JobStateRunning,
 		rivertype.JobStateScheduled,
 	}

--- a/internal/service/feedback_records_purge_job_args.go
+++ b/internal/service/feedback_records_purge_job_args.go
@@ -1,6 +1,9 @@
 package service
 
-import "github.com/riverqueue/river"
+import (
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
 
 const (
 	feedbackRecordsPurgeKind = "feedback_records_purge"
@@ -22,17 +25,30 @@ const (
 // has no per-tenant cap, and the API server's write timeout would cut the response long before a
 // large tenant finished deleting.
 //
-// Uniqueness is by TenantID across the default (in-flight) states — the enqueue site sets ByArgs
-// without a ByPeriod — so a second purge request while one is already running collapses into it,
-// while a purge requested after the previous one completed runs again. ByPeriod must not be added:
-// River's default unique states include `completed` and cannot be narrowed, so a period-based
-// dedupe would silently swallow a legitimate later purge (the same trap documented on the
-// enrichment event path).
+// Uniqueness is by TenantID across the in-flight states only, spelled out explicitly at the enqueue
+// site (see feedbackRecordsPurgeUniqueStates). A second request while a purge is running collapses
+// into it; a purge requested after the previous one finished starts a new run.
+//
+// Do not fall back to River's default state set here. It includes `completed`, and with no ByPeriod
+// the uniqueness window is unbounded, so the first purge of a tenant would be the only one that
+// ever runs — every later request skipped as a duplicate while still returning 202.
 //
 // The worker re-reads the tenant from these args and scopes every statement by it; nothing about
 // the purge is resolved at enqueue time.
 type FeedbackRecordsPurgeArgs struct {
 	TenantID string `json:"tenant_id" river:"unique"`
+}
+
+// feedbackRecordsPurgeUniqueStates is the in-flight state set the purge dedupes across. These four
+// are exactly the states River requires ByState to contain, so this is the narrowest legal set —
+// and, crucially, it excludes `completed`.
+func feedbackRecordsPurgeUniqueStates() []rivertype.JobState {
+	return []rivertype.JobState{
+		rivertype.JobStateAvailable,
+		rivertype.JobStatePending,
+		rivertype.JobStateRunning,
+		rivertype.JobStateScheduled,
+	}
 }
 
 // Kind returns the River job kind.

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -100,9 +100,13 @@ func (s *FeedbackRecordsPurgeService) Purge(
 		return nil, err
 	}
 
+	// The repository returns what it committed even on failure — the batches before the error stay
+	// deleted. Pass those counts back rather than dropping them to nil, so the worker can report how
+	// far a failed purge got; a purge that dies midway leaves the dataset partly empty, and that is
+	// exactly the state an operator needs to see.
 	counts, err := s.repo.PurgeFeedbackRecordsByTenant(ctx, normalizedTenantID)
 	if err != nil {
-		return nil, fmt.Errorf("purge feedback records for tenant: %w", err)
+		return counts, fmt.Errorf("purge feedback records for tenant: %w", err)
 	}
 
 	slog.Info("feedback records purge: complete",

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -106,7 +106,9 @@ func (s *FeedbackRecordsPurgeService) Purge(
 		"tenant_id_length", len(normalizedTenantID),
 		"deleted_feedback_records", counts.DeletedFeedbackRecords,
 		"deleted_embeddings", counts.DeletedEmbeddings,
-		"deleted_taxonomy_cluster_memberships", counts.DeletedTaxonomyClusterMemberships,
+		"deleted_taxonomy_cluster_memberships", counts.ClusterMemberships,
+		"deleted_taxonomy_runs", counts.Runs,
+		"deleted_taxonomy_nodes", counts.Nodes,
 	)
 
 	return counts, nil

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -45,9 +45,12 @@ func NewFeedbackRecordsPurgeService(
 
 // Enqueue accepts a purge request for a tenant and schedules the job that performs it.
 //
-// Idempotent by design: the job is unique by tenant across River's in-flight states, so requesting
-// a purge while one is already running collapses into that run and still reports accepted. A purge
-// requested after the previous one finished is a new run (see FeedbackRecordsPurgeArgs).
+// Idempotent by design: the job is unique by tenant across River's in-flight states, so requesting a
+// purge while one is queued or running collapses into it and still reports accepted. A purge
+// requested after the previous one finished is a new run (see FeedbackRecordsPurgeArgs). One gap is
+// deliberate: `retryable` is not in the unique set, so a request arriving while a purge sits in
+// backoff inserts a second job — River then discards the older one when it schedules, so the tenant
+// still ends up with exactly one purge.
 func (s *FeedbackRecordsPurgeService) Enqueue(
 	ctx context.Context, tenantID string,
 ) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
@@ -103,7 +106,7 @@ func (s *FeedbackRecordsPurgeService) Purge(
 	}
 
 	slog.Info("feedback records purge: complete",
-		"tenant_id_length", len(normalizedTenantID),
+		"tenant_id", normalizedTenantID,
 		"deleted_feedback_records", counts.DeletedFeedbackRecords,
 		"deleted_embeddings", counts.DeletedEmbeddings,
 		"deleted_taxonomy_cluster_memberships", counts.ClusterMemberships,

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -63,9 +63,16 @@ func (s *FeedbackRecordsPurgeService) Enqueue(
 	if _, err := s.inserter.Insert(ctx, FeedbackRecordsPurgeArgs{TenantID: normalizedTenantID}, &river.InsertOpts{
 		Queue:       FeedbackRecordsPurgeQueueName,
 		MaxAttempts: FeedbackRecordsPurgeMaxAttempts,
-		// Unique by TenantID across in-flight states (no ByPeriod): collapse concurrent requests
-		// into one purge, but let a purge requested after the previous one completed run again.
-		UniqueOpts: river.UniqueOpts{ByArgs: true},
+		// Unique by TenantID across the IN-FLIGHT states only. ByState must be spelled out:
+		// River's default set includes `completed`, and with no ByPeriod the uniqueness window is
+		// unbounded — so the default would make the first purge of a tenant the only one that ever
+		// runs, silently skipping every later request as a duplicate for as long as the completed
+		// row is retained (forever, if a deployment disables completed-job cleanup).
+		//
+		// Available/Pending/Running/Scheduled are exactly the states River requires ByState to
+		// include, so this is the narrowest legal set: concurrent requests still collapse into the
+		// running purge, and a purge requested after the previous one finished starts a new run.
+		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: feedbackRecordsPurgeUniqueStates()},
 	}); err != nil {
 		return nil, fmt.Errorf("enqueue feedback records purge: %w", err)
 	}

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/riverqueue/river"
+
+	"github.com/formbricks/hub/internal/models"
+)
+
+// ErrPurgeInserterNotConfigured is returned when a purge is requested from a process built without
+// a job inserter (hub-worker performs purges but never enqueues them).
+var ErrPurgeInserterNotConfigured = errors.New("feedback records purge inserter not configured")
+
+// FeedbackRecordsPurgeRepository is the repository surface the purge needs.
+type FeedbackRecordsPurgeRepository interface {
+	PurgeFeedbackRecordsByTenant(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeCounts, error)
+}
+
+// FeedbackRecordsPurgeService owns the two halves of a tenant feedback-records purge: accepting the
+// request (enqueue) and performing it (the worker's call).
+//
+// They are split because the purge is unbounded and must not run on the request path. The API
+// process only ever reaches Enqueue — its River client is insert-only — while hub-worker reaches
+// Purge. Keeping both here means the tenant normalization rule is written once and applies to
+// whichever entry point is used.
+// The queue and retry budget are not constructor parameters: unlike the enrichment jobs they have
+// no config knob, and both are properties of the job kind itself (see FeedbackRecordsPurgeArgs).
+type FeedbackRecordsPurgeService struct {
+	repo     FeedbackRecordsPurgeRepository
+	inserter RiverJobInserter
+}
+
+// NewFeedbackRecordsPurgeService creates the purge service. inserter may be nil in a process that
+// only performs purges and never enqueues them (hub-worker); Enqueue then reports a clear error
+// rather than panicking.
+func NewFeedbackRecordsPurgeService(
+	repo FeedbackRecordsPurgeRepository, inserter RiverJobInserter,
+) *FeedbackRecordsPurgeService {
+	return &FeedbackRecordsPurgeService{repo: repo, inserter: inserter}
+}
+
+// Enqueue accepts a purge request for a tenant and schedules the job that performs it.
+//
+// Idempotent by design: the job is unique by tenant across River's in-flight states, so requesting
+// a purge while one is already running collapses into that run and still reports accepted. A purge
+// requested after the previous one finished is a new run (see FeedbackRecordsPurgeArgs).
+func (s *FeedbackRecordsPurgeService) Enqueue(
+	ctx context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeAcceptedResponse, error) {
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.inserter == nil {
+		return nil, ErrPurgeInserterNotConfigured
+	}
+
+	if _, err := s.inserter.Insert(ctx, FeedbackRecordsPurgeArgs{TenantID: normalizedTenantID}, &river.InsertOpts{
+		Queue:       FeedbackRecordsPurgeQueueName,
+		MaxAttempts: FeedbackRecordsPurgeMaxAttempts,
+		// Unique by TenantID across in-flight states (no ByPeriod): collapse concurrent requests
+		// into one purge, but let a purge requested after the previous one completed run again.
+		UniqueOpts: river.UniqueOpts{ByArgs: true},
+	}); err != nil {
+		return nil, fmt.Errorf("enqueue feedback records purge: %w", err)
+	}
+
+	return &models.FeedbackRecordsPurgeAcceptedResponse{
+		TenantID: normalizedTenantID,
+		Status:   models.FeedbackRecordsPurgeStatusAccepted,
+		Message:  "Feedback records purge accepted for " + normalizedTenantID,
+	}, nil
+}
+
+// Purge performs the purge for a tenant. Called by the worker, never from the request path.
+//
+// The tenant is re-normalized here rather than trusted from the job args: enqueue-time validation
+// is not a substitute for scoping the work at execution time, and a job's args outlive the request
+// that created them.
+func (s *FeedbackRecordsPurgeService) Purge(
+	ctx context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	normalizedTenantID, err := normalizeRequiredTenantIDValue(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	counts, err := s.repo.PurgeFeedbackRecordsByTenant(ctx, normalizedTenantID)
+	if err != nil {
+		return nil, fmt.Errorf("purge feedback records for tenant: %w", err)
+	}
+
+	slog.Info("feedback records purge: complete",
+		"tenant_id_length", len(normalizedTenantID),
+		"deleted_feedback_records", counts.DeletedFeedbackRecords,
+		"deleted_embeddings", counts.DeletedEmbeddings,
+		"deleted_taxonomy_cluster_memberships", counts.DeletedTaxonomyClusterMemberships,
+	)
+
+	return counts, nil
+}

--- a/internal/service/feedback_records_purge_service_test.go
+++ b/internal/service/feedback_records_purge_service_test.go
@@ -75,10 +75,12 @@ func TestFeedbackRecordsPurgeService_Enqueue(t *testing.T) {
 			"River's default state set includes completed, which would swallow every later purge")
 		assert.NotContains(t, unique.ByState, rivertype.JobStateCompleted,
 			"a completed purge must never block the next one")
-		// The four states River requires ByState to include; anything else would fail validation.
+		// The four states River requires, plus retryable so a request during backoff collapses into
+		// the existing purge rather than inserting a second one that fights it for the tenant lock.
 		assert.ElementsMatch(t, []rivertype.JobState{
 			rivertype.JobStateAvailable,
 			rivertype.JobStatePending,
+			rivertype.JobStateRetryable,
 			rivertype.JobStateRunning,
 			rivertype.JobStateScheduled,
 		}, unique.ByState)

--- a/internal/service/feedback_records_purge_service_test.go
+++ b/internal/service/feedback_records_purge_service_test.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+)
+
+type stubPurgeRepo struct {
+	counts    *models.FeedbackRecordsPurgeCounts
+	err       error
+	tenantIDs []string
+}
+
+func (s *stubPurgeRepo) PurgeFeedbackRecordsByTenant(
+	_ context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	s.tenantIDs = append(s.tenantIDs, tenantID)
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	if s.counts != nil {
+		return s.counts, nil
+	}
+
+	return &models.FeedbackRecordsPurgeCounts{}, nil
+}
+
+func TestFeedbackRecordsPurgeService_Enqueue(t *testing.T) {
+	t.Run("enqueues one purge job on the purge queue", func(t *testing.T) {
+		inserter := &recordingInserter{}
+
+		accepted, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, inserter).
+			Enqueue(context.Background(), "org-1")
+		require.NoError(t, err)
+
+		assert.Equal(t, "org-1", accepted.TenantID)
+		assert.Equal(t, models.FeedbackRecordsPurgeStatusAccepted, accepted.Status)
+
+		require.Len(t, inserter.args, 1)
+		args, ok := inserter.args[0].(FeedbackRecordsPurgeArgs)
+		require.True(t, ok, "enqueued args type = %T", inserter.args[0])
+		assert.Equal(t, "org-1", args.TenantID)
+		assert.Equal(t, FeedbackRecordsPurgeQueueName, inserter.opts[0].Queue)
+		assert.Equal(t, FeedbackRecordsPurgeMaxAttempts, inserter.opts[0].MaxAttempts)
+	})
+
+	// The regression test for the trap this codebase has already hit once: River's default unique
+	// states include `completed` and cannot be narrowed, so a ByPeriod here would make a purge
+	// requested after an earlier one finished silently do nothing. ByArgs alone dedupes only
+	// in-flight work, which is what "collapse concurrent requests, allow a later purge" needs.
+	t.Run("dedupes by tenant across in-flight states only", func(t *testing.T) {
+		inserter := &recordingInserter{}
+
+		_, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, inserter).
+			Enqueue(context.Background(), "org-1")
+		require.NoError(t, err)
+
+		assert.True(t, inserter.opts[0].UniqueOpts.ByArgs, "purges must dedupe by tenant")
+		assert.Zero(t, inserter.opts[0].UniqueOpts.ByPeriod,
+			"ByPeriod would let River's completed state swallow a legitimate later purge")
+	})
+
+	t.Run("normalizes the tenant before enqueueing", func(t *testing.T) {
+		inserter := &recordingInserter{}
+
+		accepted, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, inserter).
+			Enqueue(context.Background(), "  org-1  ")
+		require.NoError(t, err)
+
+		assert.Equal(t, "org-1", accepted.TenantID)
+
+		args, ok := inserter.args[0].(FeedbackRecordsPurgeArgs)
+		require.True(t, ok)
+		// An untrimmed tenant would match no rows on the Hub side, so the purge would silently
+		// delete nothing while still reporting accepted.
+		assert.Equal(t, "org-1", args.TenantID)
+	})
+
+	t.Run("rejects a blank tenant without enqueueing", func(t *testing.T) {
+		inserter := &recordingInserter{}
+
+		_, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, inserter).
+			Enqueue(context.Background(), "   ")
+
+		var validationErr *huberrors.ValidationError
+		require.ErrorAs(t, err, &validationErr)
+		assert.Empty(t, inserter.args, "a blank tenant must never reach the queue")
+	})
+
+	t.Run("reports a clear error when built without an inserter", func(t *testing.T) {
+		_, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, nil).
+			Enqueue(context.Background(), "org-1")
+
+		require.ErrorIs(t, err, ErrPurgeInserterNotConfigured)
+	})
+
+	t.Run("propagates an insert failure instead of reporting accepted", func(t *testing.T) {
+		insertErr := errors.New("queue down")
+		inserter := &recordingInserter{err: insertErr}
+
+		accepted, err := NewFeedbackRecordsPurgeService(&stubPurgeRepo{}, inserter).
+			Enqueue(context.Background(), "org-1")
+
+		require.ErrorIs(t, err, insertErr)
+		assert.Nil(t, accepted)
+	})
+}
+
+func TestFeedbackRecordsPurgeService_Purge(t *testing.T) {
+	t.Run("purges the tenant and returns counts", func(t *testing.T) {
+		repo := &stubPurgeRepo{counts: &models.FeedbackRecordsPurgeCounts{
+			DeletedFeedbackRecords:            3,
+			DeletedEmbeddings:                 2,
+			DeletedTaxonomyClusterMemberships: 5,
+		}}
+
+		counts, err := NewFeedbackRecordsPurgeService(repo, nil).Purge(context.Background(), "org-1")
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(3), counts.DeletedFeedbackRecords)
+		assert.Equal(t, int64(2), counts.DeletedEmbeddings)
+		assert.Equal(t, int64(5), counts.DeletedTaxonomyClusterMemberships)
+		assert.Equal(t, []string{"org-1"}, repo.tenantIDs)
+	})
+
+	// Job args outlive the request that created them, so the worker path re-scopes rather than
+	// trusting enqueue-time validation.
+	t.Run("re-normalizes the tenant from the job args", func(t *testing.T) {
+		repo := &stubPurgeRepo{}
+
+		_, err := NewFeedbackRecordsPurgeService(repo, nil).Purge(context.Background(), "  org-1  ")
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"org-1"}, repo.tenantIDs)
+	})
+
+	t.Run("rejects a blank tenant without touching the repository", func(t *testing.T) {
+		repo := &stubPurgeRepo{}
+
+		_, err := NewFeedbackRecordsPurgeService(repo, nil).Purge(context.Background(), "")
+
+		var validationErr *huberrors.ValidationError
+		require.ErrorAs(t, err, &validationErr)
+		assert.Empty(t, repo.tenantIDs, "a blank tenant must never reach an unscoped delete")
+	})
+
+	t.Run("propagates a tenant write conflict for River to retry", func(t *testing.T) {
+		conflict := huberrors.NewTenantWriteConflictError("tenant-owned writes in progress; retry purge later")
+		repo := &stubPurgeRepo{err: conflict}
+
+		_, err := NewFeedbackRecordsPurgeService(repo, nil).Purge(context.Background(), "org-1")
+
+		var conflictErr *huberrors.TenantWriteConflictError
+		require.ErrorAs(t, err, &conflictErr)
+	})
+}
+
+// Guards the queue the purge is inserted on against silently sharing an enrichment queue, where a
+// long purge would stall live enrichment throughput.
+func TestFeedbackRecordsPurgeQueueIsDedicated(t *testing.T) {
+	for _, other := range []string{
+		river.QueueDefault,
+		EmbeddingsQueueName,
+		TranslationsQueueName,
+		TranslationBackfillsQueueName,
+		SentimentsQueueName,
+		EmotionsQueueName,
+	} {
+		assert.NotEqual(t, FeedbackRecordsPurgeQueueName, other)
+	}
+}

--- a/internal/service/feedback_records_purge_service_test.go
+++ b/internal/service/feedback_records_purge_service_test.go
@@ -133,9 +133,12 @@ func TestFeedbackRecordsPurgeService_Enqueue(t *testing.T) {
 func TestFeedbackRecordsPurgeService_Purge(t *testing.T) {
 	t.Run("purges the tenant and returns counts", func(t *testing.T) {
 		repo := &stubPurgeRepo{counts: &models.FeedbackRecordsPurgeCounts{
-			DeletedFeedbackRecords:            3,
-			DeletedEmbeddings:                 2,
-			DeletedTaxonomyClusterMemberships: 5,
+			DeletedFeedbackRecords: 3,
+			DeletedEmbeddings:      2,
+			TenantTaxonomyDeleteCounts: models.TenantTaxonomyDeleteCounts{
+				ClusterMemberships: 5,
+				Runs:               1,
+			},
 		}}
 
 		counts, err := NewFeedbackRecordsPurgeService(repo, nil).Purge(context.Background(), "org-1")
@@ -143,7 +146,8 @@ func TestFeedbackRecordsPurgeService_Purge(t *testing.T) {
 
 		assert.Equal(t, int64(3), counts.DeletedFeedbackRecords)
 		assert.Equal(t, int64(2), counts.DeletedEmbeddings)
-		assert.Equal(t, int64(5), counts.DeletedTaxonomyClusterMemberships)
+		assert.Equal(t, int64(5), counts.ClusterMemberships)
+		assert.Equal(t, int64(1), counts.Runs)
 		assert.Equal(t, []string{"org-1"}, repo.tenantIDs)
 	})
 

--- a/internal/service/feedback_records_purge_service_test.go
+++ b/internal/service/feedback_records_purge_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -54,10 +55,13 @@ func TestFeedbackRecordsPurgeService_Enqueue(t *testing.T) {
 		assert.Equal(t, FeedbackRecordsPurgeMaxAttempts, inserter.opts[0].MaxAttempts)
 	})
 
-	// The regression test for the trap this codebase has already hit once: River's default unique
-	// states include `completed` and cannot be narrowed, so a ByPeriod here would make a purge
-	// requested after an earlier one finished silently do nothing. ByArgs alone dedupes only
-	// in-flight work, which is what "collapse concurrent requests, allow a later purge" needs.
+	// Regression test for the bug this shipped with: relying on River's DEFAULT unique states
+	// includes `completed`, and with no ByPeriod the window is unbounded — so the first purge of a
+	// tenant was the only one that ever ran, every later request being skipped as a duplicate while
+	// still returning 202. ByState must be set, and must not contain `completed`.
+	//
+	// tests/feedback_records_purge_test.go proves the resulting behaviour against a real River
+	// queue; this pins the option itself so the intent is readable at the enqueue site.
 	t.Run("dedupes by tenant across in-flight states only", func(t *testing.T) {
 		inserter := &recordingInserter{}
 
@@ -65,9 +69,19 @@ func TestFeedbackRecordsPurgeService_Enqueue(t *testing.T) {
 			Enqueue(context.Background(), "org-1")
 		require.NoError(t, err)
 
-		assert.True(t, inserter.opts[0].UniqueOpts.ByArgs, "purges must dedupe by tenant")
-		assert.Zero(t, inserter.opts[0].UniqueOpts.ByPeriod,
-			"ByPeriod would let River's completed state swallow a legitimate later purge")
+		unique := inserter.opts[0].UniqueOpts
+		assert.True(t, unique.ByArgs, "purges must dedupe by tenant")
+		assert.NotEmpty(t, unique.ByState,
+			"River's default state set includes completed, which would swallow every later purge")
+		assert.NotContains(t, unique.ByState, rivertype.JobStateCompleted,
+			"a completed purge must never block the next one")
+		// The four states River requires ByState to include; anything else would fail validation.
+		assert.ElementsMatch(t, []rivertype.JobState{
+			rivertype.JobStateAvailable,
+			rivertype.JobStatePending,
+			rivertype.JobStateRunning,
+			rivertype.JobStateScheduled,
+		}, unique.ByState)
 	})
 
 	t.Run("normalizes the tenant before enqueueing", func(t *testing.T) {

--- a/internal/service/job_kinds.go
+++ b/internal/service/job_kinds.go
@@ -33,6 +33,7 @@ func JobKindSpecs() []JobKindSpec {
 		{Args: TenantTranslationBackfillArgs{}, Queue: TranslationBackfillsQueueName},
 		{Args: FeedbackSentimentArgs{}, Queue: SentimentsQueueName},
 		{Args: FeedbackEmotionsArgs{}, Queue: EmotionsQueueName},
+		{Args: FeedbackRecordsPurgeArgs{}, Queue: FeedbackRecordsPurgeQueueName},
 	}
 }
 

--- a/internal/service/job_kinds_test.go
+++ b/internal/service/job_kinds_test.go
@@ -17,6 +17,7 @@ func TestJobKindSpecs(t *testing.T) {
 		"tenant_translation_backfill": TranslationBackfillsQueueName,
 		"feedback_sentiment":          SentimentsQueueName,
 		"feedback_emotions":           EmotionsQueueName,
+		"feedback_records_purge":      FeedbackRecordsPurgeQueueName,
 	}
 
 	specs := JobKindSpecs()
@@ -37,6 +38,7 @@ func TestJobQueueNames(t *testing.T) {
 		TranslationBackfillsQueueName,
 		SentimentsQueueName,
 		EmotionsQueueName,
+		FeedbackRecordsPurgeQueueName,
 	}, JobQueueNames())
 }
 

--- a/internal/workers/feedback_records_purge.go
+++ b/internal/workers/feedback_records_purge.go
@@ -16,9 +16,10 @@ type feedbackRecordsPurgeService interface {
 	Purge(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeCounts, error)
 }
 
-// FeedbackRecordsPurgeWorker deletes every feedback record for one tenant, plus the data derived
-// from those records. It runs off the request path because the delete is unbounded and would
-// otherwise outlive the API server's write timeout on a large tenant.
+// FeedbackRecordsPurgeWorker deletes every feedback record for one tenant, everything derived from
+// those records, and the taxonomy built on them, keeping the tenant's configuration. It runs off the
+// request path because the delete is unbounded and would otherwise outlive the API server's write
+// timeout on a large tenant.
 type FeedbackRecordsPurgeWorker struct {
 	river.WorkerDefaults[service.FeedbackRecordsPurgeArgs]
 

--- a/internal/workers/feedback_records_purge.go
+++ b/internal/workers/feedback_records_purge.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -49,14 +50,59 @@ func (w *FeedbackRecordsPurgeWorker) Timeout(*river.Job[service.FeedbackRecordsP
 
 // Work purges the tenant's feedback records. The service re-scopes the work to the tenant in the
 // job args rather than trusting enqueue-time validation.
+//
+// A failure is logged here rather than left to River. River reports retries and final discards at
+// INFO, and hub-worker does not set river.Config.Logger, so its fallback logger sits at WARN and
+// filters both — a failing purge would otherwise leave no trace outside the river_job.errors column
+// while the dataset sits partly emptied. Matches webhook_dispatch and feedback_embedding in
+// separating a retryable attempt from the last one.
 func (w *FeedbackRecordsPurgeWorker) Work(
 	ctx context.Context, job *river.Job[service.FeedbackRecordsPurgeArgs],
 ) error {
-	if _, err := w.service.Purge(ctx, job.Args.TenantID); err != nil {
-		// The tenant id is not interpolated into the error: purge failures are logged and retried
-		// by River, and the tenant is already carried on the job row.
+	counts, err := w.service.Purge(ctx, job.Args.TenantID)
+	if err != nil {
+		logPurgeFailure(job, counts, err)
+
+		// The tenant id is not interpolated into the error: it is already carried on the job row
+		// and in the log line above.
 		return fmt.Errorf("purge feedback records: %w", err)
 	}
 
 	return nil
+}
+
+// logPurgeFailure reports a failed attempt, including how much the attempt committed before it
+// failed. The partial counts matter: batches commit as they go, so a failed purge has usually
+// already removed records, and the retry resumes from there rather than restarting.
+func logPurgeFailure(
+	job *river.Job[service.FeedbackRecordsPurgeArgs], counts *models.FeedbackRecordsPurgeCounts, err error,
+) {
+	attrs := []any{
+		"tenant_id", job.Args.TenantID,
+		"job_id", job.ID,
+		"attempt", job.Attempt,
+		"max_attempts", job.MaxAttempts,
+		"error", err,
+	}
+
+	// counts is nil only when the purge failed before the repository ran (tenant normalization).
+	if counts != nil {
+		attrs = append(attrs,
+			"deleted_feedback_records", counts.DeletedFeedbackRecords,
+			"deleted_embeddings", counts.DeletedEmbeddings,
+			"deleted_taxonomy_cluster_memberships", counts.ClusterMemberships,
+			"deleted_taxonomy_runs", counts.Runs,
+			"deleted_taxonomy_nodes", counts.Nodes,
+		)
+	}
+
+	if job.Attempt >= job.MaxAttempts {
+		// Terminal: River will not try again, so the dataset stays in whatever partial state the
+		// counts above describe until someone requests another purge.
+		slog.Error("feedback records purge: failed permanently", attrs...)
+
+		return
+	}
+
+	slog.Warn("feedback records purge: attempt failed, will retry", attrs...)
 }

--- a/internal/workers/feedback_records_purge.go
+++ b/internal/workers/feedback_records_purge.go
@@ -34,9 +34,11 @@ func NewFeedbackRecordsPurgeWorker(svc feedbackRecordsPurgeService) *FeedbackRec
 // in wiring.go for why it is one.
 const feedbackRecordsPurgeMaxWorkers = 1
 
-// feedbackRecordsPurgeTimeout bounds a single purge attempt. River rescues a job that exceeds it;
-// because the purge is idempotent and tenant-scoped, the retry simply deletes whatever survived the
-// killed attempt, so a rescued purge converges without continuation bookkeeping.
+// feedbackRecordsPurgeTimeout bounds a single purge attempt. River rescues a job that exceeds it,
+// and the retry resumes rather than restarting: the purge commits in batches, so the records
+// deleted before the timeout stay deleted and the next attempt continues from there. That is the
+// property the batching exists for — a single-transaction purge would roll back on every rescue and
+// a tenant too large for one attempt could never be purged at all.
 const feedbackRecordsPurgeTimeout = 30 * time.Minute
 
 // Timeout limits how long a single purge attempt can run.

--- a/internal/workers/feedback_records_purge.go
+++ b/internal/workers/feedback_records_purge.go
@@ -1,0 +1,59 @@
+package workers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/service"
+)
+
+// feedbackRecordsPurgeService is the minimal interface the worker needs.
+type feedbackRecordsPurgeService interface {
+	Purge(ctx context.Context, tenantID string) (*models.FeedbackRecordsPurgeCounts, error)
+}
+
+// FeedbackRecordsPurgeWorker deletes every feedback record for one tenant, plus the data derived
+// from those records. It runs off the request path because the delete is unbounded and would
+// otherwise outlive the API server's write timeout on a large tenant.
+type FeedbackRecordsPurgeWorker struct {
+	river.WorkerDefaults[service.FeedbackRecordsPurgeArgs]
+
+	service feedbackRecordsPurgeService
+}
+
+// NewFeedbackRecordsPurgeWorker creates the worker.
+func NewFeedbackRecordsPurgeWorker(svc feedbackRecordsPurgeService) *FeedbackRecordsPurgeWorker {
+	return &FeedbackRecordsPurgeWorker{service: svc}
+}
+
+// feedbackRecordsPurgeMaxWorkers is the concurrency of the purge queue. See the queue declaration
+// in wiring.go for why it is one.
+const feedbackRecordsPurgeMaxWorkers = 1
+
+// feedbackRecordsPurgeTimeout bounds a single purge attempt. River rescues a job that exceeds it;
+// because the purge is idempotent and tenant-scoped, the retry simply deletes whatever survived the
+// killed attempt, so a rescued purge converges without continuation bookkeeping.
+const feedbackRecordsPurgeTimeout = 30 * time.Minute
+
+// Timeout limits how long a single purge attempt can run.
+func (w *FeedbackRecordsPurgeWorker) Timeout(*river.Job[service.FeedbackRecordsPurgeArgs]) time.Duration {
+	return feedbackRecordsPurgeTimeout
+}
+
+// Work purges the tenant's feedback records. The service re-scopes the work to the tenant in the
+// job args rather than trusting enqueue-time validation.
+func (w *FeedbackRecordsPurgeWorker) Work(
+	ctx context.Context, job *river.Job[service.FeedbackRecordsPurgeArgs],
+) error {
+	if _, err := w.service.Purge(ctx, job.Args.TenantID); err != nil {
+		// The tenant id is not interpolated into the error: purge failures are logged and retried
+		// by River, and the tenant is already carried on the job row.
+		return fmt.Errorf("purge feedback records: %w", err)
+	}
+
+	return nil
+}

--- a/internal/workers/feedback_records_purge_test.go
+++ b/internal/workers/feedback_records_purge_test.go
@@ -1,0 +1,68 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/service"
+)
+
+type recordingPurgeService struct {
+	tenantIDs []string
+	err       error
+}
+
+func (r *recordingPurgeService) Purge(
+	_ context.Context, tenantID string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	r.tenantIDs = append(r.tenantIDs, tenantID)
+
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return &models.FeedbackRecordsPurgeCounts{DeletedFeedbackRecords: 3}, nil
+}
+
+func purgeJob(tenantID string) *river.Job[service.FeedbackRecordsPurgeArgs] {
+	return &river.Job[service.FeedbackRecordsPurgeArgs]{
+		Args: service.FeedbackRecordsPurgeArgs{TenantID: tenantID},
+	}
+}
+
+func TestFeedbackRecordsPurgeWorker_Work(t *testing.T) {
+	t.Run("purges the tenant carried on the job", func(t *testing.T) {
+		svc := &recordingPurgeService{}
+
+		require.NoError(t, NewFeedbackRecordsPurgeWorker(svc).Work(context.Background(), purgeJob("org-1")))
+		assert.Equal(t, []string{"org-1"}, svc.tenantIDs)
+	})
+
+	// The error must propagate so River retries. Swallowing it would mark the job complete with the
+	// tenant's records still in place, and nothing would ever come back for them.
+	t.Run("returns the failure so River retries", func(t *testing.T) {
+		purgeErr := errors.New("purge failed")
+		svc := &recordingPurgeService{err: purgeErr}
+
+		err := NewFeedbackRecordsPurgeWorker(svc).Work(context.Background(), purgeJob("org-1"))
+
+		require.ErrorIs(t, err, purgeErr)
+		// The tenant is not interpolated into the error; it is already on the job row.
+		assert.NotContains(t, err.Error(), "org-1")
+	})
+
+	// A purge is unbounded, so it needs a timeout well above River's default. Zero would mean "use
+	// the default", which is how a large purge would get killed and retried forever.
+	t.Run("allows a long single attempt", func(t *testing.T) {
+		timeout := NewFeedbackRecordsPurgeWorker(&recordingPurgeService{}).Timeout(purgeJob("org-1"))
+
+		assert.Positive(t, timeout)
+		assert.Equal(t, feedbackRecordsPurgeTimeout, timeout)
+	})
+}

--- a/internal/workers/feedback_records_purge_test.go
+++ b/internal/workers/feedback_records_purge_test.go
@@ -3,9 +3,11 @@ package workers
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +18,8 @@ import (
 type recordingPurgeService struct {
 	tenantIDs []string
 	err       error
+	// counts is returned alongside err: the repository reports what it committed before failing.
+	counts *models.FeedbackRecordsPurgeCounts
 }
 
 func (r *recordingPurgeService) Purge(
@@ -24,16 +28,75 @@ func (r *recordingPurgeService) Purge(
 	r.tenantIDs = append(r.tenantIDs, tenantID)
 
 	if r.err != nil {
-		return nil, r.err
+		// Mirrors the service: partial progress is returned with the error, not dropped.
+		return r.counts, r.err
 	}
 
 	return &models.FeedbackRecordsPurgeCounts{DeletedFeedbackRecords: 3}, nil
 }
 
+// purgeJob builds a job the way River delivers one. The embedded JobRow must be populated: River
+// always sets it, and the worker reads Attempt/MaxAttempts from it to tell a retryable failure from
+// the last one.
 func purgeJob(tenantID string) *river.Job[service.FeedbackRecordsPurgeArgs] {
+	return purgeJobAttempt(tenantID, 1, service.FeedbackRecordsPurgeMaxAttempts)
+}
+
+func purgeJobAttempt(tenantID string, attempt, maxAttempts int) *river.Job[service.FeedbackRecordsPurgeArgs] {
 	return &river.Job[service.FeedbackRecordsPurgeArgs]{
+		JobRow: &rivertype.JobRow{
+			ID:          1,
+			Attempt:     attempt,
+			MaxAttempts: maxAttempts,
+		},
 		Args: service.FeedbackRecordsPurgeArgs{TenantID: tenantID},
 	}
+}
+
+// capturePurgeLogs swaps the default logger for the duration of a test and returns the records it
+// collected.
+func capturePurgeLogs(t *testing.T) *purgeLogCapture {
+	t.Helper()
+
+	capture := &purgeLogCapture{}
+	previous := slog.Default()
+
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return capture
+}
+
+type purgeLogCapture struct {
+	records []slog.Record
+}
+
+func (c *purgeLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+func (c *purgeLogCapture) WithAttrs([]slog.Attr) slog.Handler       { return c }
+func (c *purgeLogCapture) WithGroup(string) slog.Handler            { return c }
+
+func (c *purgeLogCapture) Handle(_ context.Context, record slog.Record) error {
+	c.records = append(c.records, record)
+
+	return nil
+}
+
+func (c *purgeLogCapture) attr(t *testing.T, index int, key string) any {
+	t.Helper()
+
+	var found any
+
+	c.records[index].Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			found = a.Value.Any()
+
+			return false
+		}
+
+		return true
+	})
+
+	return found
 }
 
 func TestFeedbackRecordsPurgeWorker_Work(t *testing.T) {
@@ -55,6 +118,41 @@ func TestFeedbackRecordsPurgeWorker_Work(t *testing.T) {
 		require.ErrorIs(t, err, purgeErr)
 		// The tenant is not interpolated into the error; it is already on the job row.
 		assert.NotContains(t, err.Error(), "org-1")
+	})
+
+	// A failed purge used to leave no trace: the worker logged only on success, and River reports
+	// retries and final discards at INFO while hub-worker's fallback logger sits at WARN. The purge
+	// commits in batches, so a silent failure leaves the dataset partly emptied with nothing to
+	// explain it.
+	t.Run("logs a retryable failure with the progress it committed", func(t *testing.T) {
+		logs := capturePurgeLogs(t)
+		svc := &recordingPurgeService{
+			err:    errors.New("purge failed"),
+			counts: &models.FeedbackRecordsPurgeCounts{DeletedFeedbackRecords: 1200, DeletedEmbeddings: 900},
+		}
+
+		err := NewFeedbackRecordsPurgeWorker(svc).Work(context.Background(), purgeJobAttempt("org-1", 2, 5))
+
+		require.Error(t, err)
+		require.Len(t, logs.records, 1)
+		assert.Equal(t, slog.LevelWarn, logs.records[0].Level,
+			"an attempt with retries left is not yet a permanent failure")
+		assert.Equal(t, "org-1", logs.attr(t, 0, "tenant_id"))
+		assert.Equal(t, int64(1200), logs.attr(t, 0, "deleted_feedback_records"),
+			"the committed progress must be reported, not discarded")
+	})
+
+	// The last attempt is the one an operator has to act on: nothing will retry it, so the dataset
+	// stays partly emptied until someone requests another purge.
+	t.Run("logs the last attempt at error level", func(t *testing.T) {
+		logs := capturePurgeLogs(t)
+		svc := &recordingPurgeService{err: errors.New("purge failed")}
+
+		err := NewFeedbackRecordsPurgeWorker(svc).Work(context.Background(), purgeJobAttempt("org-1", 5, 5))
+
+		require.Error(t, err)
+		require.Len(t, logs.records, 1)
+		assert.Equal(t, slog.LevelError, logs.records[0].Level)
 	})
 
 	// A purge is unbounded, so it needs a timeout well above River's default. Zero would mean "use

--- a/internal/workers/wiring.go
+++ b/internal/workers/wiring.go
@@ -45,6 +45,10 @@ type RiverDeps struct {
 	EmotionsResolver tenantSettingsReader
 	EmotionsClient   service.EmotionsClient
 	EmotionsMetrics  observability.EmotionsMetrics
+
+	// Feedback-records purge worker (always registered; the purge is a core tenant operation, not
+	// an enrichment, so it has no client to gate on).
+	FeedbackRecordsPurgeService feedbackRecordsPurgeService
 }
 
 // NewRiverWorkersAndQueues builds River workers and queue config from cfg and deps. Each optional
@@ -68,8 +72,15 @@ func NewRiverWorkersAndQueues(
 	maxSentiment := cfg.Sentiment.MaxConcurrent
 	maxEmotions := cfg.Emotions.MaxConcurrent
 
+	purgeWorker := NewFeedbackRecordsPurgeWorker(deps.FeedbackRecordsPurgeService)
+	river.AddWorker(workers, purgeWorker)
+
 	queues := map[string]river.QueueConfig{
 		river.QueueDefault: {MaxWorkers: maxDefault},
+		// Purges run one at a time. Each one is an unbounded delete that holds its tenant's write
+		// lock exclusively, so running several concurrently would multiply that load on Postgres for
+		// no gain — purges are rare and admin-initiated, and a queued one loses nothing by waiting.
+		service.FeedbackRecordsPurgeQueueName: {MaxWorkers: feedbackRecordsPurgeMaxWorkers},
 	}
 
 	if deps.EmbeddingClient != nil {

--- a/internal/workers/wiring.go
+++ b/internal/workers/wiring.go
@@ -77,9 +77,11 @@ func NewRiverWorkersAndQueues(
 
 	queues := map[string]river.QueueConfig{
 		river.QueueDefault: {MaxWorkers: maxDefault},
-		// Purges run one at a time. Each one is an unbounded delete that holds its tenant's write
-		// lock exclusively, so running several concurrently would multiply that load on Postgres for
-		// no gain — purges are rare and admin-initiated, and a queued one loses nothing by waiting.
+		// One purge at a time per replica (River's MaxWorkers is per-client, so N hub-worker replicas
+		// can still run N purges — for different tenants, which is fine). Each purge is a long
+		// sequence of batched deletes holding its tenant's write lock, so stacking several on one
+		// replica would multiply that load on Postgres for no gain: purges are rare and
+		// admin-initiated, and a queued one loses nothing by waiting.
 		service.FeedbackRecordsPurgeQueueName: {MaxWorkers: feedbackRecordsPurgeMaxWorkers},
 	}
 

--- a/internal/workers/wiring_test.go
+++ b/internal/workers/wiring_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/service"
 )
 
@@ -23,6 +24,16 @@ func (stubTranslationBackfillService) BackfillTranslationsForTenant(
 	_ context.Context, _ service.RiverJobInserter, _ string, _ int, _, _ string,
 ) (int, error) {
 	return 0, nil
+}
+
+// stubFeedbackRecordsPurgeService satisfies feedbackRecordsPurgeService. The tests only register
+// workers, never run them, so the method is never called.
+type stubFeedbackRecordsPurgeService struct{}
+
+func (stubFeedbackRecordsPurgeService) Purge(
+	_ context.Context, _ string,
+) (*models.FeedbackRecordsPurgeCounts, error) {
+	return &models.FeedbackRecordsPurgeCounts{}, nil
 }
 
 // kindProbe re-registers a job kind to observe whether it is already registered.
@@ -75,6 +86,8 @@ func fullRiverDeps() RiverDeps {
 		EmotionsResolver: stubEmotionsSettings{},
 		EmotionsClient:   &stubEmotionsClient{},
 		EmotionsMetrics:  &countingEmotionsMetrics{},
+
+		FeedbackRecordsPurgeService: stubFeedbackRecordsPurgeService{},
 	}
 }
 
@@ -99,36 +112,44 @@ func TestNewRiverWorkersAndQueuesCoversEveryJobKind(t *testing.T) {
 	assertKindRegistered[service.TenantTranslationBackfillArgs](t, workerBundle, true)
 	assertKindRegistered[service.FeedbackSentimentArgs](t, workerBundle, true)
 	assertKindRegistered[service.FeedbackEmotionsArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackRecordsPurgeArgs](t, workerBundle, true)
 
-	const probedKinds = 6
+	const probedKinds = 7
 	if got := len(service.JobKindSpecs()); got != probedKinds {
 		t.Fatalf("JobKindSpecs has %d kinds but %d are probed above — add a probe for the new kind "+
 			"and register a worker for it in NewRiverWorkersAndQueues", got, probedKinds)
 	}
 }
 
-// TestNewRiverWorkersAndQueuesWithoutOptionalClients pins the disabled-enrichment shape: webhook
-// dispatch always runs, and a nil client must leave both its worker and its queue out rather than
-// registering a worker that would fail on every job.
+// TestNewRiverWorkersAndQueuesWithoutOptionalClients pins the disabled-enrichment shape: the
+// always-on workers (webhook dispatch and the feedback-records purge) still run, and a nil client
+// must leave both its worker and its queue out rather than registering a worker that would fail on
+// every job.
 func TestNewRiverWorkersAndQueuesWithoutOptionalClients(t *testing.T) {
 	cfg := &config.Config{}
 	deps := RiverDeps{
 		WebhooksRepo:   &mockDispatchRepo{},
 		WebhookSender:  &mockSender{},
 		WebhookMetrics: newCountingWebhookMetrics(),
+
+		FeedbackRecordsPurgeService: stubFeedbackRecordsPurgeService{},
 	}
 
 	workerBundle, queues := NewRiverWorkersAndQueues(cfg, deps)
 
-	if len(queues) != 1 {
-		t.Fatalf("queues = %v, want only %q", queues, river.QueueDefault)
+	alwaysOnQueues := []string{river.QueueDefault, service.FeedbackRecordsPurgeQueueName}
+	if len(queues) != len(alwaysOnQueues) {
+		t.Fatalf("queues = %v, want only %v", queues, alwaysOnQueues)
 	}
 
-	if _, ok := queues[river.QueueDefault]; !ok {
-		t.Fatalf("queues = %v, want %q declared", queues, river.QueueDefault)
+	for _, name := range alwaysOnQueues {
+		if _, ok := queues[name]; !ok {
+			t.Fatalf("queues = %v, want %q declared", queues, name)
+		}
 	}
 
 	assertKindRegistered[service.WebhookDispatchArgs](t, workerBundle, true)
+	assertKindRegistered[service.FeedbackRecordsPurgeArgs](t, workerBundle, true)
 	assertKindRegistered[service.FeedbackEmbeddingArgs](t, workerBundle, false)
 	assertKindRegistered[service.FeedbackTranslationArgs](t, workerBundle, false)
 	assertKindRegistered[service.TenantTranslationBackfillArgs](t, workerBundle, false)
@@ -156,6 +177,8 @@ func TestNewRiverWorkersAndQueuesUsesConfiguredConcurrency(t *testing.T) {
 		service.TranslationBackfillsQueueName: 4,
 		service.SentimentsQueueName:           5,
 		service.EmotionsQueueName:             6,
+		// Purges are deliberately serialized rather than configurable — see wiring.go.
+		service.FeedbackRecordsPurgeQueueName: feedbackRecordsPurgeMaxWorkers,
 	}
 
 	for name, wantMax := range want {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1291,18 +1291,21 @@ paths:
                 - Feedback Records
             summary: Purge all feedback records for a tenant
             description: |
-                Permanently deletes every feedback record for the specified tenant_id, along with the data derived
-                from those records: embeddings, taxonomy cluster memberships, and the enrichment stored on each
-                record (sentiment, emotions, translations).
+                Permanently deletes every feedback record for the specified tenant_id, everything derived from
+                those records — embeddings and the enrichment stored on each record (sentiment, emotions,
+                translations) — and the taxonomy built on them: runs, clusters, nodes, cluster memberships,
+                active-run pointers and node events.
 
-                This is intended for emptying a dataset that stays in use. The tenant's taxonomy structure (runs,
-                clusters, nodes, active-run pointers and node events), its webhooks, and its settings are all left
-                in place — the clusters simply end up with no members. Note that a taxonomy run's own stored
-                counters (`record_count`, `cluster_count`, and a cluster's `size`) are NOT rewritten: they record
-                what that run processed, so a run read back after a purge still reports its original counts. The
-                per-node record counts returned by the taxonomy tree are derived from memberships at read time and
-                do fall to zero. To remove everything Hub holds for a tenant during offboarding, use
-                `DELETE /v1/tenants/{tenant_id}/data` instead.
+                This is intended for emptying a dataset that stays in use, so it removes the tenant's DATA but
+                never its CONFIGURATION: webhooks and tenant settings are left untouched. That is the difference
+                from `DELETE /v1/tenants/{tenant_id}/data`, which additionally deletes both and is meant for
+                offboarding a deprovisioned tenant.
+
+                The taxonomy is removed rather than preserved because it describes records that no longer exist:
+                its per-node counts are derived from memberships and would all read zero, while a run's own stored
+                counters (`record_count`, `cluster_count`, a cluster's `size`) are historical and would keep
+                advertising the old numbers. A new taxonomy can be generated once the dataset has enough feedback
+                again; manual node renames and removals are per-run and do not survive a regeneration in any case.
 
                 The tenant is a required path segment, so it cannot be omitted the way a filter on a collection
                 delete could be — dropping it routes elsewhere rather than widening the operation to every tenant.
@@ -1318,11 +1321,11 @@ paths:
                 joins the running purge rather than queueing a second one, and still returns 202. A purge requested
                 after an earlier one finished starts a new run.
 
-                The delete is committed in batches, so a purge interrupted by a restart or a timeout keeps the
-                progress it made and resumes on retry. While each batch runs, the tenant's write lock is held
-                exclusively and Hub-owned writes for that tenant are rejected with HTTP 409 (code
-                `tenant_write_conflict`); the lock is released between batches, and writes for other tenants are
-                never affected. This does not apply to the request below — scheduling a purge takes no lock, so
+                Records are deleted in committed batches, so a purge interrupted by a restart or a timeout keeps
+                the progress it made and resumes on retry; the taxonomy is removed in a final step once the records
+                are gone. While each step runs, the tenant's write lock is held exclusively and Hub-owned writes
+                for that tenant are rejected with HTTP 409 (code `tenant_write_conflict`); the lock is released
+                between steps, and writes for other tenants are never affected. This does not apply to the request below — scheduling a purge takes no lock, so
                 this endpoint does not return 409. A batch that cannot acquire the lock is retried by the job
                 queue without any caller action, up to a bounded number of attempts.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1288,7 +1288,7 @@ paths:
     /v1/tenants/{tenant_id}/feedback-records:
         delete:
             tags:
-                - Feedback Records
+                - Tenant Data
             summary: Purge all feedback records for a tenant
             description: |
                 Permanently deletes every feedback record for the specified tenant_id, everything derived from
@@ -1312,10 +1312,13 @@ paths:
 
                 Asynchronous: the request schedules the purge and returns 202 immediately, because the deletion is
                 unbounded and can outlive a request. There is therefore no deleted count in the response. Poll
-                `GET /v1/feedback-records/count?tenant_id=...` to observe progress. For a dataset that is no longer
+                `GET /v1/feedback-records/count?tenant_id=...` to observe progress.
+
+                The purge removes only the records that existed when it started — it takes a high-water mark up
+                front — so feedback ingested while it runs is never deleted. For a dataset that is no longer
                 receiving feedback the count reaching zero means the purge is complete; for one still ingesting,
-                the count reflects newly arrived records rather than purge failure, since the purge only removes
-                what existed when it started.
+                a nonzero count is those newer records. Note this means the count alone cannot distinguish
+                "finished" from "failed" on an active dataset.
 
                 Idempotent and safe to repeat. Requesting a purge while one is already running for the same tenant
                 joins the running purge rather than queueing a second one, and still returns 202. A purge requested

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -564,83 +564,6 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
-    /v1/feedback-records/purge:
-        post:
-            tags:
-                - Feedback Records
-            summary: Purge all feedback records for a tenant
-            description: |
-                Permanently deletes every feedback record for the specified tenant_id, along with the data derived
-                from those records: embeddings, taxonomy cluster memberships, and the enrichment stored on each
-                record (sentiment, emotions, translations).
-
-                This is intended for emptying a dataset that stays in use. The tenant's taxonomy structure (runs,
-                clusters and nodes), its webhooks, and its settings are left in place — the clusters simply end up
-                with no members, and per-node record counts, which are derived at read time, fall to zero. To
-                remove everything Hub holds for a tenant during offboarding, use
-                `DELETE /v1/tenants/{tenant_id}/data` instead.
-
-                tenant_id is required. This is a distinct endpoint rather than a filter on
-                `DELETE /v1/feedback-records` precisely so that it cannot be reached by omitting a parameter: that
-                endpoint erases one data subject's records, and widening it to a whole tenant when a filter is left
-                out is how a narrow deletion silently becomes a dataset wipe.
-
-                Asynchronous: the request enqueues the purge and returns 202 immediately, because the deletion is
-                unbounded and can outlive a request. There is therefore no deleted count in the response. Poll
-                `GET /v1/feedback-records/count?tenant_id=...` to observe progress; the purge is complete when it
-                reaches zero.
-
-                Idempotent and safe to repeat. Requesting a purge while one is already running for the same tenant
-                joins the running purge rather than queueing a second one, and still returns 202. A purge requested
-                after an earlier one finished starts a new run.
-
-                While the purge runs it holds the tenant's write lock exclusively, so Hub-owned writes for that
-                tenant are rejected with HTTP 409 (code `tenant_write_conflict`) until it completes; writes for
-                other tenants are unaffected. Note this affects other endpoints, not this one: accepting a purge
-                takes no lock, so this request does not return 409. If in-flight writes do not drain within the
-                configured lock timeout, the purge attempt is retried by the job queue without any caller action.
-
-                No webhook events are published for a purge, and no webhooks are deleted. Enrichment jobs already
-                queued for purged records no-op when they run, since the record they reference is gone.
-            operationId: purge-feedback-records
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/FeedbackRecordsPurgeInputBody'
-            responses:
-                "202":
-                    description: Purge accepted and scheduled
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/FeedbackRecordsPurgeOutputBody'
-                            examples:
-                                accepted:
-                                    summary: Purge accepted
-                                    value:
-                                        tenant_id: "org-123"
-                                        status: "accepted"
-                                        message: "Feedback records purge accepted for org-123"
-                "400":
-                    description: Bad Request (e.g. missing or invalid tenant_id, or unknown fields in the body)
-                    content:
-                        application/problem+json:
-                            schema:
-                                $ref: '#/components/schemas/ErrorModel'
-                "401":
-                    description: Unauthorized (missing or invalid API key)
-                    content:
-                        application/problem+json:
-                            schema:
-                                $ref: '#/components/schemas/ErrorModel'
-                default:
-                    description: Error
-                    content:
-                        application/problem+json:
-                            schema:
-                                $ref: '#/components/schemas/ErrorModel'
     /v1/feedback-records/{id}:
         get:
             tags:
@@ -1352,6 +1275,93 @@ paths:
                     description: |
                         Conflict – tenant-owned writes were in flight and did not drain within the purge
                         lock timeout (code `tenant_write_conflict`). No data was deleted; retry the purge.
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/tenants/{tenant_id}/feedback-records:
+        delete:
+            tags:
+                - Feedback Records
+            summary: Purge all feedback records for a tenant
+            description: |
+                Permanently deletes every feedback record for the specified tenant_id, along with the data derived
+                from those records: embeddings, taxonomy cluster memberships, and the enrichment stored on each
+                record (sentiment, emotions, translations).
+
+                This is intended for emptying a dataset that stays in use. The tenant's taxonomy structure (runs,
+                clusters, nodes, active-run pointers and node events), its webhooks, and its settings are all left
+                in place — the clusters simply end up with no members. Note that a taxonomy run's own stored
+                counters (`record_count`, `cluster_count`, and a cluster's `size`) are NOT rewritten: they record
+                what that run processed, so a run read back after a purge still reports its original counts. The
+                per-node record counts returned by the taxonomy tree are derived from memberships at read time and
+                do fall to zero. To remove everything Hub holds for a tenant during offboarding, use
+                `DELETE /v1/tenants/{tenant_id}/data` instead.
+
+                The tenant is a required path segment, so it cannot be omitted the way a filter on a collection
+                delete could be — dropping it routes elsewhere rather than widening the operation to every tenant.
+
+                Asynchronous: the request schedules the purge and returns 202 immediately, because the deletion is
+                unbounded and can outlive a request. There is therefore no deleted count in the response. Poll
+                `GET /v1/feedback-records/count?tenant_id=...` to observe progress. For a dataset that is no longer
+                receiving feedback the count reaching zero means the purge is complete; for one still ingesting,
+                the count reflects newly arrived records rather than purge failure, since the purge only removes
+                what existed when it started.
+
+                Idempotent and safe to repeat. Requesting a purge while one is already running for the same tenant
+                joins the running purge rather than queueing a second one, and still returns 202. A purge requested
+                after an earlier one finished starts a new run.
+
+                The delete is committed in batches, so a purge interrupted by a restart or a timeout keeps the
+                progress it made and resumes on retry. While each batch runs, the tenant's write lock is held
+                exclusively and Hub-owned writes for that tenant are rejected with HTTP 409 (code
+                `tenant_write_conflict`); the lock is released between batches, and writes for other tenants are
+                never affected. This does not apply to the request below — scheduling a purge takes no lock, so
+                this endpoint does not return 409. A batch that cannot acquire the lock is retried by the job
+                queue without any caller action, up to a bounded number of attempts.
+
+                No webhook events are published for a purge, and no webhooks are deleted. Enrichment jobs already
+                queued for purged records no-op when they run, since the record they reference is gone.
+            operationId: purge-tenant-feedback-records
+            parameters:
+                - name: tenant_id
+                  in: path
+                  required: true
+                  description: Tenant ID whose feedback records should be purged. Empty strings and NULL bytes are not allowed.
+                  schema:
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    pattern: '^[^\x00]*$'
+                    example: "org-123"
+            responses:
+                "202":
+                    description: Purge accepted and scheduled
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FeedbackRecordsPurgeOutputBody'
+                            examples:
+                                accepted:
+                                    summary: Purge accepted
+                                    value:
+                                        tenant_id: "org-123"
+                                        status: "accepted"
+                                        message: "Feedback records purge accepted for org-123"
+                "400":
+                    description: Bad Request (e.g. missing or invalid tenant_id)
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+                "401":
+                    description: Unauthorized (missing or invalid API key)
                     content:
                         application/problem+json:
                             schema:
@@ -2715,21 +2725,6 @@ components:
                     example: 42
             required:
                 - count
-        FeedbackRecordsPurgeInputBody:
-            type: object
-            additionalProperties: false
-            required:
-                - tenant_id
-            properties:
-                tenant_id:
-                    type: string
-                    description: |
-                        Tenant ID whose feedback records should be purged. Required — there is no "all tenants"
-                        form of this operation. Empty strings and NULL bytes are not allowed.
-                    minLength: 1
-                    maxLength: 255
-                    pattern: '^[^\x00]*$'
-                    example: "org-123"
         FeedbackRecordsPurgeOutputBody:
             type: object
             additionalProperties: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -564,6 +564,83 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/feedback-records/purge:
+        post:
+            tags:
+                - Feedback Records
+            summary: Purge all feedback records for a tenant
+            description: |
+                Permanently deletes every feedback record for the specified tenant_id, along with the data derived
+                from those records: embeddings, taxonomy cluster memberships, and the enrichment stored on each
+                record (sentiment, emotions, translations).
+
+                This is intended for emptying a dataset that stays in use. The tenant's taxonomy structure (runs,
+                clusters and nodes), its webhooks, and its settings are left in place — the clusters simply end up
+                with no members, and per-node record counts, which are derived at read time, fall to zero. To
+                remove everything Hub holds for a tenant during offboarding, use
+                `DELETE /v1/tenants/{tenant_id}/data` instead.
+
+                tenant_id is required. This is a distinct endpoint rather than a filter on
+                `DELETE /v1/feedback-records` precisely so that it cannot be reached by omitting a parameter: that
+                endpoint erases one data subject's records, and widening it to a whole tenant when a filter is left
+                out is how a narrow deletion silently becomes a dataset wipe.
+
+                Asynchronous: the request enqueues the purge and returns 202 immediately, because the deletion is
+                unbounded and can outlive a request. There is therefore no deleted count in the response. Poll
+                `GET /v1/feedback-records/count?tenant_id=...` to observe progress; the purge is complete when it
+                reaches zero.
+
+                Idempotent and safe to repeat. Requesting a purge while one is already running for the same tenant
+                joins the running purge rather than queueing a second one, and still returns 202. A purge requested
+                after an earlier one finished starts a new run.
+
+                While the purge runs it holds the tenant's write lock exclusively, so Hub-owned writes for that
+                tenant are rejected with HTTP 409 (code `tenant_write_conflict`) until it completes; writes for
+                other tenants are unaffected. Note this affects other endpoints, not this one: accepting a purge
+                takes no lock, so this request does not return 409. If in-flight writes do not drain within the
+                configured lock timeout, the purge attempt is retried by the job queue without any caller action.
+
+                No webhook events are published for a purge, and no webhooks are deleted. Enrichment jobs already
+                queued for purged records no-op when they run, since the record they reference is gone.
+            operationId: purge-feedback-records
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/FeedbackRecordsPurgeInputBody'
+            responses:
+                "202":
+                    description: Purge accepted and scheduled
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FeedbackRecordsPurgeOutputBody'
+                            examples:
+                                accepted:
+                                    summary: Purge accepted
+                                    value:
+                                        tenant_id: "org-123"
+                                        status: "accepted"
+                                        message: "Feedback records purge accepted for org-123"
+                "400":
+                    description: Bad Request (e.g. missing or invalid tenant_id, or unknown fields in the body)
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+                "401":
+                    description: Unauthorized (missing or invalid API key)
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/feedback-records/{id}:
         get:
             tags:
@@ -2638,6 +2715,48 @@ components:
                     example: 42
             required:
                 - count
+        FeedbackRecordsPurgeInputBody:
+            type: object
+            additionalProperties: false
+            required:
+                - tenant_id
+            properties:
+                tenant_id:
+                    type: string
+                    description: |
+                        Tenant ID whose feedback records should be purged. Required — there is no "all tenants"
+                        form of this operation. Empty strings and NULL bytes are not allowed.
+                    minLength: 1
+                    maxLength: 255
+                    pattern: '^[^\x00]*$'
+                    example: "org-123"
+        FeedbackRecordsPurgeOutputBody:
+            type: object
+            additionalProperties: false
+            required:
+                - tenant_id
+                - status
+            properties:
+                tenant_id:
+                    type: string
+                    description: Tenant ID whose feedback records are being purged
+                    minLength: 1
+                    maxLength: 255
+                    pattern: '^[^\x00]*$'
+                    example: "org-123"
+                status:
+                    type: string
+                    description: |
+                        Always `accepted`. The purge runs in the background, so this reports that the work was
+                        scheduled, not that it finished — poll `GET /v1/feedback-records/count` for the tenant to
+                        observe completion.
+                    enum:
+                        - accepted
+                    example: "accepted"
+                message:
+                    type: string
+                    description: Human-readable confirmation
+                    example: "Feedback records purge accepted for org-123"
         TenantDataDeleteOutputBody:
             type: object
             additionalProperties: false

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -76,9 +76,10 @@ func seedPurgeEmbedding(ctx context.Context, t *testing.T, db *pgxpool.Pool, rec
 	require.NoError(t, err)
 }
 
-// TestPurgeFeedbackRecordsByTenant is the test that justifies this endpoint existing separately from
-// the tenant offboarding purge: the records go, and the taxonomy structure, webhooks and settings
-// stay. If the survival half ever regresses, a purged dataset silently loses its topic tree.
+// TestPurgeFeedbackRecordsByTenant pins the line that justifies this endpoint existing separately
+// from the tenant offboarding purge: the tenant's DATA goes — records, embeddings and the taxonomy
+// built on them — while its CONFIGURATION stays. If the configuration half ever regresses, a purge
+// silently destroys integrator webhooks and enrichment opt-outs that nothing can restore.
 func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 	ctx := context.Background()
 	db := newPurgeTestDB(ctx, t)
@@ -123,7 +124,10 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 	t.Run("reports exact counts for the records and their derived rows", func(t *testing.T) {
 		assert.Equal(t, int64(1), counts.DeletedFeedbackRecords)
 		assert.Equal(t, int64(1), counts.DeletedEmbeddings)
-		assert.Equal(t, int64(1), counts.DeletedTaxonomyClusterMemberships)
+		assert.Equal(t, int64(1), counts.ClusterMemberships)
+		assert.Equal(t, int64(1), counts.Runs)
+		assert.Equal(t, int64(3), counts.Nodes)
+		assert.Equal(t, int64(1), counts.ActiveRuns)
 	})
 
 	t.Run("removes the records and everything derived from them", func(t *testing.T) {
@@ -135,19 +139,27 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, tenantID))
 	})
 
-	// The reason this endpoint exists. The clusters keep existing with no members; per-node counts
-	// are derived from memberships at read time, so they report zero without being rewritten.
-	t.Run("keeps the taxonomy structure, webhooks and settings", func(t *testing.T) {
-		assert.Equal(t, 1, countRows(ctx, t, db,
+	// The taxonomy goes with the records it describes. Keeping it would leave a tree the dashboard
+	// hides behind its minimum-records gate, whose run header still advertised the old record_count,
+	// and which would resurface over unrelated data once the dataset refilled.
+	t.Run("removes the taxonomy built on those records", func(t *testing.T) {
+		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_runs WHERE id = $1`, ids.RunID))
-		assert.Equal(t, 1, countRows(ctx, t, db,
+		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_clusters WHERE id = $1`, ids.ClusterID))
-		assert.Equal(t, 3, countRows(ctx, t, db,
+		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_nodes WHERE run_id = $1`, ids.RunID))
-		assert.Equal(t, 1, countRows(ctx, t, db,
+		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_active_runs WHERE tenant_id = $1`, tenantID))
-		assert.Equal(t, 1, countRows(ctx, t, db,
+		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_node_events WHERE tenant_id = $1`, tenantID))
+	})
+
+	// The line between this purge and the offboarding one. Webhooks are integrator-configured
+	// directly against the Hub (with signing keys reads never return) and tenant_settings holds
+	// enrichment opt-outs that silently revert to enabled once the row is gone — neither is this
+	// operation's business.
+	t.Run("keeps the tenant's configuration", func(t *testing.T) {
 		assert.Equal(t, 1, countRows(ctx, t, db,
 			`SELECT count(*) FROM webhooks WHERE tenant_id = $1`, tenantID))
 		assert.Equal(t, 1, countRows(ctx, t, db,
@@ -161,6 +173,10 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 			`SELECT count(*) FROM embeddings WHERE feedback_record_id = $1`, otherIDs.FeedbackRecordID))
 		assert.Equal(t, 1, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, otherTenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_runs WHERE id = $1`, otherIDs.RunID))
+		assert.Equal(t, 3, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_nodes WHERE run_id = $1`, otherIDs.RunID))
 	})
 
 	t.Run("is idempotent", func(t *testing.T) {
@@ -169,7 +185,9 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 
 		assert.Zero(t, repeat.DeletedFeedbackRecords)
 		assert.Zero(t, repeat.DeletedEmbeddings)
-		assert.Zero(t, repeat.DeletedTaxonomyClusterMemberships)
+		assert.Zero(t, repeat.ClusterMemberships)
+		assert.Zero(t, repeat.Runs)
+		assert.Zero(t, repeat.Nodes)
 	})
 }
 
@@ -289,5 +307,5 @@ func TestPurgeFeedbackRecordsByTenantUnknownTenant(t *testing.T) {
 
 	assert.Zero(t, counts.DeletedFeedbackRecords)
 	assert.Zero(t, counts.DeletedEmbeddings)
-	assert.Zero(t, counts.DeletedTaxonomyClusterMemberships)
+	assert.Zero(t, counts.ClusterMemberships)
 }

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -1,0 +1,274 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+	"github.com/formbricks/hub/internal/service"
+	"github.com/formbricks/hub/pkg/database"
+)
+
+// newPurgeTestDB opens a pool against the integration database.
+func newPurgeTestDB(ctx context.Context, t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = defaultTestDatabaseURL
+	}
+
+	t.Setenv("API_KEY", testAPIKey)
+	t.Setenv("DATABASE_URL", databaseURL)
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	t.Cleanup(db.Close)
+
+	return db
+}
+
+// newPurgeService builds the worker-side purge service (no inserter: this exercises the execution
+// half, which is what actually touches the database).
+func newPurgeService(t *testing.T, db *pgxpool.Pool) *service.FeedbackRecordsPurgeService {
+	t.Helper()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	return service.NewFeedbackRecordsPurgeService(
+		repository.NewTenantDataRepository(db, cfg.TenantData.PurgeLockTimeout.Duration()), nil,
+	)
+}
+
+func countRows(ctx context.Context, t *testing.T, db *pgxpool.Pool, query string, args ...any) int {
+	t.Helper()
+
+	var count int
+
+	require.NoError(t, db.QueryRow(ctx, query, args...).Scan(&count))
+
+	return count
+}
+
+// seedPurgeEmbedding attaches an embedding to a record so the cascade is observable.
+func seedPurgeEmbedding(ctx context.Context, t *testing.T, db *pgxpool.Pool, recordID uuid.UUID) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, `
+		INSERT INTO embeddings (feedback_record_id, model, embedding)
+		VALUES ($1, 'test-model', array_fill(0.1::real, ARRAY[768])::halfvec)`, recordID)
+	require.NoError(t, err)
+}
+
+// TestPurgeFeedbackRecordsByTenant is the test that justifies this endpoint existing separately from
+// the tenant offboarding purge: the records go, and the taxonomy structure, webhooks and settings
+// stay. If the survival half ever regresses, a purged dataset silently loses its topic tree.
+func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
+	ctx := context.Background()
+	db := newPurgeTestDB(ctx, t)
+	purge := newPurgeService(t, db)
+
+	tenantID := "purge-tenant-" + uuid.NewString()
+	otherTenantID := "purge-other-" + uuid.NewString()
+
+	scope := models.TaxonomyScope{
+		TenantID:   tenantID,
+		SourceType: "formbricks",
+		SourceID:   "survey-1",
+		FieldID:    "field-1",
+	}
+	ids := seedTaxonomyGraph(ctx, t, db, scope)
+	seedPurgeEmbedding(ctx, t, db, ids.FeedbackRecordID)
+
+	// A second tenant with its own graph, to prove the purge does not reach across the boundary.
+	otherScope := models.TaxonomyScope{
+		TenantID:   otherTenantID,
+		SourceType: "formbricks",
+		SourceID:   "survey-1",
+		FieldID:    "field-1",
+	}
+	otherIDs := seedTaxonomyGraph(ctx, t, db, otherScope)
+	seedPurgeEmbedding(ctx, t, db, otherIDs.FeedbackRecordID)
+
+	// Tenant configuration that must outlive the purge.
+	_, err := db.Exec(ctx, `
+		INSERT INTO webhooks (tenant_id, url, signing_key, event_types)
+		VALUES ($1, 'https://example.test/hook', 'test-signing-key', ARRAY['feedback_record.created'])`, tenantID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO tenant_settings (tenant_id, settings)
+		VALUES ($1, '{"target_language":"en-US"}'::jsonb)`, tenantID)
+	require.NoError(t, err)
+
+	counts, err := purge.Purge(ctx, tenantID)
+	require.NoError(t, err)
+
+	t.Run("reports exact counts for the records and their derived rows", func(t *testing.T) {
+		assert.Equal(t, int64(1), counts.DeletedFeedbackRecords)
+		assert.Equal(t, int64(1), counts.DeletedEmbeddings)
+		assert.Equal(t, int64(1), counts.DeletedTaxonomyClusterMemberships)
+	})
+
+	t.Run("removes the records and everything derived from them", func(t *testing.T) {
+		assert.Zero(t, countRows(ctx, t, db,
+			`SELECT count(*) FROM feedback_records WHERE tenant_id = $1`, tenantID))
+		assert.Zero(t, countRows(ctx, t, db,
+			`SELECT count(*) FROM embeddings WHERE feedback_record_id = $1`, ids.FeedbackRecordID))
+		assert.Zero(t, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, tenantID))
+	})
+
+	// The reason this endpoint exists. The clusters keep existing with no members; per-node counts
+	// are derived from memberships at read time, so they report zero without being rewritten.
+	t.Run("keeps the taxonomy structure, webhooks and settings", func(t *testing.T) {
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_runs WHERE id = $1`, ids.RunID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_clusters WHERE id = $1`, ids.ClusterID))
+		assert.Equal(t, 3, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_nodes WHERE run_id = $1`, ids.RunID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_active_runs WHERE tenant_id = $1`, tenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_node_events WHERE tenant_id = $1`, tenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM webhooks WHERE tenant_id = $1`, tenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM tenant_settings WHERE tenant_id = $1`, tenantID))
+	})
+
+	t.Run("leaves other tenants untouched", func(t *testing.T) {
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM feedback_records WHERE tenant_id = $1`, otherTenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM embeddings WHERE feedback_record_id = $1`, otherIDs.FeedbackRecordID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, otherTenantID))
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		repeat, err := purge.Purge(ctx, tenantID)
+		require.NoError(t, err)
+
+		assert.Zero(t, repeat.DeletedFeedbackRecords)
+		assert.Zero(t, repeat.DeletedEmbeddings)
+		assert.Zero(t, repeat.DeletedTaxonomyClusterMemberships)
+	})
+}
+
+// postPurge sends an authenticated purge request and returns the response, with the body already
+// read into a buffer so callers need not manage closing it.
+func postPurge(ctx context.Context, t *testing.T, url string, payload map[string]any) (int, []byte) {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, responseBody
+}
+
+// countPurgeJobs returns how many purge jobs are queued for a tenant.
+func countPurgeJobs(ctx context.Context, t *testing.T, db *pgxpool.Pool, tenantID string) int {
+	t.Helper()
+
+	return countRows(ctx, t, db, `
+		SELECT count(*) FROM river_job
+		WHERE kind = 'feedback_records_purge' AND args->>'tenant_id' = $1`, tenantID)
+}
+
+// TestPurgeFeedbackRecordsEndpoint covers the half the DB tests cannot: that the HTTP endpoint
+// actually schedules a real, correctly-shaped job. A 202 with nothing on the queue would look like
+// success to every caller while deleting nothing, forever.
+func TestPurgeFeedbackRecordsEndpoint(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	db := newPurgeTestDB(ctx, t)
+	tenantID := "purge-endpoint-" + uuid.NewString()
+
+	purgeURL := server.URL + "/v1/feedback-records/purge"
+
+	status, body := postPurge(ctx, t, purgeURL, map[string]any{"tenant_id": tenantID})
+	require.Equal(t, http.StatusAccepted, status, "body: %s", body)
+
+	var accepted models.FeedbackRecordsPurgeAcceptedResponse
+	require.NoError(t, json.Unmarshal(body, &accepted))
+	assert.Equal(t, tenantID, accepted.TenantID)
+	assert.Equal(t, models.FeedbackRecordsPurgeStatusAccepted, accepted.Status)
+
+	t.Run("enqueues exactly one job on the purge queue with the tenant in its args", func(t *testing.T) {
+		var queue string
+
+		require.NoError(t, db.QueryRow(ctx, `
+			SELECT coalesce(min(queue), '')
+			FROM river_job
+			WHERE kind = 'feedback_records_purge' AND args->>'tenant_id' = $1`, tenantID,
+		).Scan(&queue))
+
+		assert.Equal(t, 1, countPurgeJobs(ctx, t, db, tenantID))
+		assert.Equal(t, service.FeedbackRecordsPurgeQueueName, queue)
+	})
+
+	// Requesting a purge while one is pending must join it rather than queueing a second, so a
+	// double-click cannot stack purges.
+	t.Run("a repeat request collapses into the pending purge", func(t *testing.T) {
+		repeatStatus, _ := postPurge(ctx, t, purgeURL, map[string]any{"tenant_id": tenantID})
+		require.Equal(t, http.StatusAccepted, repeatStatus)
+
+		assert.Equal(t, 1, countPurgeJobs(ctx, t, db, tenantID),
+			"a second request must not queue a second purge")
+	})
+
+	t.Run("rejects a request without a tenant", func(t *testing.T) {
+		noTenantStatus, _ := postPurge(ctx, t, purgeURL, map[string]any{})
+		assert.Equal(t, http.StatusBadRequest, noTenantStatus)
+		assert.Zero(t, countPurgeJobs(ctx, t, db, ""))
+	})
+}
+
+// A purge for a tenant that has never held records must succeed with zero counts rather than error,
+// so a caller retrying (or purging an already-empty dataset) gets a clean result.
+func TestPurgeFeedbackRecordsByTenantUnknownTenant(t *testing.T) {
+	ctx := context.Background()
+	db := newPurgeTestDB(ctx, t)
+
+	counts, err := newPurgeService(t, db).Purge(ctx, "purge-unknown-"+uuid.NewString())
+	require.NoError(t, err)
+
+	assert.Zero(t, counts.DeletedFeedbackRecords)
+	assert.Zero(t, counts.DeletedEmbeddings)
+	assert.Zero(t, counts.DeletedTaxonomyClusterMemberships)
+}

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -126,8 +126,10 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 		assert.Equal(t, int64(1), counts.DeletedEmbeddings)
 		assert.Equal(t, int64(1), counts.ClusterMemberships)
 		assert.Equal(t, int64(1), counts.Runs)
+		assert.Equal(t, int64(1), counts.Clusters)
 		assert.Equal(t, int64(3), counts.Nodes)
 		assert.Equal(t, int64(1), counts.ActiveRuns)
+		assert.Equal(t, int64(1), counts.NodeEvents)
 	})
 
 	t.Run("removes the records and everything derived from them", func(t *testing.T) {
@@ -308,4 +310,30 @@ func TestPurgeFeedbackRecordsByTenantUnknownTenant(t *testing.T) {
 	assert.Zero(t, counts.DeletedFeedbackRecords)
 	assert.Zero(t, counts.DeletedEmbeddings)
 	assert.Zero(t, counts.ClusterMemberships)
+}
+
+// TestPurgeFeedbackRecordsMultipleBatches exercises the batch loop against a real database: the
+// unit tests drive it through a fake that hands back the same transaction every time, so the loop,
+// its per-batch commits and the high-water mark are only meaningfully covered here.
+func TestPurgeFeedbackRecordsMultipleBatches(t *testing.T) {
+	ctx := context.Background()
+	db := newPurgeTestDB(ctx, t)
+
+	tenantID := "purge-batches-" + uuid.NewString()
+
+	// More than two batches at a batch size of 2000.
+	const seeded = 4500
+
+	_, err := db.Exec(ctx, `
+		INSERT INTO feedback_records (source_type, field_id, field_label, field_type, value_text, tenant_id, submission_id)
+		SELECT 'formbricks', 'f1', 'Feedback', 'text'::field_type_enum, 'r ' || g, $1, 's-' || g
+		FROM generate_series(1, $2) g`, tenantID, seeded)
+	require.NoError(t, err)
+
+	counts, err := newPurgeService(t, db).Purge(ctx, tenantID)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(seeded), counts.DeletedFeedbackRecords)
+	assert.Zero(t, countRows(ctx, t, db,
+		`SELECT count(*) FROM feedback_records WHERE tenant_id = $1`, tenantID))
 }

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -174,19 +173,15 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 	})
 }
 
-// postPurge sends an authenticated purge request and returns the response, with the body already
-// read into a buffer so callers need not manage closing it.
-func postPurge(ctx context.Context, t *testing.T, url string, payload map[string]any) (int, []byte) {
+// postPurge sends an authenticated purge request (DELETE, tenant in the path) and returns the
+// status and body, already read so callers need not manage closing it.
+func postPurge(ctx context.Context, t *testing.T, url string) (int, []byte) {
 	t.Helper()
 
-	body, err := json.Marshal(payload)
-	require.NoError(t, err)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, http.NoBody)
 	require.NoError(t, err)
 
 	req.Header.Set("Authorization", "Bearer "+testAPIKey)
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := (&http.Client{}).Do(req)
 	require.NoError(t, err)
@@ -219,9 +214,9 @@ func TestPurgeFeedbackRecordsEndpoint(t *testing.T) {
 	db := newPurgeTestDB(ctx, t)
 	tenantID := "purge-endpoint-" + uuid.NewString()
 
-	purgeURL := server.URL + "/v1/feedback-records/purge"
+	purgeURL := server.URL + "/v1/tenants/" + tenantID + "/feedback-records"
 
-	status, body := postPurge(ctx, t, purgeURL, map[string]any{"tenant_id": tenantID})
+	status, body := postPurge(ctx, t, purgeURL)
 	require.Equal(t, http.StatusAccepted, status, "body: %s", body)
 
 	var accepted models.FeedbackRecordsPurgeAcceptedResponse
@@ -245,17 +240,41 @@ func TestPurgeFeedbackRecordsEndpoint(t *testing.T) {
 	// Requesting a purge while one is pending must join it rather than queueing a second, so a
 	// double-click cannot stack purges.
 	t.Run("a repeat request collapses into the pending purge", func(t *testing.T) {
-		repeatStatus, _ := postPurge(ctx, t, purgeURL, map[string]any{"tenant_id": tenantID})
+		repeatStatus, _ := postPurge(ctx, t, purgeURL)
 		require.Equal(t, http.StatusAccepted, repeatStatus)
 
 		assert.Equal(t, 1, countPurgeJobs(ctx, t, db, tenantID),
 			"a second request must not queue a second purge")
 	})
 
-	t.Run("rejects a request without a tenant", func(t *testing.T) {
-		noTenantStatus, _ := postPurge(ctx, t, purgeURL, map[string]any{})
-		assert.Equal(t, http.StatusBadRequest, noTenantStatus)
-		assert.Zero(t, countPurgeJobs(ctx, t, db, ""))
+	// The regression test for the shipped bug: with River's DEFAULT unique states a completed purge
+	// blocked every later one — the API kept returning 202 while no job was ever created, for as
+	// long as the completed row was retained. Only a real River insert can catch this; the unit test
+	// can pin the option but not the semantics.
+	t.Run("a purge requested after the previous one completed runs again", func(t *testing.T) {
+		_, err := db.Exec(ctx, `
+			UPDATE river_job SET state = 'completed', finalized_at = now()
+			WHERE kind = 'feedback_records_purge' AND args->>'tenant_id' = $1`, tenantID)
+		require.NoError(t, err)
+
+		againStatus, _ := postPurge(ctx, t, purgeURL)
+		require.Equal(t, http.StatusAccepted, againStatus)
+
+		runnable := countRows(ctx, t, db, `
+			SELECT count(*) FROM river_job
+			WHERE kind = 'feedback_records_purge' AND args->>'tenant_id' = $1
+				AND state NOT IN ('completed', 'cancelled', 'discarded')`, tenantID)
+
+		assert.Equal(t, 1, runnable,
+			"a completed purge must not block the next one — the tenant would be unpurgeable")
+	})
+
+	// A blank tenant segment must be rejected, not treated as "every tenant". The routing makes an
+	// omitted tenant impossible, so this is the only shape left to guard.
+	t.Run("rejects a blank tenant", func(t *testing.T) {
+		blankStatus, _ := postPurge(ctx, t, server.URL+"/v1/tenants/%20/feedback-records")
+		assert.Equal(t, http.StatusBadRequest, blankStatus)
+		assert.Zero(t, countPurgeJobs(ctx, t, db, " "))
 	})
 }
 

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -234,6 +234,11 @@ func TestPurgeFeedbackRecordsEndpoint(t *testing.T) {
 	db := newPurgeTestDB(ctx, t)
 	tenantID := "purge-endpoint-" + uuid.NewString()
 
+	// This test enqueues REAL purge jobs, and newPurgeTestDB uses the shared integration database
+	// rather than an ephemeral one. Without this the jobs outlive the run in `available` state, and
+	// the next worker pointed at that database executes them.
+	deletePurgeJobs(ctx, t, db, tenantID)
+
 	purgeURL := server.URL + "/v1/tenants/" + tenantID + "/feedback-records"
 
 	status, body := postPurge(ctx, t, purgeURL)
@@ -336,4 +341,19 @@ func TestPurgeFeedbackRecordsMultipleBatches(t *testing.T) {
 	assert.Equal(t, int64(seeded), counts.DeletedFeedbackRecords)
 	assert.Zero(t, countRows(ctx, t, db,
 		`SELECT count(*) FROM feedback_records WHERE tenant_id = $1`, tenantID))
+}
+
+// deletePurgeJobs registers cleanup that removes every purge job this test enqueued for a tenant.
+// Registered before the jobs are created so it still runs if an assertion fails partway.
+func deletePurgeJobs(ctx context.Context, t *testing.T, db *pgxpool.Pool, tenantID string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		if _, err := db.Exec(ctx, `
+			DELETE FROM river_job
+			WHERE kind = 'feedback_records_purge' AND args->>'tenant_id' = $1`, tenantID,
+		); err != nil {
+			t.Errorf("cleanup purge jobs for %s: %v", tenantID, err)
+		}
+	})
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -144,7 +144,7 @@ func setupTestServerWithEventProviders(
 	protectedMux.HandleFunc("PATCH /v1/feedback-records/{id}", feedbackRecordsHandler.Update)
 	protectedMux.HandleFunc("DELETE /v1/feedback-records/{id}", feedbackRecordsHandler.Delete)
 	protectedMux.HandleFunc("DELETE /v1/feedback-records", feedbackRecordsHandler.DeleteByUser)
-	protectedMux.HandleFunc("POST /v1/feedback-records/purge", feedbackRecordsPurgeHandler.Purge)
+	protectedMux.HandleFunc("DELETE /v1/tenants/{tenant_id}/feedback-records", feedbackRecordsPurgeHandler.Purge)
 	protectedMux.HandleFunc("POST /v1/webhooks", webhooksHandler.Create)
 	protectedMux.HandleFunc("GET /v1/webhooks", webhooksHandler.List)
 	protectedMux.HandleFunc("GET /v1/webhooks/{id}", webhooksHandler.Get)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -112,6 +114,16 @@ func setupTestServerWithEventProviders(
 	feedbackRecordsHandler := handlers.NewFeedbackRecordsHandler(feedbackRecordsService)
 	tenantDataService := service.NewTenantDataService(tenantDataRepo)
 	tenantDataHandler := handlers.NewTenantDataHandler(tenantDataService)
+
+	// Insert-only River client, matching the API process: the purge endpoint enqueues a job and
+	// hub-worker performs it, so the test server needs somewhere real for that job to land.
+	riverClient, err := river.NewClient(riverpgxv5.New(db), &river.Config{})
+	require.NoError(t, err, "Failed to create River client")
+
+	feedbackRecordsPurgeHandler := handlers.NewFeedbackRecordsPurgeHandler(
+		service.NewFeedbackRecordsPurgeService(tenantDataRepo, riverClient),
+	)
+
 	tenantSettingsRepo := repository.NewTenantSettingsRepository(db)
 	tenantSettingsService := service.NewTenantSettingsService(tenantSettingsRepo)
 	tenantSettingsHandler := handlers.NewTenantSettingsHandler(tenantSettingsService)
@@ -132,6 +144,7 @@ func setupTestServerWithEventProviders(
 	protectedMux.HandleFunc("PATCH /v1/feedback-records/{id}", feedbackRecordsHandler.Update)
 	protectedMux.HandleFunc("DELETE /v1/feedback-records/{id}", feedbackRecordsHandler.Delete)
 	protectedMux.HandleFunc("DELETE /v1/feedback-records", feedbackRecordsHandler.DeleteByUser)
+	protectedMux.HandleFunc("POST /v1/feedback-records/purge", feedbackRecordsPurgeHandler.Purge)
 	protectedMux.HandleFunc("POST /v1/webhooks", webhooksHandler.Create)
 	protectedMux.HandleFunc("GET /v1/webhooks", webhooksHandler.List)
 	protectedMux.HandleFunc("GET /v1/webhooks/{id}", webhooksHandler.Get)


### PR DESCRIPTION
## What does this PR do?

Adds `DELETE /v1/tenants/{tenant_id}/feedback-records`, which deletes every feedback record for a tenant, everything derived from those records, **and the taxonomy built on them** — while leaving the tenant's **configuration (webhooks and settings) intact**.

This is for [ENG-2129](https://linear.app/formbricks/issue/ENG-2129/purge-feedback-dataset-functionality) — letting an operator empty a feedback dataset from the Formbricks dashboard while continuing to use it. The existing `DELETE /v1/tenants/{tenant_id}/data` is an *offboarding* primitive: it also destroys the tenant's webhooks and `tenant_settings`, which is the wrong blast radius for "clear this dataset and keep using it", and it is synchronous. The Formbricks-side API and UI land separately.

Three design calls worth reviewing:

**Its own path, not a filter on the collection DELETE.** The obvious shape would be `DELETE /v1/feedback-records?tenant_id=…`, making the existing `user_id` optional. That endpoint erases one data subject's records (GDPR) and is reachable through the Formbricks Envoy gateway as the `bulkDelete` operation requiring only `write` — and for API keys it is deliberately not owner/manager-gated. Relaxing `user_id` there would hand any write key a one-request wipe of a shared dataset, and would turn a dropped or empty `user_id` in any existing caller into a full-dataset deletion. A distinct path cannot be reached by omitting a parameter, and the gateway is an allowlist so it stays closed by default. This also follows `AGENTS.md`: *"Do not model `tenant_id` as an optional filter for tenant-owned resources."*

**Asynchronous, 202 + a River job.** `feedback_records` has no per-tenant cap, and the API server's `writeTimeout` is a hardcoded 15s (`cmd/api/app.go`), so a synchronous purge cannot return a response for a large tenant — Postgres would keep deleting while the client saw a dropped connection. The job is unique by tenant across River's in-flight states (`ByArgs`, **no** `ByPeriod` — that would let the un-narrowable `completed` state swallow a legitimate later purge, the trap already documented on the enrichment event path). So concurrent requests collapse into one run, while a purge requested after an earlier one finished starts a new run. There is no deleted count in the response, because the work has been accepted rather than done; callers poll `GET /v1/feedback-records/count`.

**The taxonomy goes with the records; the configuration stays.** That line is what justifies this endpoint existing beside `DELETE /v1/tenants/{tenant_id}/data` rather than reusing it. Keeping the taxonomy was the original design and was wrong: it describes records that no longer exist, so every per-node count reads zero while the run header keeps advertising its original `record_count` — a *required* response field, so the API would be obliged to return a number it knows is false. The dashboard also gates the Topics view at 750 records, so a preserved tree is not merely stale but unreachable, resurfacing over unrelated data only once the dataset refills. And the manual renames/removals that preservation would protect are run-scoped, with no carry-forward into a regenerated run.

What it must *not* take is configuration. The offboarding purge additionally drops webhooks — integrator-configured directly against the Hub, including a `signing_key` reads never return — and `tenant_settings`, whose enrichment opt-outs silently revert to *enabled* once the row is gone, so a tenant that had switched sentiment off starts being enriched again. Neither is recoverable from the dashboard.

Exclusion flags (`keep_webhooks=true` and friends) were considered and rejected: they make the destructive behaviour the default, since omitting a parameter would delete more. The safe polarity breaks the org-delete cascade, which needs the full wipe.

Embeddings and memberships are deleted explicitly rather than by cascade so the counts are exact; the five taxonomy DELETEs and their ordering constraint now live in one helper shared with the offboarding purge.

The transaction handling is now shared with the full tenant purge via `withTenantPurgeTx`, so the two cannot drift on locking, rollback or commit.

### Request / response

```
POST /v1/feedback-records/purge
{ "tenant_id": "org-123" }

202 Accepted
{
  "tenant_id": "org-123",
  "status": "accepted",
  "message": "Feedback records purge accepted for org-123"
}
```

No `409` is documented: accepting a purge takes no tenant lock (the worker takes it exclusively), so this endpoint cannot return one. Documenting it would be a contract we never honour.

## How should this be tested?

Against a pgvector Postgres with migrations applied and River migrated (`make init-db && make river-migrate`); `DATABASE_URL` pointing at `test_db`.

- `make build && make fmt && make lint && make lint-openapi && make test-unit && make tests`
- **End to end with a real worker** — this is the part unit tests can't reach. Run `hub-api` and `hub-worker`, then:
  ```bash
  # seed a tenant with records, then:
  curl -H "Authorization: Bearer $API_KEY" "$HUB/v1/feedback-records/count?tenant_id=demo"   # {"count":25}
  curl -X POST -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json' \
       -d '{"tenant_id":"demo"}' "$HUB/v1/feedback-records/purge"                            # 202 accepted
  curl -H "Authorization: Bearer $API_KEY" "$HUB/v1/feedback-records/count?tenant_id=demo"   # {"count":0}
  ```
  I ran exactly this: 25 records went to 0, the worker logged `feedback records purge: complete deleted_feedback_records=25`, and the tenant's webhook and `tenant_settings` rows both survived.
- **Confirm no new destructive capability**: `DELETE /v1/feedback-records?tenant_id=…` without `user_id` still returns 400, the purge without a tenant returns 400, and the purge unauthenticated returns 401.

Automated coverage worth looking at:

- `tests/feedback_records_purge_test.go` — against a real database: records/embeddings/memberships go, taxonomy runs/clusters/nodes + webhooks + `tenant_settings` survive, other tenants untouched, repeat purge reports zero. Against a real River queue: the endpoint enqueues exactly one correctly-shaped job, and a repeat request collapses into the pending one (a 202 with nothing queued would look like success while deleting nothing).
- `internal/repository/feedback_records_purge_repository_test.go` — asserts the purge never deletes from the taxonomy structure, webhooks or `tenant_settings`, and that every statement is tenant-scoped.
- `internal/service/feedback_records_purge_service_test.go` — pins `UniqueOpts` to `ByArgs` with no `ByPeriod`. I fault-injected a `ByPeriod` to confirm that test actually fails.

Note `setupTestServer` needs its own route registration and now its own River client, since the integration harness builds its mux separately from `cmd/api`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` — no schema change; ran `make migrate-validate` anyway and it passes

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make lint-openapi`, `make tests`)
- [x] If API behavior changed: added request/response examples to this PR
- [ ] Updated docs in `docs/` if changes were necessary — the OpenAPI description carries the behaviour; happy to add prose docs if wanted
- [x] Ran `make tests-coverage` for meaningful logic changes

