### PR TITLE
feat: add as_of and disabled_reason to the enrichment status endpoint (ENG-2375)

### DIFF
--- a/internal/api/handlers/enrichment_status_handler_test.go
+++ b/internal/api/handlers/enrichment_status_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,9 +50,12 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 	t.Run("returns 200 with the status body", func(t *testing.T) {
 		want := &models.EnrichmentStatusResponse{
 			TenantID:    "t1",
+			AsOf:        time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
 			Translation: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
 			Sentiment:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 8},
-			Emotions:    models.EnrichmentTypeStatus{Enabled: false},
+			Emotions: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 		}
 		h := NewEnrichmentStatusHandler(&fakeEnrichmentStatusService{resp: want})
 		rec := httptest.NewRecorder()
@@ -62,5 +66,63 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 		var got models.EnrichmentStatusResponse
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 		assert.Equal(t, *want, got)
+	})
+
+	// Asserts the JSON the client actually receives, by field name, rather than round-tripping
+	// through models.EnrichmentStatusResponse. That round trip is symmetric with the marshal that
+	// produced it, so it cannot observe the wire format at all: it passes unchanged if a field is
+	// renamed, dropped, or emitted with the wrong presence semantics. The published OpenAPI schema
+	// is a promise about these bytes, and Stainless generates the SDK from it, so something has to
+	// check them.
+	t.Run("wire format matches the published schema", func(t *testing.T) {
+		resp := &models.EnrichmentStatusResponse{
+			TenantID:    "t1",
+			AsOf:        time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+			Translation: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			Sentiment: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
+			Emotions: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
+		}
+		h := NewEnrichmentStatusHandler(&fakeEnrichmentStatusService{resp: resp})
+		rec := httptest.NewRecorder()
+		h.GetStatus(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/enrichment-status?tenant_id=t1", nil))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+		assert.Equal(t, "t1", body["tenant_id"])
+		// RFC 3339 in UTC, matching `format: date-time` in the schema. Parsing it back is what
+		// proves the client can, which is the whole reason the field exists.
+		asOf, parseErr := time.Parse(time.RFC3339Nano, body["as_of"].(string))
+		require.NoError(t, parseErr, "as_of must be RFC 3339")
+		assert.True(t, asOf.Equal(resp.AsOf), "as_of survives serialization unchanged")
+
+		// An ENABLED enrichment must omit disabled_reason entirely. Emitting it as "" would be the
+		// natural result of dropping `omitempty`, and "" is not one of the three values the schema's
+		// enum allows — a strict client would reject the whole response.
+		translation, ok := body["translation"].(map[string]any)
+		require.True(t, ok, "translation is an object")
+
+		_, present := translation["disabled_reason"]
+		assert.False(t, present, "enabled enrichment must omit disabled_reason, not send an empty one")
+
+		// A DISABLED enrichment must carry its reason, and it must be one of the enum values.
+		allowed := map[string]bool{"not_configured": true, "switched_off": true, "no_target_language": true}
+		wantReasons := map[string]string{"sentiment": "switched_off", "emotions": "not_configured"}
+
+		for name, wantReason := range wantReasons {
+			enrichment, isObj := body[name].(map[string]any)
+			require.True(t, isObj, "%s is an object", name)
+
+			reason, hasReason := enrichment["disabled_reason"].(string)
+			require.True(t, hasReason, "%s: disabled enrichment must carry disabled_reason", name)
+			assert.True(t, allowed[reason], "%s: %q is outside the schema enum", name, reason)
+			assert.Equal(t, wantReason, reason, "%s: wrong reason on the wire", name)
+		}
 	})
 }

--- a/internal/models/enrichment_status.go
+++ b/internal/models/enrichment_status.go
@@ -1,22 +1,53 @@
 package models
 
