### PR TITLE
build: move the Go toolchain to 1.26.6 (ENG-2420)

### DIFF
--- a/.github/workflows/api-contract-tests.yml
+++ b/.github/workflows/api-contract-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/migrations-validate.yml
+++ b/.github/workflows/migrations-validate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ run:
   timeout: 5m
   concurrency: 4
   modules-download-mode: readonly
-  go: "1.26.5"
+  go: "1.26.6"
   # Allow linting test files but suppress specific strict rules via exclusion below
   tests: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Build
 # =============================================================================
 # TARGETOS/TARGETARCH are set by Docker Buildx for multi-platform builds (e.g. linux/arm64 on Mac M1).
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG GOOSE_VERSION=v3.27.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/formbricks/hub
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-playground/form/v4 v4.3.0


### PR DESCRIPTION
## What does this PR do?

Moves the Go toolchain from 1.26.5 to 1.26.6, which clears the `govulncheck` failure currently blocking **Code Quality Checks**.

[ENG-2420](https://linear.app/formbricks/issue/ENG-2420/hub-bump-the-go-toolchain-to-1266-govulncheck-blocks-every-go-pr)

`govulncheck` reports 7 Go standard-library advisories at 1.26.5, every one of them `Fixed in: go1.26.6`:

| ID | Package |
| -- | -- |
| GO-2026-6218 | `net/url` |
| GO-2026-6091 | `html/template` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | `encoding/asn1` |
| GO-2026-5026 | `net/http` |

### Why this is its own PR

These are stdlib advisories — they arrived by the calendar, not by a commit, so no PR introduced them. And `code-quality.yml` triggers on `pull_request` only, never on pushes to `main`, so nothing re-evaluates `main` and the failure surfaces on whichever PR runs CI next.

**#122 currently reads green, but that green is stale** — its Code Quality run is from 2026-08-13, before these entries existed in the vulnerability database. It is ready for review and closest to merging, and it goes red the moment anyone pushes to it or re-runs CI.

I hit this on the ENG-2375 branch and deliberately cut it out rather than letting it ride inside a large feature PR, so it can merge quickly and unblock everything else.

### Scope note

Eight pins, not just the workflows. The one worth a second look is the **`Dockerfile` builder image** — without it, release binaries would keep being built against the vulnerable stdlib while CI reported green.

## How should this be tested?

- **The scan itself.** On this branch, `govulncheck ./...` reports `No vulnerabilities found`, down from 7 on `main`:

```
$ govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

- **`make build`** — both binaries build on 1.26.6 (the toolchain downloads automatically via the `go.mod` directive).
- **`make test-unit`** — full unit suite green on the new toolchain.
- **CI on this PR** is the real check: Code Quality Checks should go green, and the integration matrix (pg16/17/18) should stay green, confirming the bump is a no-op behaviourally.

No source changes, so there is nothing to exercise by hand.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits — n/a, version-string changes only
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests in `tests/`) — not run locally; the CI matrix covers pg16/17/18 and is the meaningful signal for a toolchain change
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch — branched from `01f6e8b`, 0 commits behind
- [x] If database schema changed: n/a

### Appreciated

- [ ] If API changed: n/a, no API change
- [ ] If API behavior changed: n/a
- [ ] Updated docs in `docs/` if changes were necessary — n/a, this repo has no `docs/`
- [ ] Ran `make tests-coverage` for meaningful logic changes — n/a, no logic changed