+import "time"
+
+// DisabledReason names the gate that switched an enrichment off for a tenant. It exists because
+// `enabled: false` alone is unactionable: an operator who has not configured a provider, a tenant
+// that turned the enrichment off, and a tenant with no resolvable translation target are three
+// different problems with three different fixes, and the UI cannot tell them apart from a bool.
+//
+// The value set is closed and small so it is safe as a metric label and as a UI translation key.
+type DisabledReason string
+
+const (
+	// DisabledReasonNotConfigured means the deployment has no provider+model for this enrichment,
+	// so it is off for every tenant. Fixed by the operator, not by the tenant.
+	DisabledReasonNotConfigured DisabledReason = "not_configured"
+	// DisabledReasonSwitchedOff means the deployment is configured but this tenant has explicitly
+	// turned the enrichment off (the tri-state per-directory switch). Sentiment and emotions only.
+	DisabledReasonSwitchedOff DisabledReason = "switched_off"
+	// DisabledReasonNoTargetLanguage means translation is configured but neither the tenant's own
+	// target_language nor the deployment default resolves, so there is nothing to translate into.
+	// Translation only — it has no on/off switch, an absent target IS the off state.
+	DisabledReasonNoTargetLanguage DisabledReason = "no_target_language"
+)
+
 // EnrichmentTypeStatus is one tenant's progress for a single record-level enrichment
 // (translation, sentiment, or emotions). Enabled reports whether the enrichment is both
 // deployment-configured and switched on for the tenant (for translation: has a resolvable
 // target language). Eligible is the number of feedback records that qualify for the
 // enrichment; Done is how many have been enriched. The UI derives "in progress" as
 // Eligible - Done. When Enabled is false, Eligible and Done are zero (no work will run).
+//
+// DisabledReason is present exactly when Enabled is false, and absent otherwise — the two are
+// derived from one decision (see enrichmentTypeStatus), so they cannot contradict each other.
 type EnrichmentTypeStatus struct {
-	Enabled  bool  `json:"enabled"`
-	Eligible int64 `json:"eligible"`
-	Done     int64 `json:"done"`
+	Enabled        bool           `json:"enabled"`
+	Eligible       int64          `json:"eligible"`
+	Done           int64          `json:"done"`
+	DisabledReason DisabledReason `json:"disabled_reason,omitempty"`
 }
 
 // EnrichmentStatusResponse reports a tenant's enrichment progress across the record-level
 // enrichments. Counts are directory-level totals; the response never includes record
 // identifiers or feedback content.
 type EnrichmentStatusResponse struct {
-	TenantID    string               `json:"tenant_id"`
+	TenantID string `json:"tenant_id"`
+	// AsOf is when the counts were computed, not when the response was serialized. The endpoint is
+	// polled, so a client holding two responses can derive throughput and an ETA from the change in
+	// Done over the change in AsOf without the Hub computing either.
+	AsOf        time.Time            `json:"as_of"`
 	Translation EnrichmentTypeStatus `json:"translation"`
 	Sentiment   EnrichmentTypeStatus `json:"sentiment"`
 	Emotions    EnrichmentTypeStatus `json:"emotions"`

--- a/internal/service/enrichment_status_service.go
+++ b/internal/service/enrichment_status_service.go
@@ -79,25 +79,71 @@ func (s *EnrichmentStatusService) GetEnrichmentStatus(
 		return nil, fmt.Errorf("count enrichment status: %w", err)
 	}
 
-	translationEnabled := s.translationConfigured &&
-		resolveTargetLang(settings.Settings.TargetLanguage, s.defaultLang) != ""
+	// Stamped after the count returns, so AsOf describes when the numbers were true rather than
+	// when the response happened to be written. UTC because it crosses a process boundary.
+	asOf := time.Now().UTC()
 
 	return &models.EnrichmentStatusResponse{
 		TenantID: normalizedTenantID,
-		Translation: enrichmentTypeStatus(translationEnabled,
+		AsOf:     asOf,
+		Translation: enrichmentTypeStatus(
+			translationDisabledReason(s.translationConfigured,
+				resolveTargetLang(settings.Settings.TargetLanguage, s.defaultLang)),
 			counts.TranslationEligible, counts.TranslationDone),
-		Sentiment: enrichmentTypeStatus(s.sentimentConfigured && settings.Settings.SentimentEnrichmentEnabled(),
+		Sentiment: enrichmentTypeStatus(
+			switchedEnrichmentDisabledReason(s.sentimentConfigured,
+				settings.Settings.SentimentEnrichmentEnabled()),
 			counts.SentimentEligible, counts.SentimentDone),
-		Emotions: enrichmentTypeStatus(s.emotionsConfigured && settings.Settings.EmotionsEnrichmentEnabled(),
+		Emotions: enrichmentTypeStatus(
+			switchedEnrichmentDisabledReason(s.emotionsConfigured,
+				settings.Settings.EmotionsEnrichmentEnabled()),
 			counts.EmotionsEligible, counts.EmotionsDone),
 	}, nil
 }
 
-// enrichmentTypeStatus assembles one enrichment's status, zeroing the counts when it is not
-// enabled for the tenant so the API never reports a backlog for work that will never run.
-func enrichmentTypeStatus(enabled bool, eligible, done int64) models.EnrichmentTypeStatus {
-	if !enabled {
-		return models.EnrichmentTypeStatus{Enabled: false}
+// switchedEnrichmentDisabledReason resolves the two gates guarding sentiment and emotions:
+// the deployment provider+model gate, then the tenant's tri-state switch. An empty result means
+// the enrichment is enabled.
+//
+// The deployment gate is reported first when both are closed. It is the outer gate and the one an
+// operator can act on; telling a tenant "you switched it off" when no provider is configured at all
+// would send them to a setting that changes nothing.
+func switchedEnrichmentDisabledReason(configured, switchedOn bool) models.DisabledReason {
+	switch {
+	case !configured:
+		return models.DisabledReasonNotConfigured
+	case !switchedOn:
+		return models.DisabledReasonSwitchedOff
+	default:
+		return ""
+	}
+}
+
+// translationDisabledReason resolves translation's gates: the deployment provider+model gate, then
+// a resolvable effective target language (the tenant's own, else the deployment default). An empty
+// result means translation is enabled.
+//
+// Translation has no on/off switch, so it can never report switched_off — an unresolvable target
+// IS its off state, and that is what no_target_language says.
+func translationDisabledReason(configured bool, effectiveTarget string) models.DisabledReason {
+	switch {
+	case !configured:
+		return models.DisabledReasonNotConfigured
+	case effectiveTarget == "":
+		return models.DisabledReasonNoTargetLanguage
+	default:
+		return ""
+	}
+}
+
+// enrichmentTypeStatus assembles one enrichment's status from the gate decision, zeroing the counts
+// when it is not enabled so the API never reports a backlog for work that will never run.
+//
+// Enabled and DisabledReason are derived from the same value here rather than passed separately, so
+// the response cannot carry an enabled enrichment with a reason, or a disabled one without.
+func enrichmentTypeStatus(reason models.DisabledReason, eligible, done int64) models.EnrichmentTypeStatus {
+	if reason != "" {
+		return models.EnrichmentTypeStatus{Enabled: false, DisabledReason: reason}
 	}
 
 	return models.EnrichmentTypeStatus{Enabled: true, Eligible: eligible, Done: done}

--- a/internal/service/enrichment_status_service_test.go
+++ b/internal/service/enrichment_status_service_test.go
@@ -179,7 +179,6 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 
 			svc := NewEnrichmentStatusService(params)
 
-			before := time.Now().UTC()
 			got, err := svc.GetEnrichmentStatus(context.Background(), "  tenant-1 ")
 			require.NoError(t, err)
 
@@ -189,11 +188,15 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			assert.Equal(t, testCase.wantSent, got.Sentiment)
 			assert.Equal(t, testCase.wantEmotion, got.Emotions)
 
-			// AsOf must be a real stamp taken during the call, not a zero value the JSON encoder
-			// would happily render as year 1 — a client differencing two of those gets nonsense.
+			// AsOf must be a real stamp, not the zero value the JSON encoder would happily render as
+			// year 1 — a client differencing two of those gets nonsense.
+			//
+			// Bounded generously rather than pinned between two time.Now() reads taken around the
+			// call: .UTC() strips the monotonic clock reading, so tight bounds are pure wall-clock
+			// and an NTP step backwards mid-test would fail them with no defect in the code. An hour
+			// still catches a zero value or a wrong clock source, and cannot flake.
 			assert.False(t, got.AsOf.IsZero(), "as_of is stamped")
-			assert.False(t, got.AsOf.Before(before), "as_of is taken during the call")
-			assert.False(t, got.AsOf.After(time.Now().UTC()), "as_of is not in the future")
+			assert.WithinDuration(t, time.Now().UTC(), got.AsOf, time.Hour, "as_of is a current stamp")
 			assert.Equal(t, time.UTC, got.AsOf.Location(), "as_of is UTC")
 
 			// enabled and disabled_reason are derived from one decision, so they can never disagree.

--- a/internal/service/enrichment_status_service_test.go
+++ b/internal/service/enrichment_status_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,7 @@ var fullCounts = repository.EnrichmentStatusCounts{
 
 func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 	emotionsOff := false
+	sentimentOff := false
 
 	cases := []struct {
 		name        string
@@ -79,9 +81,11 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			params: NewEnrichmentStatusServiceParams{
 				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: false, EmotionsConfigured: true,
 			},
-			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: false},
+			settings:  &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
 		},
 		{
@@ -92,18 +96,66 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
 				TargetLanguage: "de-DE", EmotionsEnabled: &emotionsOff,
 			}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: false},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent:  models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
 		},
 		{
 			name: "translation with no target and no default is zeroed",
 			params: NewEnrichmentStatusServiceParams{
 				DefaultLang: "", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
 			},
-			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: false},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{}},
+			wantTrans: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNoTargetLanguage,
+			},
 			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			// Translation has a perfectly good target, so only the deployment gate can be the
+			// reason — proves the target check does not shadow it.
+			name: "translation not deployment-configured reports not_configured, not no_target_language",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: false, SentimentConfigured: true, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
+			wantTrans: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			name: "tenant sentiment switch off is reported as switched_off",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
+				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
+			}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			// Both gates closed at once. The deployment gate must win: sending a tenant to a switch
+			// that changes nothing (because no provider is configured at all) is the wrong fix.
+			name: "both gates closed reports the deployment gate, not the tenant switch",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: false, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
+				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
+			}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
 		},
 		{
@@ -127,6 +179,7 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 
 			svc := NewEnrichmentStatusService(params)
 
+			before := time.Now().UTC()
 			got, err := svc.GetEnrichmentStatus(context.Background(), "  tenant-1 ")
 			require.NoError(t, err)
 
@@ -135,6 +188,24 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			assert.Equal(t, testCase.wantTrans, got.Translation)
 			assert.Equal(t, testCase.wantSent, got.Sentiment)
 			assert.Equal(t, testCase.wantEmotion, got.Emotions)
+
+			// AsOf must be a real stamp taken during the call, not a zero value the JSON encoder
+			// would happily render as year 1 — a client differencing two of those gets nonsense.
+			assert.False(t, got.AsOf.IsZero(), "as_of is stamped")
+			assert.False(t, got.AsOf.Before(before), "as_of is taken during the call")
+			assert.False(t, got.AsOf.After(time.Now().UTC()), "as_of is not in the future")
+			assert.Equal(t, time.UTC, got.AsOf.Location(), "as_of is UTC")
+
+			// enabled and disabled_reason are derived from one decision, so they can never disagree.
+			for name, status := range map[string]models.EnrichmentTypeStatus{
+				"translation": got.Translation, "sentiment": got.Sentiment, "emotions": got.Emotions,
+			} {
+				if status.Enabled {
+					assert.Empty(t, status.DisabledReason, "%s: enabled must carry no reason", name)
+				} else {
+					assert.NotEmpty(t, status.DisabledReason, "%s: disabled must carry a reason", name)
+				}
+			}
 		})
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1505,7 +1505,10 @@ paths:
                 is active for the tenant (deployment-configured and switched on / with a resolvable
                 target language), and `eligible`/`done` are directory-level counts of feedback records
                 that qualify and that have been enriched — the UI derives "in progress" as
-                `eligible - done`. When an enrichment is not enabled its counts are zero. The response
+                `eligible - done`. When an enrichment is not enabled its counts are zero and
+                `disabled_reason` names the gate that closed it, so the UI can explain *why* rather than
+                silently hiding the enrichment. `as_of` is when the counts were computed, which lets a
+                polling client derive throughput and an ETA without the Hub computing either. The response
                 contains counts only (no record identifiers or content).
             operationId: get-enrichment-status
             parameters:
@@ -3816,6 +3819,20 @@ components:
                     type: integer
                     format: int64
                     description: Eligible records that have been enriched.
+                disabled_reason:
+                    type: string
+                    enum:
+                        - not_configured
+                        - switched_off
+                        - no_target_language
+                    description: |
+                        Which gate switched the enrichment off. Present exactly when `enabled` is false, and
+                        absent otherwise. `not_configured` — the deployment has no provider/model for this
+                        enrichment, so it is off for every tenant and only an operator can fix it.
+                        `switched_off` — the tenant turned it off (sentiment and emotions only).
+                        `no_target_language` — translation is configured but neither the tenant's
+                        `target_language` nor the deployment default resolves (translation only; it has no
+                        on/off switch, so an absent target is its off state).
             required:
                 - enabled
                 - eligible
@@ -3827,6 +3844,14 @@ components:
             properties:
                 tenant_id:
                     type: string
+                as_of:
+                    type: string
+                    format: date-time
+                    description: |
+                        When the counts were computed (UTC), not when the response was serialized. The
+                        endpoint is polled, so two responses are enough to derive throughput and an ETA
+                        client-side from the change in `done` over the change in `as_of` — the Hub computes
+                        neither.
                 translation:
                     $ref: '#/components/schemas/EnrichmentTypeStatus'
                 sentiment:
@@ -3835,6 +3860,7 @@ components:
                     $ref: '#/components/schemas/EnrichmentTypeStatus'
             required:
                 - tenant_id
+                - as_of
                 - translation
                 - sentiment
                 - emotions


### PR DESCRIPTION
## What does this PR do?

First of several PRs on [ENG-2375](https://linear.app/formbricks/issue/ENG-2375/extend-status-endpoint-with-more-info). Adds two fields to `GET /v1/enrichment-status` that need no migration and no new query.

`enabled: false` was unactionable on its own. Three very different situations collapsed into it — the deployment has no provider configured, the tenant switched the enrichment off, or translation has no resolvable target language — each with a different fix and a different person who can apply it. The UI could only hide the enrichment rather than explain it.

- **`disabled_reason`** — `not_configured` | `switched_off` | `no_target_language`. The service already evaluated those gates separately and then collapsed them into one bool, so this is mostly a matter of not throwing the answer away. `enabled` and `disabled_reason` are derived from the same value, so a response cannot carry an enabled enrichment with a reason or a disabled one without.
- **`as_of`** — stamped when the counts are computed, not when the response is serialized. The endpoint is polled, so two responses are enough for a client to derive throughput and an ETA from the change in `done` over the change in `as_of`. Hub computes neither.

When both the deployment gate and the tenant switch are closed, the deployment gate is reported. It is the outer gate, and pointing a tenant at a switch that changes nothing while no provider exists is the wrong fix.

### Open question for the consumer — @Dhruwang

The ticket specified `disabled_reason: … | null`. This PR emits it as **absent** when an enrichment is enabled, not `null`.

I originally justified that with "the spec has no nullable fields" — **that was wrong**, and I want to correct it here rather than let it stand. `WebhookPublicData.disabled_reason` and `WebhookData.disabled_reason` both use `type: [string, "null"]`, the OpenAPI 3.1 nullable form; my earlier check grepped for the 3.0 `nullable: true` spelling and found nothing.

So the honest position is that both forms exist in this spec, your ticket asked for `null`, and the sibling field of the same name is nullable — which makes this one the odd one out. Switching costs a `*DisabledReason` and `type: [string, "null"]`, roughly six lines including the test. Happy to change it before this merges; it is much cheaper now than after later PRs build on the response shape.

Worth flagging separately: `disabled_reason` now means two unrelated things in this spec — why a *webhook* was disabled (free-form, nullable) versus which gate closed an *enrichment* (enum, optional). Stainless generates per-schema models so there is no type clash, but it is a readability trap.

### Before / after

Captured by running `origin/main` (`01f6e8b`) and this branch side by side against the **same database and the same tenant**, so only the code differs.

**State A — tenant has no target language, deployment has no default**

```jsonc
// before
{"tenant_id":"demo-t1","translation":{"enabled":false,"eligible":0,"done":0},"sentiment":{"enabled":true,"eligible":0,"done":0},"emotions":{"enabled":true,"eligible":0,"done":0}}

// after
{"tenant_id":"demo-t1","as_of":"2026-08-17T15:47:32.581756Z","translation":{"enabled":false,"eligible":0,"done":0,"disabled_reason":"no_target_language"},"sentiment":{"enabled":true,"eligible":0,"done":0},"emotions":{"enabled":true,"eligible":0,"done":0}}
```

**State B — target set to `de-DE`, tenant switched sentiment off**

```jsonc
// before
{"tenant_id":"demo-t1","translation":{"enabled":true,"eligible":0,"done":0},"sentiment":{"enabled":false,"eligible":0,"done":0},"emotions":{"enabled":true,"eligible":0,"done":0}}

// after
{"tenant_id":"demo-t1","as_of":"2026-08-17T15:47:32.635006Z","translation":{"enabled":true,"eligible":0,"done":0},"sentiment":{"enabled":false,"eligible":0,"done":0,"disabled_reason":"switched_off"},"emotions":{"enabled":true,"eligible":0,"done":0}}
```

**State C — no providers configured at all; tenant state unchanged from B**

```jsonc
// before
{"tenant_id":"demo-t1","translation":{"enabled":false,"eligible":0,"done":0},"sentiment":{"enabled":false,"eligible":0,"done":0},"emotions":{"enabled":false,"eligible":0,"done":0}}

// after
{"tenant_id":"demo-t1","as_of":"2026-08-17T15:48:11.503321Z","translation":{"enabled":false,"eligible":0,"done":0,"disabled_reason":"not_configured"},"sentiment":{"enabled":false,"eligible":0,"done":0,"disabled_reason":"not_configured"},"emotions":{"enabled":false,"eligible":0,"done":0,"disabled_reason":"not_configured"}}
```

**The whole point, in one comparison.** `sentiment` in states B and C, on `main` today:

```json
B: {"enabled": false, "eligible": 0, "done": 0}
C: {"enabled": false, "eligible": 0, "done": 0}
```

Byte-identical, and they mean different things: in B the tenant turned sentiment off and can turn it back on; in C no provider is configured and nothing the tenant does will help. After this PR they read `switched_off` and `not_configured`.

Note also that state C's tenant still has `sentiment_enabled: false` *and* a target language set, yet everything reports `not_configured` — the deployment gate winning over the tenant switch, as intended.

## How should this be tested?

Unit tests cover the gate matrix; the integration suite and a manual pass cover the wire format.

**Automated**

- `make test-unit` — the service table now pins every gate combination, including the two precedence cases (deployment gate beats the tenant switch; the target check does not shadow the deployment gate for translation).
- `make tests` — integration suite. Requires River's migrations as well as goose's, or `TestTenantTranslationBackfillWorker_Work` fails with `relation "river_job" does not exist`:

```
goose -dir migrations postgres "$DATABASE_URL" up
river migrate-up --database-url "$DATABASE_URL"
DATABASE_URL=... API_KEY=... make tests
```

**Manual — the part unit tests structurally cannot check**

The previous HTTP test unmarshalled the response back into the same Go struct and compared structs, which is symmetric with the marshal that produced it and therefore blind to the wire format. There is now a `wire format matches the published schema` test asserting the JSON by field name, and it was verified by deleting `omitempty` from `DisabledReason` — it fails on exactly that line, and passes again when restored.

To reproduce end to end:

1. Run the API with all three enrichments "configured". No real provider calls are made — the status endpoint only reads whether provider+model are set:

```
DATABASE_URL=... API_KEY=k PORT=8099 \
  SENTIMENT_PROVIDER=openai SENTIMENT_MODEL=gpt-4o-mini \
  EMOTIONS_PROVIDER=openai EMOTIONS_MODEL=gpt-4o-mini \
  TRANSLATION_PROVIDER=openai TRANSLATION_MODEL=gpt-4o-mini \
  TRANSLATION_DEFAULT_LANGUAGE="" go run ./cmd/api
```

2. `curl -H "Authorization: Bearer k" "localhost:8099/v1/enrichment-status?tenant_id=t1"` → translation `no_target_language`, others enabled with **no** `disabled_reason` key at all.
3. Set a target and switch sentiment off, then re-poll → translation enabled, sentiment `switched_off`:

```
curl -X PUT -H "Authorization: Bearer k" -H 'Content-Type: application/json' \
  -d '{"target_language":"de-DE","sentiment_enabled":false}' \
  localhost:8099/v1/tenants/t1/settings
```

4. Restart with no `*_PROVIDER` / `*_MODEL` vars → all three `not_configured`, even though the tenant state from step 3 is unchanged.

I ran 1–4 against a scratch database and additionally validated the live responses against the enum and required-list parsed out of `openapi.yaml`: required fields present, `as_of` parses as RFC 3339, no enabled enrichment carries a reason, no disabled one lacks it, nothing outside the enum, no empty strings.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch — cut from `01f6e8b`, 0 commits behind
- [x] If database schema changed: n/a, no migration in this PR

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples to this PR
- [ ] Updated docs in `docs/` if changes were necessary — n/a, this repo has no `docs/`
- [ ] Ran `make tests-coverage` for meaningful logic changes — not run; the logic here is a gate resolver fully covered by the service table
