### PR TITLE
feat: report why an enrichment is off and what failed, durably (ENG-2375)

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -816,10 +816,16 @@ func runEnrichmentBacklogPoller(
 		// backlog gauge and no second election is needed. Its query is cheap next to the backlog
 		// scan: it reads the markers, of which there are few, not every feedback record.
 		//
-		// queryCtx, not ctx — this shares the tick's timeout budget. Handing it the process-lifetime
-		// context would let a slow count pin a pool connection until shutdown, which is the exact
-		// thing enrichmentBacklogQueryTimeout exists to prevent.
-		refreshFailedRecords(queryCtx, statusRepo, failures)
+		// Its OWN deadline, not the leftover of queryCtx. Both need a bound — an unbounded count
+		// can pin a pool connection until shutdown, which is what enrichmentBacklogQueryTimeout
+		// exists to prevent — but sharing one budget couples them the wrong way round: the backlog
+		// scan above is the documented whole-table sequential scan, so on a large deployment it
+		// eats most of the window, and this count then times out on every tick and withdraws the
+		// gauge for as long as the scan stays slow. A separate timeout off the same parent keeps
+		// the bound and drops the coupling.
+		failedCtx, cancelFailed := context.WithTimeout(ctx, enrichmentBacklogQueryTimeout)
+		refreshFailedRecords(failedCtx, statusRepo, failures)
+		cancelFailed()
 	}
 
 	update()

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -815,7 +815,11 @@ func runEnrichmentBacklogPoller(
 		// Refreshed by the SAME leader on the SAME tick, so the failure gauge cannot drift from the
 		// backlog gauge and no second election is needed. Its query is cheap next to the backlog
 		// scan: it reads the markers, of which there are few, not every feedback record.
-		refreshFailedRecords(ctx, statusRepo, failures)
+		//
+		// queryCtx, not ctx — this shares the tick's timeout budget. Handing it the process-lifetime
+		// context would let a slow count pin a pool connection until shutdown, which is the exact
+		// thing enrichmentBacklogQueryTimeout exists to prevent.
+		refreshFailedRecords(queryCtx, statusRepo, failures)
 	}
 
 	update()
@@ -1082,10 +1086,17 @@ func (a *App) awaitEnrichmentBacklogPoller(ctx context.Context) {
 	}
 }
 
-// refreshFailedRecords republishes the cross-tenant failed-record gauge. Best effort: a failure
-// here logs and leaves the previous reading rather than tearing down the backlog gauge with it,
-// because the two answer different questions and one being unavailable is not a reason to lose
-// both.
+// refreshFailedRecords republishes the cross-tenant failed-record gauge.
+//
+// A failed query WITHDRAWS this gauge rather than leaving its last reading published, following
+// the rule EnrichmentBacklogMetrics states outright: exporting nothing is the honest state,
+// because absence is visible and a stale value is not. The failure mode it avoids is specific —
+// the backlog scan succeeds so this process keeps leadership, this query times out, and a
+// dashboard would otherwise show a plausible, unchanging failure count that no longer reflects
+// the database, with nothing absent to alert on.
+//
+// It withdraws only ITS OWN series. The backlog gauge is refreshed by a query that succeeded and
+// has no reason to be torn down alongside.
 func refreshFailedRecords(
 	ctx context.Context,
 	statusRepo *repository.EnrichmentStatusRepository,
@@ -1097,8 +1108,12 @@ func refreshFailedRecords(
 
 	counts, err := statusRepo.CountFailedRecordsAggregate(ctx)
 	if err != nil {
+		failures.ClearFailedRecords()
+
+		// Shutdown cancels the query mid-flight; that is not a poll failure worth logging, for the
+		// same reason the backlog poller skips it.
 		if ctx.Err() == nil {
-			slog.WarnContext(ctx, "enrichment failed-records poll failed", "error", err)
+			slog.WarnContext(ctx, "enrichment failed-records poll failed; gauge withdrawn", "error", err)
 		}
 
 		return

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -650,15 +650,16 @@ func (a *App) Run(ctx context.Context) error {
 		go func() {
 			defer close(done)
 
-			runEnrichmentBacklogPoller(ctx, a.db, a.metrics.EnrichmentBacklog, enrichmentBacklogPollConfig{
-				// Trim to stay consistent with NewEnrichmentStatusService (config already canonicalizes
-				// this, so it's defensive symmetry) — the endpoint and the gauge resolve the same target.
-				defaultLang:            strings.TrimSpace(a.cfg.Translation.DefaultLanguage),
-				translationConfigured:  translationConfigured,
-				sentimentConfigured:    a.cfg.Sentiment.Enabled(),
-				emotionsConfigured:     a.cfg.Emotions.Enabled(),
-				taxonomyEmbeddingModel: taxonomyEmbeddingModel,
-			})
+			runEnrichmentBacklogPoller(ctx, a.db, a.metrics.EnrichmentBacklog, a.metrics.EnrichmentFailures,
+				enrichmentBacklogPollConfig{
+					// Trim to stay consistent with NewEnrichmentStatusService (config already canonicalizes
+					// this, so it's defensive symmetry) — the endpoint and the gauge resolve the same target.
+					defaultLang:            strings.TrimSpace(a.cfg.Translation.DefaultLanguage),
+					translationConfigured:  translationConfigured,
+					sentimentConfigured:    a.cfg.Sentiment.Enabled(),
+					emotionsConfigured:     a.cfg.Emotions.Enabled(),
+					taxonomyEmbeddingModel: taxonomyEmbeddingModel,
+				})
 		}()
 	}
 
@@ -725,8 +726,11 @@ func runEnrichmentBacklogPoller(
 	ctx context.Context,
 	db *pgxpool.Pool,
 	backlog observability.EnrichmentBacklogMetrics,
+	failures observability.EnrichmentFailureMetrics,
 	cfg enrichmentBacklogPollConfig,
 ) {
+	statusRepo := repository.NewEnrichmentStatusRepository(db)
+
 	leader := repository.NewEnrichmentBacklogLeader(db)
 	defer leader.Close(ctx)
 
@@ -735,6 +739,7 @@ func runEnrichmentBacklogPoller(
 	// final collect-and-export on shutdown would publish one last reading for a backlog this
 	// process no longer owns.
 	defer backlog.ClearEnrichmentPending()
+	defer clearFailedRecords(failures)
 
 	ticker := time.NewTicker(enrichmentBacklogInterval)
 	defer ticker.Stop()
@@ -760,6 +765,7 @@ func runEnrichmentBacklogPoller(
 			// A failed scan also costs this process its leadership, so withdraw the series rather
 			// than leave it frozen at the last good reading while the new leader publishes its own.
 			backlog.ClearEnrichmentPending()
+			clearFailedRecords(failures)
 
 			// Count the failure so the gap is alertable, then escalate the log from warn to error
 			// once failures persist: a single blip is noise, but a run of them means nobody is
@@ -784,6 +790,7 @@ func runEnrichmentBacklogPoller(
 			// anything this process exported while it was previously the leader, so a handover
 			// leaves exactly one series rather than a live one plus a frozen one.
 			backlog.ClearEnrichmentPending()
+			clearFailedRecords(failures)
 
 			return
 		}
@@ -804,6 +811,11 @@ func runEnrichmentBacklogPoller(
 			backlog.SetEnrichmentPending(
 				observability.EnrichmentTypeTaxonomyEmbedding, counts.TaxonomyEmbeddingPending)
 		}
+
+		// Refreshed by the SAME leader on the SAME tick, so the failure gauge cannot drift from the
+		// backlog gauge and no second election is needed. Its query is cheap next to the backlog
+		// scan: it reads the markers, of which there are few, not every feedback record.
+		refreshFailedRecords(ctx, statusRepo, failures)
 	}
 
 	update()
@@ -1067,5 +1079,52 @@ func (a *App) awaitEnrichmentBacklogPoller(ctx context.Context) {
 	case <-ctx.Done():
 		slog.Warn("enrichment backlog poller did not finish before the shutdown deadline; " +
 			"its final gauge reading may still be exported")
+	}
+}
+
+// refreshFailedRecords republishes the cross-tenant failed-record gauge. Best effort: a failure
+// here logs and leaves the previous reading rather than tearing down the backlog gauge with it,
+// because the two answer different questions and one being unavailable is not a reason to lose
+// both.
+func refreshFailedRecords(
+	ctx context.Context,
+	statusRepo *repository.EnrichmentStatusRepository,
+	failures observability.EnrichmentFailureMetrics,
+) {
+	if failures == nil {
+		return
+	}
+
+	counts, err := statusRepo.CountFailedRecordsAggregate(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.WarnContext(ctx, "enrichment failed-records poll failed", "error", err)
+		}
+
+		return
+	}
+
+	// Zero the known buckets before applying, so an enrichment whose last failure was resolved
+	// reports 0 rather than keeping its final non-zero reading forever. The query returns no row
+	// for an empty bucket, which would otherwise be indistinguishable from "not refreshed".
+	for _, enrichment := range []string{
+		observability.EnrichmentTypeSentiment,
+		observability.EnrichmentTypeEmotions,
+		observability.EnrichmentTypeTranslation,
+	} {
+		failures.SetFailedRecords(enrichment, true, 0)
+		failures.SetFailedRecords(enrichment, false, 0)
+	}
+
+	for _, count := range counts {
+		failures.SetFailedRecords(count.Enrichment, count.Terminal, count.Count)
+	}
+}
+
+// clearFailedRecords withdraws the gauge, for the same reason the backlog gauge is withdrawn: a
+// process that is no longer the leader must export nothing rather than a frozen last reading.
+func clearFailedRecords(failures observability.EnrichmentFailureMetrics) {
+	if failures != nil {
+		failures.ClearFailedRecords()
 	}
 }

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/formbricks/hub/internal/api/middleware"
 	"github.com/formbricks/hub/internal/api/routes"
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/llm"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/internal/repository"
@@ -105,6 +106,20 @@ func setupEmbeddingSearchHandler(
 	metrics *observability.Metrics,
 	meterProvider *sdkmetric.MeterProvider,
 ) (*handlers.SearchHandler, error) {
+	// The API works no enrichment jobs, but it does embed SEARCH QUERIES, and those are real
+	// provider calls with real cost. Recording them here means the token metric covers everything
+	// the deployment actually spends rather than only the worker's share.
+	var genAIUsage llm.UsageRecorder
+
+	if meterProvider != nil {
+		recorder, err := observability.NewGenAIMetrics(meterProvider.Meter("hub"))
+		if err != nil {
+			return nil, fmt.Errorf("create gen_ai metrics: %w", err)
+		}
+
+		genAIUsage = recorder
+	}
+
 	embeddingCfg := service.EmbeddingClientConfig{
 		Provider:            embeddingProviderName,
 		ProviderAPIKey:      cfg.Embedding.ProviderAPIKey,
@@ -113,6 +128,7 @@ func setupEmbeddingSearchHandler(
 		Normalize:           cfg.Embedding.Normalize,
 		GoogleCloudProject:  cfg.Embedding.GoogleCloudProject,
 		GoogleCloudLocation: cfg.Embedding.GoogleCloudLocation,
+		UsageRecorder:       genAIUsage,
 	}
 	if err := service.ValidateEmbeddingConfig(embeddingCfg); err != nil {
 		return nil, fmt.Errorf("embedding config: %w", err)

--- a/cmd/backfill-classify/main.go
+++ b/cmd/backfill-classify/main.go
@@ -114,7 +114,9 @@ func run() int {
 			return exitFailure
 		}
 
-		river.AddWorker(riverWorkers, workers.NewFeedbackSentimentWorker(feedbackRecordsService, settingsService, client, nil))
+		// nil failure recorder: this client is never Start()ed (see backfill-translations), so it
+		// works no jobs and records no failures; hub-worker does both.
+		river.AddWorker(riverWorkers, workers.NewFeedbackSentimentWorker(feedbackRecordsService, settingsService, client, nil, nil))
 
 		queueName = service.SentimentsQueueName
 		maxAttempts = classifyMaxAttempts(cfg.Sentiment.MaxAttempts)
@@ -140,7 +142,7 @@ func run() int {
 			return exitFailure
 		}
 
-		river.AddWorker(riverWorkers, workers.NewFeedbackEmotionsWorker(feedbackRecordsService, settingsService, client, nil))
+		river.AddWorker(riverWorkers, workers.NewFeedbackEmotionsWorker(feedbackRecordsService, settingsService, client, nil, nil))
 
 		queueName = service.EmotionsQueueName
 		maxAttempts = classifyMaxAttempts(cfg.Emotions.MaxAttempts)

--- a/cmd/backfill-classify/main.go
+++ b/cmd/backfill-classify/main.go
@@ -116,7 +116,7 @@ func run() int {
 
 		// nil failure recorder: this client is never Start()ed (see backfill-translations), so it
 		// works no jobs and records no failures; hub-worker does both.
-		river.AddWorker(riverWorkers, workers.NewFeedbackSentimentWorker(feedbackRecordsService, settingsService, client, nil, nil))
+		river.AddWorker(riverWorkers, workers.NewFeedbackSentimentWorker(feedbackRecordsService, settingsService, client, nil, nil, nil))
 
 		queueName = service.SentimentsQueueName
 		maxAttempts = classifyMaxAttempts(cfg.Sentiment.MaxAttempts)
@@ -142,7 +142,7 @@ func run() int {
 			return exitFailure
 		}
 
-		river.AddWorker(riverWorkers, workers.NewFeedbackEmotionsWorker(feedbackRecordsService, settingsService, client, nil, nil))
+		river.AddWorker(riverWorkers, workers.NewFeedbackEmotionsWorker(feedbackRecordsService, settingsService, client, nil, nil, nil))
 
 		queueName = service.EmotionsQueueName
 		maxAttempts = classifyMaxAttempts(cfg.Emotions.MaxAttempts)

--- a/cmd/backfill-translations/main.go
+++ b/cmd/backfill-translations/main.go
@@ -102,7 +102,10 @@ func run() int {
 	// Producer-only: we only enqueue jobs; workers run in hub-worker (or the API process).
 	// River requires the job kind registered (worker added) and MaxWorkers > 0 for a declared queue.
 	riverWorkers := river.NewWorkers()
-	river.AddWorker(riverWorkers, workers.NewFeedbackTranslationWorker(feedbackRecordsService, translationClient, nil))
+	// nil metrics and nil failure recorder: this client is never Start()ed, so it works no jobs.
+	// The registration exists only because River validates that every configured queue has a
+	// worker. hub-worker is the process that runs these and owns failure bookkeeping.
+	river.AddWorker(riverWorkers, workers.NewFeedbackTranslationWorker(feedbackRecordsService, translationClient, nil, nil))
 
 	riverClient, err := river.NewClient(riverpgxv5.New(db), &river.Config{
 		Queues: map[string]river.QueueConfig{

--- a/cmd/backfill-translations/main.go
+++ b/cmd/backfill-translations/main.go
@@ -105,7 +105,7 @@ func run() int {
 	// nil metrics and nil failure recorder: this client is never Start()ed, so it works no jobs.
 	// The registration exists only because River validates that every configured queue has a
 	// worker. hub-worker is the process that runs these and owns failure bookkeeping.
-	river.AddWorker(riverWorkers, workers.NewFeedbackTranslationWorker(feedbackRecordsService, translationClient, nil, nil))
+	river.AddWorker(riverWorkers, workers.NewFeedbackTranslationWorker(feedbackRecordsService, translationClient, nil, nil, nil))
 
 	riverClient, err := river.NewClient(riverpgxv5.New(db), &river.Config{
 		Queues: map[string]river.QueueConfig{

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -99,6 +99,11 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		WebhookMetrics:     webhookMetrics,
 
 		FeedbackRecordsPurgeService: feedbackRecordsPurgeService,
+
+		// hub-worker is the only process that works enrichment jobs, so it is the only one that
+		// can observe a failure and the only one that records them. The backfill commands register
+		// workers but never Start() a client, so they never reach this path.
+		Failures: repository.NewEnrichmentFailuresRepository(db),
 	}
 
 	providerName, embeddingModel := embeddingProviderAndModel(cfg)

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -14,6 +14,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/llm"
 	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/internal/repository"
 	"github.com/formbricks/hub/internal/service"
@@ -35,6 +36,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 	var (
 		metrics        *observability.Metrics
 		meterProvider  *sdkmetric.MeterProvider
+		genAIUsage     llm.UsageRecorder
 		tracerProvider *sdktrace.TracerProvider
 		err            error
 	)
@@ -51,6 +53,16 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 				_ = observability.ShutdownMeterProvider(context.Background(), meterProvider)
 
 				return nil, fmt.Errorf("create metrics: %w", err)
+			}
+
+			// hub-worker is where the provider calls happen, so it is where their cost is
+			// observable. A nil recorder (metrics disabled) leaves the clients behaving exactly
+			// as before.
+			genAIUsage, err = observability.NewGenAIMetrics(meterProvider.Meter("hub"))
+			if err != nil {
+				_ = observability.ShutdownMeterProvider(context.Background(), meterProvider)
+
+				return nil, fmt.Errorf("create gen_ai metrics: %w", err)
 			}
 		}
 	}
@@ -122,6 +134,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 
 	if providerName != "" {
 		embeddingCfg := service.EmbeddingClientConfig{
+			UsageRecorder:       genAIUsage,
 			Provider:            providerName,
 			ProviderAPIKey:      cfg.Embedding.ProviderAPIKey,
 			Model:               embeddingModel,
@@ -187,6 +200,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 
 	if cfg.Translation.Provider != "" && cfg.Translation.Model != "" {
 		translationCfg := service.TranslationClientConfig{
+			UsageRecorder:       genAIUsage,
 			Provider:            cfg.Translation.Provider,
 			ProviderAPIKey:      cfg.Translation.ProviderAPIKey,
 			Model:               cfg.Translation.Model,
@@ -227,6 +241,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 
 	if cfg.Sentiment.Enabled() {
 		sentimentClient, err := service.NewSentimentClient(context.Background(), service.SentimentClientConfig{
+			UsageRecorder:       genAIUsage,
 			Provider:            cfg.Sentiment.Provider,
 			ProviderAPIKey:      cfg.Sentiment.ProviderAPIKey,
 			Model:               cfg.Sentiment.Model,
@@ -260,6 +275,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 
 	if cfg.Emotions.Enabled() {
 		emotionsClient, err := service.NewEmotionsClient(context.Background(), service.EmotionsClientConfig{
+			UsageRecorder:       genAIUsage,
 			Provider:            cfg.Emotions.Provider,
 			ProviderAPIKey:      cfg.Emotions.ProviderAPIKey,
 			Model:               cfg.Emotions.Model,

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -116,6 +116,9 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 		// can observe a failure and the only one that records them. The backfill commands register
 		// workers but never Start() a client, so they never reach this path.
 		Failures: repository.NewEnrichmentFailuresRepository(db),
+		// The worker is where a terminal give-up is observed, so it is where the counter lives.
+		// nil when metrics are disabled, which the worker treats as "do not record".
+		FailureMetrics: failureMetrics(metrics),
 	}
 
 	providerName, embeddingModel := embeddingProviderAndModel(cfg)
@@ -473,4 +476,14 @@ func (a *WorkerApp) Shutdown(ctx context.Context) (err error) {
 	}
 
 	return err
+}
+
+// failureMetrics pulls the enrichment failure metrics off the aggregate, tolerating metrics being
+// disabled entirely (a nil *Metrics), which is the default for a deployment with no OTLP exporter.
+func failureMetrics(metrics *observability.Metrics) observability.EnrichmentFailureMetrics {
+	if metrics == nil {
+		return nil
+	}
+
+	return metrics.EnrichmentFailures
 }

--- a/internal/api/handlers/enrichment_status_handler_test.go
+++ b/internal/api/handlers/enrichment_status_handler_test.go
@@ -76,9 +76,11 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 	// check them.
 	t.Run("wire format matches the published schema", func(t *testing.T) {
 		resp := &models.EnrichmentStatusResponse{
-			TenantID:    "t1",
-			AsOf:        time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
-			Translation: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			TenantID: "t1",
+			AsOf:     time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+			Translation: models.EnrichmentTypeStatus{
+				Enabled: true, Eligible: 10, Done: 4, Failed: 2, FailedTerminal: 1,
+			},
 			Sentiment: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
 			},
@@ -96,6 +98,21 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 
 		assert.Equal(t, "t1", body["tenant_id"])
+
+		// failed / failed_terminal are REQUIRED in the schema, so they must be present even when
+		// zero — an omitted required field breaks a strict generated client.
+		for _, name := range []string{"translation", "sentiment", "emotions"} {
+			enrichment, isObj := body[name].(map[string]any)
+			require.True(t, isObj, "%s is an object", name)
+
+			for _, field := range []string{"enabled", "eligible", "done", "failed", "failed_terminal"} {
+				_, present := enrichment[field]
+				assert.True(t, present, "%s.%s must always be present", name, field)
+			}
+		}
+
+		assert.InDelta(t, 2, body["translation"].(map[string]any)["failed"], 0.001)
+		assert.InDelta(t, 1, body["translation"].(map[string]any)["failed_terminal"], 0.001)
 		// RFC 3339 in UTC, matching `format: date-time` in the schema. Parsing it back is what
 		// proves the client can, which is the whole reason the field exists.
 		asOf, parseErr := time.Parse(time.RFC3339Nano, body["as_of"].(string))

--- a/internal/api/handlers/enrichment_status_handler_test.go
+++ b/internal/api/handlers/enrichment_status_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,9 +50,12 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 	t.Run("returns 200 with the status body", func(t *testing.T) {
 		want := &models.EnrichmentStatusResponse{
 			TenantID:    "t1",
+			AsOf:        time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
 			Translation: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
 			Sentiment:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 8},
-			Emotions:    models.EnrichmentTypeStatus{Enabled: false},
+			Emotions: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 		}
 		h := NewEnrichmentStatusHandler(&fakeEnrichmentStatusService{resp: want})
 		rec := httptest.NewRecorder()
@@ -62,5 +66,63 @@ func TestEnrichmentStatusHandler_GetStatus(t *testing.T) {
 		var got models.EnrichmentStatusResponse
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 		assert.Equal(t, *want, got)
+	})
+
+	// Asserts the JSON the client actually receives, by field name, rather than round-tripping
+	// through models.EnrichmentStatusResponse. That round trip is symmetric with the marshal that
+	// produced it, so it cannot observe the wire format at all: it passes unchanged if a field is
+	// renamed, dropped, or emitted with the wrong presence semantics. The published OpenAPI schema
+	// is a promise about these bytes, and Stainless generates the SDK from it, so something has to
+	// check them.
+	t.Run("wire format matches the published schema", func(t *testing.T) {
+		resp := &models.EnrichmentStatusResponse{
+			TenantID:    "t1",
+			AsOf:        time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+			Translation: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			Sentiment: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
+			Emotions: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
+		}
+		h := NewEnrichmentStatusHandler(&fakeEnrichmentStatusService{resp: resp})
+		rec := httptest.NewRecorder()
+		h.GetStatus(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/enrichment-status?tenant_id=t1", nil))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+		assert.Equal(t, "t1", body["tenant_id"])
+		// RFC 3339 in UTC, matching `format: date-time` in the schema. Parsing it back is what
+		// proves the client can, which is the whole reason the field exists.
+		asOf, parseErr := time.Parse(time.RFC3339Nano, body["as_of"].(string))
+		require.NoError(t, parseErr, "as_of must be RFC 3339")
+		assert.True(t, asOf.Equal(resp.AsOf), "as_of survives serialization unchanged")
+
+		// An ENABLED enrichment must omit disabled_reason entirely. Emitting it as "" would be the
+		// natural result of dropping `omitempty`, and "" is not one of the three values the schema's
+		// enum allows — a strict client would reject the whole response.
+		translation, ok := body["translation"].(map[string]any)
+		require.True(t, ok, "translation is an object")
+
+		_, present := translation["disabled_reason"]
+		assert.False(t, present, "enabled enrichment must omit disabled_reason, not send an empty one")
+
+		// A DISABLED enrichment must carry its reason, and it must be one of the enum values.
+		allowed := map[string]bool{"not_configured": true, "switched_off": true, "no_target_language": true}
+		wantReasons := map[string]string{"sentiment": "switched_off", "emotions": "not_configured"}
+
+		for name, wantReason := range wantReasons {
+			enrichment, isObj := body[name].(map[string]any)
+			require.True(t, isObj, "%s is an object", name)
+
+			reason, hasReason := enrichment["disabled_reason"].(string)
+			require.True(t, hasReason, "%s: disabled enrichment must carry disabled_reason", name)
+			assert.True(t, allowed[reason], "%s: %q is outside the schema enum", name, reason)
+			assert.Equal(t, wantReason, reason, "%s: wrong reason on the wire", name)
+		}
 	})
 }

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -43,6 +44,13 @@ type Client struct {
 	model      string
 	dimensions int
 	normalize  bool
+	// provider is the gen_ai.provider.name this client reports. The two constructors below pick
+	// different backends and they are NOT the same provider to a cost dashboard: the API-key path
+	// is AI Studio (gcp.gemini) and the ADC path is Vertex (gcp.vertex_ai), billed separately.
+	provider llm.Provider
+	// usage receives one record per provider call. nil disables recording entirely, which is how
+	// the backfill commands and the unit tests opt out.
+	usage llm.UsageRecorder
 	// thinkingBudgetUnsupported latches once the configured model rejects a zero thinking
 	// budget (Pro models cannot disable thinking), so later calls fall back to the model's
 	// default thinking behavior instead of failing.
@@ -73,6 +81,15 @@ func WithNormalize(normalize bool) ClientOption {
 	}
 }
 
+// WithUsageRecorder attaches a recorder that receives each call's token counts and duration. The
+// provider returns those numbers on every generate-content response; without this they are decoded
+// and dropped, and a deployment running on Google records no enrichment cost at all.
+func WithUsageRecorder(recorder llm.UsageRecorder) ClientOption {
+	return func(c *Client) {
+		c.usage = recorder
+	}
+}
+
 // NewClient creates a Gemini embeddings client.
 func NewClient(ctx context.Context, apiKey string, opts ...ClientOption) (*Client, error) {
 	genaiClient, err := genai.NewClient(ctx, &genai.ClientConfig{
@@ -86,6 +103,7 @@ func NewClient(ctx context.Context, apiKey string, opts ...ClientOption) (*Clien
 	client := &Client{
 		client:     genaiClient,
 		dimensions: models.EmbeddingVectorDimensions,
+		provider:   llm.ProviderGCPGemini,
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -118,6 +136,7 @@ func NewGoogleGeminiClient(ctx context.Context, project, location string, opts .
 	client := &Client{
 		client:     genaiClient,
 		dimensions: models.EmbeddingVectorDimensions,
+		provider:   llm.ProviderGCPVertexAI,
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -149,11 +168,15 @@ func (c *Client) Translate(ctx context.Context, systemPrompt, userText string) (
 	}
 
 	temperature := float32(0)
+	started := time.Now()
 
 	resp, err := c.client.Models.GenerateContent(ctx, c.model, genai.Text(userText), &genai.GenerateContentConfig{
 		Temperature:       &temperature,
 		SystemInstruction: genai.NewContentFromText(systemPrompt, genai.RoleUser),
 	})
+
+	c.recordGenerate(ctx, started, resp, err)
+
 	if err != nil {
 		return "", wrapGenerateContentError(err)
 	}
@@ -194,6 +217,8 @@ func (c *Client) CompleteJSON(ctx context.Context, systemPrompt, userText string
 		config.ThinkingConfig = &genai.ThinkingConfig{ThinkingBudget: new(int32)}
 	}
 
+	started := time.Now()
+
 	resp, err := c.client.Models.GenerateContent(ctx, c.model, genai.Text(userText), config)
 	if err != nil && isUnsupportedThinkingBudgetError(err) {
 		c.thinkingBudgetUnsupported.Store(true)
@@ -202,6 +227,11 @@ func (c *Client) CompleteJSON(ctx context.Context, systemPrompt, userText string
 
 		resp, err = c.client.Models.GenerateContent(ctx, c.model, genai.Text(userText), config)
 	}
+
+	// One record for the whole sequence, including the thinking-budget retry above: the token
+	// counts come from whichever request answered, and the duration spans both. That inflates a
+	// single call's latency at most once per client per process, since the rejection latches.
+	c.recordGenerate(ctx, started, resp, err)
 
 	if err != nil {
 		return "", wrapGenerateContentError(err)
@@ -391,11 +421,19 @@ func (c *Client) embedWithTaskType(ctx context.Context, input, taskType string) 
 
 	contents := []*genai.Content{genai.NewContentFromText(input, genai.RoleUser)}
 	dimInt32 := int32(c.dimensions)
+	started := time.Now()
 
 	resp, err := c.client.Models.EmbedContent(ctx, c.model, contents, &genai.EmbedContentConfig{
 		TaskType:             taskType,
 		OutputDimensionality: &dimInt32,
 	})
+
+	// Token counts deliberately zero: an embed response carries no token usage at all — Vertex
+	// reports a billable CHARACTER count and AI Studio reports nothing — so there is no number to
+	// report in {token} units. The duration still lands, which is what makes a slow embedding
+	// provider visible. The recorder skips zero counts rather than emitting them.
+	c.recordUsage(ctx, llm.OperationEmbeddings, started, 0, 0, err)
+
 	if err != nil {
 		return nil, wrapGenaiError("gemini embedding", err)
 	}
@@ -417,4 +455,68 @@ func (c *Client) embedWithTaskType(ctx context.Context, input, taskType string) 
 	}
 
 	return out, nil
+}
+
+// recordGenerate reports one generate-content call, pulling the token counts off the response's
+// usage metadata.
+//
+// Output tokens include ThoughtsTokenCount. Thinking tokens are billed as output, and this client
+// asks for a zero thinking budget but falls back to the model's default when the model rejects
+// that (see CompleteJSON), so leaving them out would under-report the cost of exactly the models
+// where it is largest.
+func (c *Client) recordGenerate(
+	ctx context.Context, started time.Time, resp *genai.GenerateContentResponse, err error,
+) {
+	var input, output int64
+
+	if resp != nil && resp.UsageMetadata != nil {
+		input = int64(resp.UsageMetadata.PromptTokenCount)
+		output = int64(resp.UsageMetadata.CandidatesTokenCount) + int64(resp.UsageMetadata.ThoughtsTokenCount)
+	}
+
+	c.recordUsage(ctx, llm.OperationChat, started, input, output, err)
+}
+
+// recordUsage reports one call. Split out so every provider entry point records the same shape,
+// and so a nil recorder is checked in exactly one place.
+func (c *Client) recordUsage(
+	ctx context.Context, operation llm.Operation, started time.Time, inputTokens, outputTokens int64, err error,
+) {
+	if c.usage == nil {
+		return
+	}
+
+	c.usage.RecordUsage(ctx, llm.Usage{
+		Operation:    operation,
+		Provider:     c.provider,
+		Model:        c.model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		Duration:     time.Since(started),
+		ErrorType:    errorTypeOf(err),
+	})
+}
+
+// errorTypeOf maps an error to the BOUNDED error.type attribute. An HTTP status becomes its
+// number, everything else a coarse class — never the provider's message, which is unbounded and
+// would blow up metric cardinality the first time a provider echoed user input back in an error.
+func errorTypeOf(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var apiErr genai.APIError
+	if errors.As(err, &apiErr) && apiErr.Code != 0 {
+		return strconv.Itoa(apiErr.Code)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return "cancelled"
+	}
+
+	return "other"
 }

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -350,11 +349,17 @@ func terminalEmptyReason(resp *genai.GenerateContentResponse) (huberrors.Termina
 
 // emptyResponseDetail renders the block/finish metadata explaining an empty response
 // (": blocked: SAFETY", ": finish reason: MAX_TOKENS"), or "" when none is present.
+//
+// BlockReasonMessage is TRUNCATED, matching the 256-char cap the OpenAI client puts on a refusal
+// string. Both are free-form provider prose that ends up in an error and therefore in logs, and
+// while a block message is usually a fixed phrase, nothing in the API promises that — it is the
+// provider describing why it rejected this particular text, which is the category of string that
+// can quote the text back. Everything else here is a bounded enum.
 func emptyResponseDetail(resp *genai.GenerateContentResponse) string {
 	if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
 		detail := fmt.Sprintf(": blocked: %s", resp.PromptFeedback.BlockReason)
 		if resp.PromptFeedback.BlockReasonMessage != "" {
-			detail += " (" + resp.PromptFeedback.BlockReasonMessage + ")"
+			detail += fmt.Sprintf(" (%.256s)", resp.PromptFeedback.BlockReasonMessage)
 		}
 
 		return detail
@@ -482,41 +487,20 @@ func (c *Client) recordGenerate(
 func (c *Client) recordUsage(
 	ctx context.Context, operation llm.Operation, started time.Time, inputTokens, outputTokens int64, err error,
 ) {
-	if c.usage == nil {
-		return
-	}
-
-	c.usage.RecordUsage(ctx, llm.Usage{
-		Operation:    operation,
-		Provider:     c.provider,
-		Model:        c.model,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-		Duration:     time.Since(started),
-		ErrorType:    errorTypeOf(err),
-	})
+	llm.Record(ctx, c.usage, operation, c.provider, c.model,
+		started, inputTokens, outputTokens, errorTypeOf(err))
 }
 
-// errorTypeOf maps an error to the BOUNDED error.type attribute. An HTTP status becomes its
-// number, everything else a coarse class — never the provider's message, which is unbounded and
-// would blow up metric cardinality the first time a provider echoed user input back in an error.
+// errorTypeOf maps an error to the BOUNDED error.type attribute. Only the status extraction is
+// Google-specific; the rest of the classification is shared so the two clients cannot disagree on
+// what "timeout" means.
 func errorTypeOf(err error) string {
-	if err == nil {
-		return ""
-	}
+	return llm.ClassifyError(err, func(err error) (int, bool) {
+		var apiErr genai.APIError
+		if errors.As(err, &apiErr) {
+			return apiErr.Code, true
+		}
 
-	var apiErr genai.APIError
-	if errors.As(err, &apiErr) && apiErr.Code != 0 {
-		return strconv.Itoa(apiErr.Code)
-	}
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		return "timeout"
-	}
-
-	if errors.Is(err, context.Canceled) {
-		return "cancelled"
-	}
-
-	return "other"
+		return 0, false
+	})
 }

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -228,11 +228,58 @@ func isUnsupportedThinkingBudgetError(err error) bool {
 // like a provider outage.
 func generateContentText(resp *genai.GenerateContentResponse) (string, error) {
 	out := strings.TrimSpace(resp.Text())
-	if out == "" {
-		return "", fmt.Errorf("%w%s", ErrNoCompletionInResponse, emptyResponseDetail(resp))
+	if out != "" {
+		return out, nil
 	}
 
-	return out, nil
+	err := fmt.Errorf("%w%s", ErrNoCompletionInResponse, emptyResponseDetail(resp))
+
+	if reason, terminal := terminalEmptyReason(resp); terminal {
+		return "", huberrors.NewTerminalProviderError(reason, err)
+	}
+
+	return "", err
+}
+
+// terminalEmptyReason classifies an empty response as permanent for this input, or leaves it
+// retryable.
+//
+// Only outcomes determined by the CONTENT are terminal. Anything else — an empty response with
+// no metadata, OTHER, LANGUAGE, a malformed function call — stays retryable on purpose: a false
+// terminal abandons a record for good, a false transient costs a few wasted calls.
+func terminalEmptyReason(resp *genai.GenerateContentResponse) (huberrors.TerminalReason, bool) {
+	// A prompt-level block is the provider rejecting the input before generating anything, which
+	// is as content-determined as it gets.
+	if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
+		return huberrors.TerminalReasonContentFilter, true
+	}
+
+	if len(resp.Candidates) == 0 {
+		return "", false
+	}
+
+	switch resp.Candidates[0].FinishReason {
+	case genai.FinishReasonSafety, genai.FinishReasonProhibitedContent,
+		genai.FinishReasonBlocklist, genai.FinishReasonSPII,
+		genai.FinishReasonImageSafety, genai.FinishReasonImageProhibitedContent:
+		return huberrors.TerminalReasonContentFilter, true
+	case genai.FinishReasonRecitation, genai.FinishReasonImageRecitation:
+		return huberrors.TerminalReasonRecitation, true
+	case genai.FinishReasonMaxTokens:
+		return huberrors.TerminalReasonLength, true
+	case genai.FinishReasonUnspecified, genai.FinishReasonStop,
+		genai.FinishReasonLanguage, genai.FinishReasonOther,
+		genai.FinishReasonMalformedFunctionCall, genai.FinishReasonUnexpectedToolCall,
+		genai.FinishReasonNoImage, genai.FinishReasonImageOther:
+		// Deliberately retryable, listed rather than defaulted so the choice is reviewable.
+		// LANGUAGE is arguably permanent, but it is rare and abandoning a record wrongly is the
+		// worse error; the image and tool reasons cannot occur for the calls this client makes;
+		// STOP with empty text and UNSPECIFIED carry no information at all.
+		return "", false
+	default:
+		// A reason added by a future SDK version. Retry rather than abandon — the same asymmetry.
+		return "", false
+	}
 }
 
 // emptyResponseDetail renders the block/finish metadata explaining an empty response

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -227,6 +227,14 @@ func isUnsupportedThinkingBudgetError(err error) bool {
 // user's input — so a persistent block is diagnosable in logs instead of looking
 // like a provider outage.
 func generateContentText(resp *genai.GenerateContentResponse) (string, error) {
+	// Checked BEFORE the text, because MAX_TOKENS usually truncates rather than blanks the output.
+	// Returning a truncated result would store a half-finished translation as complete, or produce
+	// invalid JSON that reads as a transient parse failure when it is permanent for this input.
+	if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason == genai.FinishReasonMaxTokens {
+		return "", huberrors.NewTerminalProviderError(huberrors.TerminalReasonLength,
+			fmt.Errorf("%w: finish reason: %s", ErrNoCompletionInResponse, genai.FinishReasonMaxTokens))
+	}
+
 	out := strings.TrimSpace(resp.Text())
 	if out != "" {
 		return out, nil

--- a/internal/googleai/client.go
+++ b/internal/googleai/client.go
@@ -230,12 +230,18 @@ func generateContentText(resp *genai.GenerateContentResponse) (string, error) {
 	// Checked BEFORE the text, because MAX_TOKENS usually truncates rather than blanks the output.
 	// Returning a truncated result would store a half-finished translation as complete, or produce
 	// invalid JSON that reads as a transient parse failure when it is permanent for this input.
-	if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason == genai.FinishReasonMaxTokens {
+	if firstFinishReason(resp) == genai.FinishReasonMaxTokens {
 		return "", huberrors.NewTerminalProviderError(huberrors.TerminalReasonLength,
 			fmt.Errorf("%w: finish reason: %s", ErrNoCompletionInResponse, genai.FinishReasonMaxTokens))
 	}
 
-	out := strings.TrimSpace(resp.Text())
+	// resp.Text() guards an empty Candidates slice and a nil Content, but NOT a nil candidate
+	// pointer (genai types.go), so it panics on `"candidates": [null]`. Guard before calling it.
+	out := ""
+	if firstCandidate(resp) != nil {
+		out = strings.TrimSpace(resp.Text())
+	}
+
 	if out != "" {
 		return out, nil
 	}
@@ -247,6 +253,32 @@ func generateContentText(resp *genai.GenerateContentResponse) (string, error) {
 	}
 
 	return "", err
+}
+
+// firstCandidate returns the first usable candidate, or nil when the response carries none.
+//
+// Candidates is a slice of POINTERS, so `"candidates": [null]` on the wire unmarshals to a slice
+// holding nil, and every bare resp.Candidates[0].X in this file would panic on it. The SDK's own
+// Text() has the same gap — it checks the slice length and a nil Content but not a nil candidate —
+// so callers must guard before reaching it. Reading candidates through one accessor keeps that in
+// a single place.
+func firstCandidate(resp *genai.GenerateContentResponse) *genai.Candidate {
+	if resp == nil || len(resp.Candidates) == 0 {
+		return nil
+	}
+
+	return resp.Candidates[0]
+}
+
+// firstFinishReason reads the first candidate's finish reason, or "" when there is no usable
+// candidate.
+func firstFinishReason(resp *genai.GenerateContentResponse) genai.FinishReason {
+	candidate := firstCandidate(resp)
+	if candidate == nil {
+		return ""
+	}
+
+	return candidate.FinishReason
 }
 
 // terminalEmptyReason classifies an empty response as permanent for this input, or leaves it
@@ -262,11 +294,7 @@ func terminalEmptyReason(resp *genai.GenerateContentResponse) (huberrors.Termina
 		return huberrors.TerminalReasonContentFilter, true
 	}
 
-	if len(resp.Candidates) == 0 {
-		return "", false
-	}
-
-	switch resp.Candidates[0].FinishReason {
+	switch firstFinishReason(resp) {
 	case genai.FinishReasonSafety, genai.FinishReasonProhibitedContent,
 		genai.FinishReasonBlocklist, genai.FinishReasonSPII,
 		genai.FinishReasonImageSafety, genai.FinishReasonImageProhibitedContent:
@@ -302,11 +330,8 @@ func emptyResponseDetail(resp *genai.GenerateContentResponse) string {
 		return detail
 	}
 
-	if len(resp.Candidates) > 0 {
-		candidate := resp.Candidates[0]
-		if candidate.FinishReason != "" && candidate.FinishReason != genai.FinishReasonStop {
-			return fmt.Sprintf(": finish reason: %s", candidate.FinishReason)
-		}
+	if finish := firstFinishReason(resp); finish != "" && finish != genai.FinishReasonStop {
+		return fmt.Sprintf(": finish reason: %s", finish)
 	}
 
 	return ""

--- a/internal/googleai/client_test.go
+++ b/internal/googleai/client_test.go
@@ -414,3 +414,27 @@ func TestGenerateContentTextTruncatedIsTerminal(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, huberrors.TerminalReasonLength, reason)
 }
+
+// TestNilCandidateDoesNotPanic covers a response carrying a nil candidate pointer. Candidates is a
+// slice of POINTERS, so `"candidates": [null]` on the wire produces exactly this, and a bare
+// resp.Candidates[0].FinishReason panics. It matters more than it looks: the MAX_TOKENS check runs
+// before the text is read, so this path is taken by every response, not only empty ones.
+func TestNilCandidateDoesNotPanic(t *testing.T) {
+	resp := &genai.GenerateContentResponse{Candidates: []*genai.Candidate{nil}}
+
+	require.NotPanics(t, func() {
+		_, err := generateContentText(resp)
+		require.Error(t, err, "a response with no usable candidate has no text")
+		// Nothing about a nil candidate says the input is at fault, so it must stay retryable.
+		require.NotErrorIs(t, err, huberrors.ErrTerminalProvider)
+	})
+
+	require.NotPanics(t, func() {
+		_, terminal := terminalEmptyReason(resp)
+		require.False(t, terminal)
+	})
+
+	require.NotPanics(t, func() {
+		_ = emptyResponseDetail(resp)
+	})
+}

--- a/internal/googleai/client_test.go
+++ b/internal/googleai/client_test.go
@@ -320,3 +320,72 @@ func TestCreateEmbedding_RateLimitReturnsRateLimitError(t *testing.T) {
 	require.ErrorAs(t, err, &rateLimited, "an embedding 429 must surface as a rate-limit error")
 	assert.Equal(t, 17*time.Second, rateLimited.RetryAfter)
 }
+
+// TestTerminalEmptyReason pins which empty Gemini responses are permanent for the input and which
+// stay retryable. Same asymmetry as the OpenAI client: when a reason is ambiguous, retry, because
+// a false terminal abandons a record for good.
+func TestTerminalEmptyReason(t *testing.T) {
+	withFinish := func(reason genai.FinishReason) *genai.GenerateContentResponse {
+		return &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{FinishReason: reason}},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		resp       *genai.GenerateContentResponse
+		wantReason huberrors.TerminalReason
+		terminal   bool
+	}{
+		{
+			// A prompt-level block is the provider rejecting the input before generating at all.
+			name: "prompt block is terminal",
+			resp: &genai.GenerateContentResponse{
+				PromptFeedback: &genai.GenerateContentResponsePromptFeedback{BlockReason: "SAFETY"},
+			},
+			wantReason: huberrors.TerminalReasonContentFilter, terminal: true,
+		},
+		{
+			"safety is terminal", withFinish(genai.FinishReasonSafety),
+			huberrors.TerminalReasonContentFilter, true,
+		},
+		{
+			"prohibited content is terminal", withFinish(genai.FinishReasonProhibitedContent),
+			huberrors.TerminalReasonContentFilter, true,
+		},
+		{
+			"recitation is terminal", withFinish(genai.FinishReasonRecitation),
+			huberrors.TerminalReasonRecitation, true,
+		},
+		{
+			"max tokens is terminal", withFinish(genai.FinishReasonMaxTokens),
+			huberrors.TerminalReasonLength, true,
+		},
+		// OTHER is the provider telling us nothing. Abandoning a record on it would be guessing.
+		{"OTHER stays retryable", withFinish(genai.FinishReasonOther), "", false},
+		{"LANGUAGE stays retryable", withFinish(genai.FinishReasonLanguage), "", false},
+		{"STOP with empty text stays retryable", withFinish(genai.FinishReasonStop), "", false},
+		{"no candidates stays retryable", &genai.GenerateContentResponse{}, "", false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			reason, terminal := terminalEmptyReason(testCase.resp)
+			require.Equal(t, testCase.terminal, terminal)
+
+			if testCase.terminal {
+				assert.Equal(t, testCase.wantReason, reason)
+			}
+
+			// generateContentText must carry the classification through, not just compute it.
+			_, err := generateContentText(testCase.resp)
+			require.Error(t, err)
+
+			if testCase.terminal {
+				assert.ErrorIs(t, err, huberrors.ErrTerminalProvider)
+			} else {
+				assert.NotErrorIs(t, err, huberrors.ErrTerminalProvider)
+			}
+		})
+	}
+}

--- a/internal/googleai/client_test.go
+++ b/internal/googleai/client_test.go
@@ -389,3 +389,28 @@ func TestTerminalEmptyReason(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerateContentTextTruncatedIsTerminal covers the case MAX_TOKENS actually produces: partial
+// text rather than none. Returning it would persist a half-finished translation as complete, or
+// yield invalid JSON that reads as a transient parse failure when it is permanent for this input.
+func TestGenerateContentTextTruncatedIsTerminal(t *testing.T) {
+	resp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			FinishReason: genai.FinishReasonMaxTokens,
+			Content: &genai.Content{
+				Parts: []*genai.Part{{Text: "this translation was cut off half"}},
+			},
+		}},
+	}
+
+	require.NotEmpty(t, resp.Text(), "fixture must carry partial text, or it proves nothing")
+
+	out, err := generateContentText(resp)
+	require.Error(t, err, "truncated output must not be returned as a result")
+	assert.Empty(t, out)
+	require.ErrorIs(t, err, huberrors.ErrTerminalProvider)
+
+	reason, ok := huberrors.TerminalReasonOf(err)
+	require.True(t, ok)
+	assert.Equal(t, huberrors.TerminalReasonLength, reason)
+}

--- a/internal/googleai/client_test.go
+++ b/internal/googleai/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -437,4 +438,164 @@ func TestNilCandidateDoesNotPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		_ = emptyResponseDetail(resp)
 	})
+}
+
+// recordingUsage captures what the client reports, so the assertions are about emitted values
+// rather than about a call into an interface.
+type recordingUsage struct {
+	calls []llm.Usage
+}
+
+func (r *recordingUsage) RecordUsage(_ context.Context, usage llm.Usage) {
+	r.calls = append(r.calls, usage)
+}
+
+// newStubbedClient drives the real genai SDK against a stub endpoint, so the SDK's own response
+// and error decoding is exercised rather than mocked away.
+func newStubbedClient(t *testing.T, usage llm.UsageRecorder, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	genaiClient, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+		APIKey:      "test-key",
+		Backend:     genai.BackendGeminiAPI,
+		HTTPOptions: genai.HTTPOptions{BaseURL: server.URL},
+	})
+	require.NoError(t, err)
+
+	return &Client{
+		client:     genaiClient,
+		model:      "gemini-2.5-flash",
+		dimensions: 768,
+		provider:   llm.ProviderGCPGemini,
+		usage:      usage,
+	}
+}
+
+// TestUsageIsRecordedForGenerateContent is the Google half of the cost metrics. The parity test in
+// internal/service proves a recorder is PASSED to every client; this proves one actually records,
+// which is the part that decides whether a Google deployment reports its spend or reports nothing.
+func TestUsageIsRecordedForGenerateContent(t *testing.T) {
+	t.Run("success carries token counts", func(t *testing.T) {
+		usage := &recordingUsage{}
+		client := newStubbedClient(t, usage, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"candidates":[{"finishReason":"STOP",
+				"content":{"role":"model","parts":[{"text":"hallo"}]}}],
+				"usageMetadata":{"promptTokenCount":31,"candidatesTokenCount":7,"totalTokenCount":38}}`))
+		})
+
+		_, err := client.Translate(context.Background(), "system", "hello")
+		require.NoError(t, err)
+
+		require.Len(t, usage.calls, 1)
+		got := usage.calls[0]
+		assert.Equal(t, llm.OperationChat, got.Operation)
+		assert.Equal(t, llm.ProviderGCPGemini, got.Provider)
+		assert.Equal(t, "gemini-2.5-flash", got.Model)
+		assert.Equal(t, int64(31), got.InputTokens)
+		assert.Equal(t, int64(7), got.OutputTokens)
+		assert.Empty(t, got.ErrorType, "a successful call carries no error.type")
+		assert.Positive(t, got.Duration)
+	})
+
+	// Thinking tokens bill as output. This client asks for a zero thinking budget but falls back to
+	// the model's default when the model rejects that, so a Pro model quietly spends them — leaving
+	// them out would under-report exactly the models where the cost is largest.
+	t.Run("thinking tokens count as output", func(t *testing.T) {
+		usage := &recordingUsage{}
+		client := newStubbedClient(t, usage, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"candidates":[{"finishReason":"STOP",
+				"content":{"role":"model","parts":[{"text":"hallo"}]}}],
+				"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":4,"thoughtsTokenCount":96}}`))
+		})
+
+		_, err := client.Translate(context.Background(), "system", "hello")
+		require.NoError(t, err)
+
+		require.Len(t, usage.calls, 1)
+		assert.Equal(t, int64(100), usage.calls[0].OutputTokens,
+			"4 completion + 96 thinking: dropping the thinking tokens would hide most of the bill")
+	})
+
+	t.Run("failure records a bounded error type", func(t *testing.T) {
+		usage := &recordingUsage{}
+		client := newStubbedClient(t, usage, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"code":500,"status":"INTERNAL","message":"boom"}}`))
+		})
+
+		_, err := client.Translate(context.Background(), "system", "hello")
+		require.Error(t, err)
+
+		require.Len(t, usage.calls, 1, "a failed call must still be recorded")
+		// The status code, never the provider's message — an unbounded error.type would blow up
+		// cardinality the first time a provider echoed user input back in an error body.
+		assert.Equal(t, "500", usage.calls[0].ErrorType)
+		assert.Zero(t, usage.calls[0].InputTokens, "no usage metadata means no token counts")
+		assert.Positive(t, usage.calls[0].Duration, "a failed call still took time")
+	})
+
+	// Embeddings carry no token usage on either backend — Vertex reports a billable CHARACTER count
+	// and AI Studio reports nothing — so duration is the whole signal. Pinned so the empty token
+	// series reads as the provider's doing rather than as a wiring bug.
+	t.Run("embeddings record duration but no tokens", func(t *testing.T) {
+		usage := &recordingUsage{}
+		client := newStubbedClient(t, usage, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"embeddings":[{"values":` + zeroVector(768) + `}]}`))
+		})
+
+		_, err := client.CreateEmbedding(context.Background(), "hello")
+		require.NoError(t, err)
+
+		require.Len(t, usage.calls, 1)
+		assert.Equal(t, llm.OperationEmbeddings, usage.calls[0].Operation)
+		assert.Zero(t, usage.calls[0].InputTokens)
+		assert.Zero(t, usage.calls[0].OutputTokens)
+		assert.Positive(t, usage.calls[0].Duration)
+	})
+
+	t.Run("a nil recorder records nothing and changes nothing", func(t *testing.T) {
+		client := newStubbedClient(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"candidates":[{"finishReason":"STOP",
+				"content":{"role":"model","parts":[{"text":"hallo"}]}}]}`))
+		})
+
+		out, err := client.Translate(context.Background(), "system", "hello")
+		require.NoError(t, err)
+		assert.Equal(t, "hallo", out)
+	})
+}
+
+// TestConstructorsStampTheirProvider pins the two backends apart. They are billed separately, so a
+// cost dashboard that cannot tell AI Studio from Vertex is reporting one number for two bills.
+func TestConstructorsStampTheirProvider(t *testing.T) {
+	client, err := NewClient(context.Background(), "test-key-placeholder", WithModel("gemini-2.5-flash"))
+	require.NoError(t, err)
+	assert.Equal(t, llm.ProviderGCPGemini, client.provider,
+		"the API-key path is AI Studio")
+
+	vertex, err := NewGoogleGeminiClient(context.Background(), "test-project", "europe-west3",
+		WithModel("gemini-2.5-flash"))
+	if err != nil {
+		t.Skipf("vertex client needs Application Default Credentials: %v", err)
+	}
+
+	assert.Equal(t, llm.ProviderGCPVertexAI, vertex.provider, "the ADC path is Vertex")
+}
+
+// zeroVector renders a JSON array of n zeros, for stubbing an embedding response of the right size.
+func zeroVector(n int) string {
+	values := make([]string, n)
+	for i := range values {
+		values[i] = "0.1"
+	}
+
+	return "[" + strings.Join(values, ",") + "]"
 }

--- a/internal/huberrors/terminal.go
+++ b/internal/huberrors/terminal.go
@@ -78,9 +78,14 @@ func (e *TerminalProviderError) Unwrap() error { return e.Err }
 // TerminalReasonOf returns the reason carried by the first TerminalProviderError in err's chain,
 // and whether one was found. It keeps the errors.As dance in one place for callers that record
 // the reason as a label or a column.
+//
+// A terminal error with no reason reports false rather than an empty string with ok=true. The
+// exported sentinel is exactly that shape, and callers write this value into a CHECK-constrained
+// column: handing back "" past their ok guard would fail the insert on the failure path, which is
+// the worst place to discover it.
 func TerminalReasonOf(err error) (TerminalReason, bool) {
 	var terminal *TerminalProviderError
-	if !errors.As(err, &terminal) {
+	if !errors.As(err, &terminal) || terminal.Reason == "" {
 		return "", false
 	}
 

--- a/internal/huberrors/terminal.go
+++ b/internal/huberrors/terminal.go
@@ -1,0 +1,88 @@
+package huberrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrTerminalProvider represents a provider outcome that is permanent for the given input.
+// Use with errors.Is to test whether retrying is pointless.
+var ErrTerminalProvider = &TerminalProviderError{}
+
+// TerminalReason names why the provider will never produce a result for this input. The set is
+// closed and small so it is safe as a metric label, as a database CHECK, and as a UI string.
+type TerminalReason string
+
+const (
+	// TerminalReasonContentFilter is a safety / content-policy block. The provider examined the
+	// text and declined to process it.
+	TerminalReasonContentFilter TerminalReason = "content_filter"
+	// TerminalReasonRefusal is the model explicitly declining, returned as a refusal message
+	// rather than as a filter verdict.
+	TerminalReasonRefusal TerminalReason = "refusal"
+	// TerminalReasonLength is the input or output exceeding what the model can handle. Permanent
+	// for this text at this model, though it can change if either one changes.
+	TerminalReasonLength TerminalReason = "length"
+	// TerminalReasonRecitation is the provider suppressing output that reproduces training data.
+	TerminalReasonRecitation TerminalReason = "recitation"
+)
+
+// TerminalProviderError marks a provider failure that is a property of the INPUT, not of the
+// provider's health. Retrying it is guaranteed to fail again and costs a call every time.
+//
+// This distinction is the whole point of the type. A 500 and a content-filter block are both
+// "the provider did not give us a result", but one succeeds on the next attempt and the other
+// never will. Collapsing them means either abandoning records that would have worked, or
+// retrying records that cannot, forever — and any reconciler that re-enqueues unfinished work
+// will loop on the latter until something tells it to stop.
+//
+// Classification is deliberately CONSERVATIVE: only outcomes known to be determined by the
+// content are terminal, and anything ambiguous stays retryable. The asymmetry is intentional —
+// a false terminal permanently abandons a record, while a false transient only wastes a few
+// calls.
+type TerminalProviderError struct {
+	Reason TerminalReason
+	Err    error
+}
+
+// NewTerminalProviderError wraps err as a terminal provider failure with the given reason.
+func NewTerminalProviderError(reason TerminalReason, err error) *TerminalProviderError {
+	return &TerminalProviderError{Reason: reason, Err: err}
+}
+
+// Error implements the error interface.
+func (e *TerminalProviderError) Error() string {
+	reason := string(e.Reason)
+	if reason == "" {
+		reason = "unspecified"
+	}
+
+	if e.Err != nil {
+		return fmt.Sprintf("terminal provider failure (%s): %v", reason, e.Err)
+	}
+
+	return fmt.Sprintf("terminal provider failure (%s)", reason)
+}
+
+// Is implements error comparison so errors.Is(err, ErrTerminalProvider) matches any reason.
+// Callers that need the specific reason use errors.As.
+func (e *TerminalProviderError) Is(target error) bool {
+	_, ok := target.(*TerminalProviderError)
+
+	return ok
+}
+
+// Unwrap exposes the underlying provider error for errors.Is/As.
+func (e *TerminalProviderError) Unwrap() error { return e.Err }
+
+// TerminalReasonOf returns the reason carried by the first TerminalProviderError in err's chain,
+// and whether one was found. It keeps the errors.As dance in one place for callers that record
+// the reason as a label or a column.
+func TerminalReasonOf(err error) (TerminalReason, bool) {
+	var terminal *TerminalProviderError
+	if !errors.As(err, &terminal) {
+		return "", false
+	}
+
+	return terminal.Reason, true
+}

--- a/internal/huberrors/terminal_test.go
+++ b/internal/huberrors/terminal_test.go
@@ -1,0 +1,60 @@
+package huberrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalProviderError(t *testing.T) {
+	cause := errors.New("model refused")
+	err := NewTerminalProviderError(TerminalReasonRefusal, cause)
+
+	t.Run("matches the sentinel regardless of reason", func(t *testing.T) {
+		require.ErrorIs(t, err, ErrTerminalProvider)
+		require.ErrorIs(t, NewTerminalProviderError(TerminalReasonLength, nil), ErrTerminalProvider)
+	})
+
+	t.Run("survives wrapping", func(t *testing.T) {
+		// The worker sees this error only after the service layer has wrapped it with operation
+		// context, so matching has to work through the chain rather than on the bare value.
+		wrapped := fmt.Errorf("classify sentiment: %w", fmt.Errorf("openai: %w", err))
+
+		require.ErrorIs(t, wrapped, ErrTerminalProvider)
+
+		reason, ok := TerminalReasonOf(wrapped)
+		require.True(t, ok)
+		assert.Equal(t, TerminalReasonRefusal, reason)
+	})
+
+	t.Run("unwraps to the provider cause", func(t *testing.T) {
+		require.ErrorIs(t, err, cause)
+	})
+
+	t.Run("a plain error is not terminal", func(t *testing.T) {
+		// The distinction this type exists for: an ordinary provider failure must NOT be
+		// mistaken for a permanent one, or the record is abandoned.
+		plain := fmt.Errorf("openai chat completion: %w", errors.New("500 internal server error"))
+
+		require.NotErrorIs(t, plain, ErrTerminalProvider)
+
+		_, ok := TerminalReasonOf(plain)
+		assert.False(t, ok)
+	})
+
+	t.Run("a rate limit is not terminal", func(t *testing.T) {
+		// Both are provider failures; only one is permanent. Confusing them would either abandon
+		// throttled records or retry filtered ones forever.
+		limited := NewRateLimitError(0, errors.New("429"))
+
+		require.NotErrorIs(t, limited, ErrTerminalProvider)
+	})
+
+	t.Run("nil error is safe to report", func(t *testing.T) {
+		_, ok := TerminalReasonOf(nil)
+		assert.False(t, ok)
+	})
+}

--- a/internal/huberrors/terminal_test.go
+++ b/internal/huberrors/terminal_test.go
@@ -58,3 +58,18 @@ func TestTerminalProviderError(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+// TestTerminalReasonOfRejectsEmptyReason guards the sharp edge on the exported sentinel: callers
+// write the returned reason into a CHECK-constrained column, so reporting ok with an empty string
+// would fail that insert on the failure path, where it is least likely to be noticed.
+func TestTerminalReasonOfRejectsEmptyReason(t *testing.T) {
+	_, ok := TerminalReasonOf(ErrTerminalProvider)
+	assert.False(t, ok, "the bare sentinel carries no reason and must not report one")
+
+	_, ok = TerminalReasonOf(NewTerminalProviderError("", errors.New("boom")))
+	assert.False(t, ok, "a reasonless terminal error must not report a reason")
+
+	// Terminality is still detected — only the reason is withheld, so a reasonless error is not
+	// silently downgraded to retryable.
+	require.ErrorIs(t, NewTerminalProviderError("", errors.New("boom")), ErrTerminalProvider)
+}

--- a/internal/llm/usage.go
+++ b/internal/llm/usage.go
@@ -2,6 +2,8 @@ package llm
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"time"
 )
 
@@ -58,4 +60,65 @@ type Usage struct {
 // recorder means usage is not recorded and the client behaves exactly as before.
 type UsageRecorder interface {
 	RecordUsage(ctx context.Context, usage Usage)
+}
+
+// Record sends one call's usage to recorder, or does nothing when recorder is nil.
+//
+// Both provider clients build the same struct from the same six inputs and both had to remember
+// the nil check; this keeps that shape in one place so the two cannot drift on what a Usage means.
+// What stays with each client is the part that genuinely differs: pulling token counts out of a
+// provider-shaped response, and mapping a provider-shaped error to a bounded class.
+func Record(
+	ctx context.Context, recorder UsageRecorder,
+	operation Operation, provider Provider, model string,
+	started time.Time, inputTokens, outputTokens int64, errorType string,
+) {
+	if recorder == nil {
+		return
+	}
+
+	recorder.RecordUsage(ctx, Usage{
+		Operation:    operation,
+		Provider:     provider,
+		Model:        model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		Duration:     time.Since(started),
+		ErrorType:    errorType,
+	})
+}
+
+// Bounded error.type values shared by both clients. An HTTP status becomes its own number; these
+// cover what has no status.
+const (
+	// ErrorTypeTimeout is a deadline the caller set, not one the provider reported.
+	ErrorTypeTimeout = "timeout"
+	// ErrorTypeCancelled is the surrounding context going away — a shutdown, usually.
+	ErrorTypeCancelled = "cancelled"
+	// ErrorTypeOther is everything else, deliberately vague. The alternative is the provider's own
+	// message, which is unbounded and would blow up metric cardinality the first time a provider
+	// echoed user input back in an error.
+	ErrorTypeOther = "other"
+)
+
+// ClassifyError maps an error to a bounded error.type. status extracts a provider-specific HTTP
+// status when the error carries one; it is the only part that differs between providers.
+func ClassifyError(err error, status func(error) (int, bool)) string {
+	if err == nil {
+		return ""
+	}
+
+	if code, ok := status(err); ok && code != 0 {
+		return strconv.Itoa(code)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrorTypeTimeout
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return ErrorTypeCancelled
+	}
+
+	return ErrorTypeOther
 }

--- a/internal/llm/usage.go
+++ b/internal/llm/usage.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"context"
+	"time"
+)
+
+// Operation names the kind of provider call, following the OpenTelemetry GenAI semantic
+// conventions' well-known values for gen_ai.operation.name.
+type Operation string
+
+const (
+	// OperationChat is a chat-completion call — sentiment, emotions and translation all use one.
+	OperationChat Operation = "chat"
+	// OperationEmbeddings is an embeddings call.
+	OperationEmbeddings Operation = "embeddings"
+)
+
+// Provider names the GenAI provider, following the conventions' well-known values for
+// gen_ai.provider.name. Not the Hub's own provider identifiers: "google" is `gcp.vertex_ai` or
+// `gcp.gemini` there, depending on the endpoint.
+const (
+	ProviderOpenAI Provider = "openai"
+	// ProviderGCPVertexAI is the aiplatform.googleapis.com endpoint, which is what the Hub's
+	// Google client uses when a project and location are configured.
+	ProviderGCPVertexAI Provider = "gcp.vertex_ai"
+	// ProviderGCPGemini is the generativelanguage.googleapis.com endpoint (AI Studio).
+	ProviderGCPGemini Provider = "gcp.gemini"
+)
+
+// Provider is a gen_ai.provider.name value.
+type Provider string
+
+// Usage is one provider call's cost and outcome, in provider-agnostic terms.
+//
+// It exists because both clients were discarding the `usage` block every provider returns, which
+// left no way to answer what enrichment actually costs — not per tenant, not per enrichment, not
+// in total. Recording it is nearly free: the number is already in the response.
+type Usage struct {
+	Operation Operation
+	Provider  Provider
+	// Model is the model the request asked for (gen_ai.request.model).
+	Model string
+	// InputTokens and OutputTokens are the provider's own counts. Zero when it reported none —
+	// which is not the same as a call that cost nothing, so recorders skip rather than emit zero.
+	InputTokens  int64
+	OutputTokens int64
+	// Duration is the wall time of the call, successful or not.
+	Duration time.Duration
+	// ErrorType is the error.type attribute: a SHORT, BOUNDED class such as "timeout" or a status
+	// code — never a provider message. Empty when the call succeeded. Unbounded values here would
+	// blow up metric cardinality, which is why the clients map rather than pass through.
+	ErrorType string
+}
+
+// UsageRecorder receives one Usage per provider call. Declared here rather than in observability
+// so the provider clients depend on the behaviour, not on the metrics implementation; a nil
+// recorder means usage is not recorded and the client behaves exactly as before.
+type UsageRecorder interface {
+	RecordUsage(ctx context.Context, usage Usage)
+}

--- a/internal/models/enrichment_failure.go
+++ b/internal/models/enrichment_failure.go
@@ -2,6 +2,15 @@ package models
 
 import "github.com/google/uuid"
 
+// The enrichment names. These are the values in migration 022's CHECK, the `enrichment` metric
+// label, and the discriminator on every failure marker, so they are declared once rather than
+// spelled out at each use.
+const (
+	EnrichmentNameTranslation = "translation"
+	EnrichmentNameSentiment   = "sentiment"
+	EnrichmentNameEmotions    = "emotions"
+)
+
 // The two non-terminal reasons. Both mean "did not succeed this time"; they differ in which half
 // of the job failed, which is the difference between an incident with the provider and an incident
 // with our own database. The CHECK in migration 022 restricts non-terminal rows to these.

--- a/internal/models/enrichment_failure.go
+++ b/internal/models/enrichment_failure.go
@@ -2,11 +2,20 @@ package models
 
 import "github.com/google/uuid"
 
-// EnrichmentFailureReasonProviderError is the reason recorded when an enrichment exhausted its
-// retries against a failure that was NOT determined by the record's content — a 5xx, a timeout, a
-// response that could not be parsed. It is the only reason a non-terminal row may carry, enforced
-// by the CHECK in migration 022.
-const EnrichmentFailureReasonProviderError = "provider_error"
+// The two non-terminal reasons. Both mean "did not succeed this time"; they differ in which half
+// of the job failed, which is the difference between an incident with the provider and an incident
+// with our own database. The CHECK in migration 022 restricts non-terminal rows to these.
+const (
+	// EnrichmentFailureReasonProviderError is recorded when an enrichment exhausted its retries
+	// against a provider failure that was NOT determined by the record's content — a 5xx, a
+	// timeout, a response that could not be parsed.
+	EnrichmentFailureReasonProviderError = "provider_error"
+	// EnrichmentFailureReasonWriteFailed is recorded when the provider answered but the result
+	// could not be persisted before the attempts ran out. The record is exactly as un-enriched as
+	// a provider failure leaves it, and telling the two apart is what stops an operator hunting a
+	// provider outage that never happened.
+	EnrichmentFailureReasonWriteFailed = "write_failed"
+)
 
 // EnrichmentFailure is one record's failed enrichment, as written by the worker after the last
 // attempt is spent.

--- a/internal/models/enrichment_failure.go
+++ b/internal/models/enrichment_failure.go
@@ -1,0 +1,34 @@
+package models
+
+import "github.com/google/uuid"
+
+// EnrichmentFailureReasonProviderError is the reason recorded when an enrichment exhausted its
+// retries against a failure that was NOT determined by the record's content — a 5xx, a timeout, a
+// response that could not be parsed. It is the only reason a non-terminal row may carry, enforced
+// by the CHECK in migration 022.
+const EnrichmentFailureReasonProviderError = "provider_error"
+
+// EnrichmentFailure is one record's failed enrichment, as written by the worker after the last
+// attempt is spent.
+//
+// Terminal separates "will never succeed" from "did not succeed this time". Only the first is a
+// property of the record's own text, and only the first may be skipped by anything that
+// re-enqueues unfinished work — a transient failure left permanently skipped is a record silently
+// abandoned.
+//
+// The row is advisory: readers report a failure only when the record is also still un-enriched,
+// so a later success needs no cleanup write and cannot be contradicted by a stale row.
+type EnrichmentFailure struct {
+	FeedbackRecordID uuid.UUID
+	// TenantID is the record's own tenant, read from the record rather than from anything the
+	// caller supplied. It exists on this table to support the per-tenant index and must never be
+	// used as the tenant boundary in a query — see migration 022.
+	TenantID   string
+	Enrichment string
+	// Terminal and Reason are one decision. The database enforces that they agree, so callers must
+	// not set Terminal true with EnrichmentFailureReasonProviderError or the write is rejected.
+	Terminal bool
+	Reason   string
+	// Attempts spent before giving up. Diagnostic only.
+	Attempts int
+}

--- a/internal/models/enrichment_status.go
+++ b/internal/models/enrichment_status.go
@@ -1,22 +1,53 @@
 package models
 
+import "time"
+
+// DisabledReason names the gate that switched an enrichment off for a tenant. It exists because
+// `enabled: false` alone is unactionable: an operator who has not configured a provider, a tenant
+// that turned the enrichment off, and a tenant with no resolvable translation target are three
+// different problems with three different fixes, and the UI cannot tell them apart from a bool.
+//
+// The value set is closed and small so it is safe as a metric label and as a UI translation key.
+type DisabledReason string
+
+const (
+	// DisabledReasonNotConfigured means the deployment has no provider+model for this enrichment,
+	// so it is off for every tenant. Fixed by the operator, not by the tenant.
+	DisabledReasonNotConfigured DisabledReason = "not_configured"
+	// DisabledReasonSwitchedOff means the deployment is configured but this tenant has explicitly
+	// turned the enrichment off (the tri-state per-directory switch). Sentiment and emotions only.
+	DisabledReasonSwitchedOff DisabledReason = "switched_off"
+	// DisabledReasonNoTargetLanguage means translation is configured but neither the tenant's own
+	// target_language nor the deployment default resolves, so there is nothing to translate into.
+	// Translation only — it has no on/off switch, an absent target IS the off state.
+	DisabledReasonNoTargetLanguage DisabledReason = "no_target_language"
+)
+
 // EnrichmentTypeStatus is one tenant's progress for a single record-level enrichment
 // (translation, sentiment, or emotions). Enabled reports whether the enrichment is both
 // deployment-configured and switched on for the tenant (for translation: has a resolvable
 // target language). Eligible is the number of feedback records that qualify for the
 // enrichment; Done is how many have been enriched. The UI derives "in progress" as
 // Eligible - Done. When Enabled is false, Eligible and Done are zero (no work will run).
+//
+// DisabledReason is present exactly when Enabled is false, and absent otherwise — the two are
+// derived from one decision (see enrichmentTypeStatus), so they cannot contradict each other.
 type EnrichmentTypeStatus struct {
-	Enabled  bool  `json:"enabled"`
-	Eligible int64 `json:"eligible"`
-	Done     int64 `json:"done"`
+	Enabled        bool           `json:"enabled"`
+	Eligible       int64          `json:"eligible"`
+	Done           int64          `json:"done"`
+	DisabledReason DisabledReason `json:"disabled_reason,omitempty"`
 }
 
 // EnrichmentStatusResponse reports a tenant's enrichment progress across the record-level
 // enrichments. Counts are directory-level totals; the response never includes record
 // identifiers or feedback content.
 type EnrichmentStatusResponse struct {
-	TenantID    string               `json:"tenant_id"`
+	TenantID string `json:"tenant_id"`
+	// AsOf is when the counts were computed, not when the response was serialized. The endpoint is
+	// polled, so a client holding two responses can derive throughput and an ETA from the change in
+	// Done over the change in AsOf without the Hub computing either.
+	AsOf        time.Time            `json:"as_of"`
 	Translation EnrichmentTypeStatus `json:"translation"`
 	Sentiment   EnrichmentTypeStatus `json:"sentiment"`
 	Emotions    EnrichmentTypeStatus `json:"emotions"`

--- a/internal/models/enrichment_status.go
+++ b/internal/models/enrichment_status.go
@@ -33,9 +33,20 @@ const (
 // DisabledReason is present exactly when Enabled is false, and absent otherwise — the two are
 // derived from one decision (see enrichmentTypeStatus), so they cannot contradict each other.
 type EnrichmentTypeStatus struct {
-	Enabled        bool           `json:"enabled"`
-	Eligible       int64          `json:"eligible"`
-	Done           int64          `json:"done"`
+	Enabled  bool  `json:"enabled"`
+	Eligible int64 `json:"eligible"`
+	Done     int64 `json:"done"`
+	// Failed is eligible records whose last attempt gave up but which a retry could still rescue —
+	// a provider outage, a timeout. FailedTerminal is those the provider will never accept,
+	// because the outcome is a property of the record's own text: a content-policy block, a
+	// refusal, an input past the model's limit.
+	//
+	// The split is the difference between "3 failed — retry" and "1 can't be processed", and it is
+	// also what stops anything re-enqueueing unfinished work from looping on the second group
+	// forever. Both count only while the record is still un-enriched, so a later success removes it
+	// from either without a cleanup write.
+	Failed         int64          `json:"failed"`
+	FailedTerminal int64          `json:"failed_terminal"`
 	DisabledReason DisabledReason `json:"disabled_reason,omitempty"`
 }
 

--- a/internal/observability/aggregate.go
+++ b/internal/observability/aggregate.go
@@ -22,7 +22,10 @@ type Metrics struct {
 	EnrichmentClear EnrichmentClearMetrics
 	// EnrichmentBacklog gauges the aggregate eligible-but-unenriched record count per enrichment.
 	EnrichmentBacklog EnrichmentBacklogMetrics
-	Taxonomy          TaxonomyMetrics
+	// EnrichmentFailures counts permanent give-ups by cause and gauges how many records are
+	// currently failed. Carries the enrichment as a label rather than in the metric name.
+	EnrichmentFailures EnrichmentFailureMetrics
+	Taxonomy           TaxonomyMetrics
 }
 
 // NewMetrics creates EventMetrics, WebhookMetrics, EmbeddingMetrics, TranslationMetrics, and CacheMetrics from the given meter.
@@ -78,21 +81,27 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("enrichment backlog metrics: %w", err)
 	}
 
+	enrichmentFailures, err := NewEnrichmentFailureMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("create enrichment failure metrics: %w", err)
+	}
+
 	taxonomy, err := NewTaxonomyMetrics(meter)
 	if err != nil {
 		return nil, fmt.Errorf("taxonomy metrics: %w", err)
 	}
 
 	return &Metrics{
-		Events:            events,
-		Webhooks:          webhooks,
-		Embeddings:        embeddings,
-		Translation:       translation,
-		Sentiment:         sentiment,
-		Emotions:          emotions,
-		Cache:             cache,
-		EnrichmentClear:   enrichmentClear,
-		EnrichmentBacklog: enrichmentBacklog,
-		Taxonomy:          taxonomy,
+		Events:             events,
+		Webhooks:           webhooks,
+		Embeddings:         embeddings,
+		Translation:        translation,
+		Sentiment:          sentiment,
+		Emotions:           emotions,
+		Cache:              cache,
+		EnrichmentClear:    enrichmentClear,
+		EnrichmentBacklog:  enrichmentBacklog,
+		EnrichmentFailures: enrichmentFailures,
+		Taxonomy:           taxonomy,
 	}, nil
 }

--- a/internal/observability/enrichment_failures.go
+++ b/internal/observability/enrichment_failures.go
@@ -1,0 +1,110 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// EnrichmentFailureMetrics reports enrichment failures: a counter of permanent give-ups by cause,
+// and a gauge of how many records are currently sitting failed.
+//
+// Deliberately a NEW metric family rather than more columns on the four per-type families
+// (hub_sentiment_*, hub_emotions_*, …). Those carry the enrichment in the metric NAME, which is
+// the thing a pending consolidation will change; this one carries it as a label from the start, so
+// it is already in the shape that consolidation is heading for and will not need renaming twice.
+type EnrichmentFailureMetrics interface {
+	// RecordTerminalFailure counts one record given up on permanently. The reason is what makes
+	// this worth having: "we are losing 5% of records to the content filter" is not answerable
+	// from any existing signal, and it is a very different operational problem from a provider
+	// being down.
+	RecordTerminalFailure(ctx context.Context, enrichment, reason string)
+	// SetFailedRecords reports how many records are currently failed and still un-enriched, split
+	// by whether a retry could help. Refreshed by the same leader-elected poller as the backlog
+	// gauge, so exactly one replica publishes it.
+	SetFailedRecords(enrichment string, terminal bool, count int64)
+	// ClearFailedRecords withdraws every series this process publishes, for the same reason
+	// ClearEnrichmentPending exists: an async gauge re-observes stored values on every collection,
+	// so a process that loses leadership would otherwise export a frozen copy alongside the new
+	// leader's live one forever.
+	ClearFailedRecords()
+}
+
+// AttrTerminal labels the failed-records gauge with whether the failure is permanent. Two values,
+// so cardinality is bounded.
+const AttrTerminal = "terminal"
+
+type enrichmentFailureMetrics struct {
+	terminal metric.Int64Counter
+
+	mu     sync.Mutex
+	failed map[failedKey]int64
+}
+
+type failedKey struct {
+	enrichment string
+	terminal   bool
+}
+
+// NewEnrichmentFailureMetrics builds the failure metrics. Returns (nil, nil) when meter is nil
+// (metrics disabled); callers propagate that as a nil interface and the worker skips recording.
+func NewEnrichmentFailureMetrics(meter metric.Meter) (EnrichmentFailureMetrics, error) {
+	if meter == nil {
+		return nil, nil //nolint:nilnil // intentional: callers translate nil into "metrics disabled"
+	}
+
+	terminal, err := meter.Int64Counter(MetricNameEnrichmentTerminalTotal,
+		metric.WithDescription(
+			"Records given up on permanently, by enrichment and cause. These never resolve on "+
+				"their own: the outcome is a property of the record's own text."))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEnrichmentTerminalTotal, err)
+	}
+
+	failureMetrics := &enrichmentFailureMetrics{terminal: terminal, failed: map[failedKey]int64{}}
+
+	_, err = meter.Int64ObservableGauge(MetricNameEnrichmentFailedRecords,
+		metric.WithDescription(
+			"Records whose last enrichment attempt failed and which are still un-enriched, "+
+				"split by whether a retry could help."),
+		metric.WithInt64Callback(func(_ context.Context, observer metric.Int64Observer) error {
+			failureMetrics.mu.Lock()
+			defer failureMetrics.mu.Unlock()
+
+			for key, count := range failureMetrics.failed {
+				observer.Observe(count, metric.WithAttributes(
+					attribute.String(AttrEnrichment, key.enrichment),
+					attribute.Bool(AttrTerminal, key.terminal)))
+			}
+
+			return nil
+		}))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameEnrichmentFailedRecords, err)
+	}
+
+	return failureMetrics, nil
+}
+
+func (e *enrichmentFailureMetrics) RecordTerminalFailure(ctx context.Context, enrichment, reason string) {
+	e.terminal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(AttrEnrichment, enrichment),
+		attribute.String(AttrReason, reason)))
+}
+
+func (e *enrichmentFailureMetrics) SetFailedRecords(enrichment string, terminal bool, count int64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.failed[failedKey{enrichment: enrichment, terminal: terminal}] = count
+}
+
+func (e *enrichmentFailureMetrics) ClearFailedRecords() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.failed = map[failedKey]int64{}
+}

--- a/internal/observability/genai.go
+++ b/internal/observability/genai.go
@@ -1,0 +1,115 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/formbricks/hub/internal/llm"
+)
+
+// OpenTelemetry GenAI semantic conventions.
+//
+// These names are NOT the hub_* Prometheus-style ones used elsewhere in this package, and that is
+// deliberate: any OTel-native backend already understands gen_ai.*, so a cost dashboard works
+// without per-deployment configuration. The mixed styles in one binary look inconsistent but are
+// correct — the Prometheus exporter appends _total/_seconds suffixes on export, while these carry
+// UCUM units instead.
+//
+// The conventions moved to their own repository (open-telemetry/semantic-conventions-genai) on
+// 2026-06-12 with semconv v1.42.0, and every gen_ai.* attribute and metric is still marked
+// Development rather than Stable. Pinned here so a future reader knows which revision this
+// matched; expect churn.
+// word "token", not credentials.
+//
+//nolint:gosec // G101 false positive: these are metric and attribute NAMES containing the
+const (
+	MetricNameGenAITokenUsage        = "gen_ai.client.token.usage"
+	MetricNameGenAIOperationDuration = "gen_ai.client.operation.duration"
+)
+
+// GenAI attribute keys, all Required or Conditionally Required for the two metrics above except
+// error.type, which is Stable and applies only to failures.
+//
+//nolint:gosec // G101 false positive: attribute names, not credentials.
+const (
+	AttrGenAIOperationName = "gen_ai.operation.name"
+	AttrGenAIProviderName  = "gen_ai.provider.name"
+	AttrGenAITokenType     = "gen_ai.token.type"
+	AttrGenAIRequestModel  = "gen_ai.request.model"
+	AttrErrorType          = "error.type"
+)
+
+// Token type values for gen_ai.token.type.
+const (
+	genAITokenTypeInput  = "input"
+	genAITokenTypeOutput = "output"
+)
+
+// genAIMetrics implements llm.UsageRecorder against OTel instruments.
+type genAIMetrics struct {
+	tokens   metric.Int64Histogram
+	duration metric.Float64Histogram
+}
+
+// NewGenAIMetrics builds the GenAI usage recorder. Returns nil when meter is nil (metrics
+// disabled), and callers pass that straight through — the provider clients treat a nil recorder as
+// "do not record" rather than nil-checking at every call site.
+func NewGenAIMetrics(meter metric.Meter) (llm.UsageRecorder, error) {
+	if meter == nil {
+		return nil, nil //nolint:nilnil // intentional: a nil recorder disables recording
+	}
+
+	tokens, err := meter.Int64Histogram(MetricNameGenAITokenUsage,
+		metric.WithDescription("Number of input and output tokens used."),
+		metric.WithUnit("{token}"))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameGenAITokenUsage, err)
+	}
+
+	duration, err := meter.Float64Histogram(MetricNameGenAIOperationDuration,
+		metric.WithDescription("GenAI operation duration."),
+		metric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", MetricNameGenAIOperationDuration, err)
+	}
+
+	return &genAIMetrics{tokens: tokens, duration: duration}, nil
+}
+
+// RecordUsage emits one call's duration and, when the provider reported them, its token counts.
+//
+// tenant_id is deliberately absent. It is unbounded, and the same rule already applies to the
+// enrichment backlog gauge: aggregate cost belongs in metrics, per-tenant cost is answered from
+// the record counts the status endpoint already returns.
+func (g *genAIMetrics) RecordUsage(ctx context.Context, usage llm.Usage) {
+	base := []attribute.KeyValue{
+		attribute.String(AttrGenAIOperationName, string(usage.Operation)),
+		attribute.String(AttrGenAIProviderName, string(usage.Provider)),
+	}
+
+	durationAttrs := base
+	if usage.Model != "" {
+		durationAttrs = append(durationAttrs, attribute.String(AttrGenAIRequestModel, usage.Model))
+	}
+
+	if usage.ErrorType != "" {
+		durationAttrs = append(durationAttrs, attribute.String(AttrErrorType, usage.ErrorType))
+	}
+
+	g.duration.Record(ctx, usage.Duration.Seconds(), metric.WithAttributes(durationAttrs...))
+
+	// Zero is not "cost nothing" — it is "the provider told us nothing", which happens on every
+	// failed call. Emitting it would drag the average down and make a provider outage look cheap.
+	if usage.InputTokens > 0 {
+		g.tokens.Record(ctx, usage.InputTokens, metric.WithAttributes(
+			append(base, attribute.String(AttrGenAITokenType, genAITokenTypeInput))...))
+	}
+
+	if usage.OutputTokens > 0 {
+		g.tokens.Record(ctx, usage.OutputTokens, metric.WithAttributes(
+			append(base, attribute.String(AttrGenAITokenType, genAITokenTypeOutput))...))
+	}
+}

--- a/internal/observability/genai_test.go
+++ b/internal/observability/genai_test.go
@@ -1,0 +1,114 @@
+package observability
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/formbricks/hub/internal/llm"
+)
+
+// collect runs the recorder against a real SDK meter and returns what was actually exported, so
+// these assertions are about emitted metrics rather than about calls into an interface.
+func collect(t *testing.T, record func(llm.UsageRecorder)) metricdata.ResourceMetrics {
+	t.Helper()
+
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	recorder, err := NewGenAIMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+	require.NotNil(t, recorder)
+
+	record(recorder)
+
+	var got metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &got))
+
+	return got
+}
+
+func instrument(t *testing.T, got metricdata.ResourceMetrics, name string) metricdata.Aggregation {
+	t.Helper()
+
+	for _, scope := range got.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+
+	t.Fatalf("instrument %q was not exported", name)
+
+	return nil
+}
+
+func TestGenAIMetricsExportTheConventionNames(t *testing.T) {
+	got := collect(t, func(r llm.UsageRecorder) {
+		r.RecordUsage(context.Background(), llm.Usage{
+			Operation: llm.OperationChat, Provider: llm.ProviderOpenAI, Model: "gpt-4o-mini",
+			InputTokens: 40, OutputTokens: 12, Duration: 250 * time.Millisecond,
+		})
+	})
+
+	// The names are the contract: an OTel-native backend recognises gen_ai.* without any
+	// per-deployment configuration, which is the reason for not using a hub_* name here.
+	tokens, ok := instrument(t, got, MetricNameGenAITokenUsage).(metricdata.Histogram[int64])
+	require.True(t, ok, "token usage must be an int64 histogram")
+	assert.Len(t, tokens.DataPoints, 2, "input and output are separate series, not one total")
+
+	_, ok = instrument(t, got, MetricNameGenAIOperationDuration).(metricdata.Histogram[float64])
+	require.True(t, ok, "operation duration must be a float64 histogram")
+}
+
+func TestGenAIMetricsOmitZeroTokenCounts(t *testing.T) {
+	// A failed call reports no usage block. Recording zero would drag the average down and make a
+	// provider outage look cheap, so the token series must simply not be emitted.
+	got := collect(t, func(r llm.UsageRecorder) {
+		r.RecordUsage(context.Background(), llm.Usage{
+			Operation: llm.OperationChat, Provider: llm.ProviderOpenAI, Model: "m",
+			Duration: 3 * time.Second, ErrorType: "500",
+		})
+	})
+
+	for _, scope := range got.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			assert.NotEqual(t, MetricNameGenAITokenUsage, m.Name,
+				"a call with no reported tokens must emit no token series")
+		}
+	}
+
+	duration, ok := instrument(t, got, MetricNameGenAIOperationDuration).(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, duration.DataPoints, 1, "the failed call is still timed")
+}
+
+func TestGenAIMetricsCarryNoTenantLabel(t *testing.T) {
+	// tenant_id is unbounded. The same rule already governs the enrichment backlog gauge: aggregate
+	// cost belongs in metrics, per-tenant cost is answered from the counts the API already returns.
+	got := collect(t, func(r llm.UsageRecorder) {
+		r.RecordUsage(context.Background(), llm.Usage{
+			Operation: llm.OperationEmbeddings, Provider: llm.ProviderOpenAI, Model: "m",
+			InputTokens: 8, Duration: time.Millisecond,
+		})
+	})
+
+	for _, scope := range got.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if hist, ok := m.Data.(metricdata.Histogram[int64]); ok {
+				for _, dp := range hist.DataPoints {
+					for _, attr := range dp.Attributes.ToSlice() {
+						assert.NotContains(t, string(attr.Key), "tenant",
+							"no tenant dimension may reach a metric label")
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/observability/genai_test.go
+++ b/internal/observability/genai_test.go
@@ -112,3 +112,45 @@ func TestGenAIMetricsCarryNoTenantLabel(t *testing.T) {
 		}
 	}
 }
+
+// TestFailedRecordsGaugeWithdrawsOnClear pins the withdraw-not-stale rule. An async gauge
+// re-observes its stored values on every collection, so a value left behind after a failed refresh
+// or a lost leadership keeps being exported indefinitely — indistinguishable from a live reading,
+// and invisible to any alert that looks for staleness by value.
+func TestFailedRecordsGaugeWithdrawsOnClear(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	failures, err := NewEnrichmentFailureMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+	require.NotNil(t, failures)
+
+	failures.SetFailedRecords(EnrichmentTypeSentiment, true, 7)
+
+	var got metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &got))
+	require.Positive(t, countDataPoints(got, MetricNameEnrichmentFailedRecords),
+		"the gauge publishes what was set")
+
+	failures.ClearFailedRecords()
+
+	require.NoError(t, reader.Collect(context.Background(), &got))
+	assert.Zero(t, countDataPoints(got, MetricNameEnrichmentFailedRecords),
+		"after withdrawal the series must be ABSENT, not frozen at its last value")
+}
+
+func countDataPoints(got metricdata.ResourceMetrics, name string) int {
+	for _, scope := range got.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+
+			if gauge, ok := m.Data.(metricdata.Gauge[int64]); ok {
+				return len(gauge.DataPoints)
+			}
+		}
+	}
+
+	return 0
+}

--- a/internal/observability/genai_test.go
+++ b/internal/observability/genai_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -89,28 +90,124 @@ func TestGenAIMetricsOmitZeroTokenCounts(t *testing.T) {
 	require.Len(t, duration.DataPoints, 1, "the failed call is still timed")
 }
 
-func TestGenAIMetricsCarryNoTenantLabel(t *testing.T) {
-	// tenant_id is unbounded. The same rule already governs the enrichment backlog gauge: aggregate
-	// cost belongs in metrics, per-tenant cost is answered from the counts the API already returns.
-	got := collect(t, func(r llm.UsageRecorder) {
-		r.RecordUsage(context.Background(), llm.Usage{
-			Operation: llm.OperationEmbeddings, Provider: llm.ProviderOpenAI, Model: "m",
-			InputTokens: 8, Duration: time.Millisecond,
-		})
-	})
+// attributeKeys returns every attribute key the named instrument actually exported.
+//
+// It handles each aggregation shape explicitly and FAILS on an unrecognised one rather than
+// returning an empty set. That is the whole point: an earlier version of this check type-asserted
+// a single shape, so the duration histogram — a Float64Histogram, and the only instrument carrying
+// the model and the error class — was silently skipped by an assertion that appeared to cover
+// everything.
+func attributeKeys(t *testing.T, got metricdata.ResourceMetrics, name string) map[string]struct{} {
+	t.Helper()
+
+	keys := map[string]struct{}{}
+	add := func(set attribute.Set) {
+		for _, attr := range set.ToSlice() {
+			keys[string(attr.Key)] = struct{}{}
+		}
+	}
+
+	found := false
 
 	for _, scope := range got.ScopeMetrics {
 		for _, m := range scope.Metrics {
-			if hist, ok := m.Data.(metricdata.Histogram[int64]); ok {
-				for _, dp := range hist.DataPoints {
-					for _, attr := range dp.Attributes.ToSlice() {
-						assert.NotContains(t, string(attr.Key), "tenant",
-							"no tenant dimension may reach a metric label")
-					}
+			if m.Name != name {
+				continue
+			}
+
+			found = true
+
+			switch data := m.Data.(type) {
+			case metricdata.Histogram[int64]:
+				for _, dp := range data.DataPoints {
+					add(dp.Attributes)
 				}
+			case metricdata.Histogram[float64]:
+				for _, dp := range data.DataPoints {
+					add(dp.Attributes)
+				}
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					add(dp.Attributes)
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					add(dp.Attributes)
+				}
+			default:
+				t.Fatalf("instrument %q exports an unhandled aggregation %T: extend this helper "+
+					"rather than letting its attributes go unchecked", name, m.Data)
 			}
 		}
 	}
+
+	require.True(t, found, "instrument %q was not exported", name)
+
+	return keys
+}
+
+// assertAttributeKeys pins an instrument's attribute keys to an ALLOWLIST.
+//
+// A denylist ("no key contains tenant") only forbids what someone thought of. The two things that
+// must never reach a label here are unbounded tenant dimensions and GenAI content attributes —
+// gen_ai.input.messages / gen_ai.output.messages, which carry the prompt and the completion, i.e.
+// customer feedback text, and which off-the-shelf GenAI instrumentation enables by configuration.
+// Adding either fails this test; adding a legitimate attribute means updating the list here, which
+// is exactly the moment to think about what it costs.
+func assertAttributeKeys(t *testing.T, got metricdata.ResourceMetrics, name string, allowed ...string) {
+	t.Helper()
+
+	permitted := map[string]struct{}{}
+	for _, key := range allowed {
+		permitted[key] = struct{}{}
+	}
+
+	for key := range attributeKeys(t, got, name) {
+		_, ok := permitted[key]
+		assert.True(t, ok, "%s: attribute %q is not on the allowlist for this instrument", name, key)
+	}
+}
+
+func TestGenAIMetricsCarryOnlyAllowedAttributes(t *testing.T) {
+	// One success and one failure, so the model and the error class are both present: recording
+	// only a success would leave the two conditional attributes unexercised and the allowlist
+	// unproven for the shape that actually carries them.
+	got := collect(t, func(r llm.UsageRecorder) {
+		r.RecordUsage(context.Background(), llm.Usage{
+			Operation: llm.OperationChat, Provider: llm.ProviderOpenAI, Model: "gpt-4o-mini",
+			InputTokens: 40, OutputTokens: 12, Duration: 250 * time.Millisecond,
+		})
+		r.RecordUsage(context.Background(), llm.Usage{
+			Operation: llm.OperationEmbeddings, Provider: llm.ProviderGCPVertexAI, Model: "text-embedding-004",
+			Duration: 10 * time.Millisecond, ErrorType: "429",
+		})
+	})
+
+	assertAttributeKeys(t, got, MetricNameGenAITokenUsage,
+		AttrGenAIOperationName, AttrGenAIProviderName, AttrGenAITokenType)
+	assertAttributeKeys(t, got, MetricNameGenAIOperationDuration,
+		AttrGenAIOperationName, AttrGenAIProviderName, AttrGenAIRequestModel, AttrErrorType)
+}
+
+func TestEnrichmentFailureMetricsCarryOnlyAllowedAttributes(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	failures, err := NewEnrichmentFailureMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+	require.NotNil(t, failures)
+
+	failures.RecordTerminalFailure(context.Background(), EnrichmentTypeSentiment, "content_filter")
+	failures.SetFailedRecords(EnrichmentTypeTranslation, true, 3)
+
+	var got metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &got))
+
+	// The reason is aggregate-only for a reason: a per-tenant breakdown by cause would characterise
+	// one customer's content ("this tenant trips the content filter 30% of the time"), which is a
+	// statement about their data rather than about the deployment.
+	assertAttributeKeys(t, got, MetricNameEnrichmentTerminalTotal, AttrEnrichment, AttrReason)
+	assertAttributeKeys(t, got, MetricNameEnrichmentFailedRecords, AttrEnrichment, AttrTerminal)
 }
 
 // TestFailedRecordsGaugeWithdrawsOnClear pins the withdraw-not-stale rule. An async gauge

--- a/internal/observability/names.go
+++ b/internal/observability/names.go
@@ -17,12 +17,17 @@ const (
 	MetricNameEnrichmentOutputsCleared  = "hub_enrichment_outputs_cleared_total"
 	MetricNameEnrichmentPendingRecords  = "hub_enrichment_pending_records"
 	MetricNameEnrichmentBacklogPollErrs = "hub_enrichment_backlog_poll_errors_total"
-	MetricNameWebhookJobsEnqueued       = "hub_webhook_jobs_enqueued_total"
-	MetricNameWebhookProviderErrors     = "hub_webhook_provider_errors_total"
-	MetricNameWebhookDeliveries         = "hub_webhook_deliveries_total"
-	MetricNameWebhookDisabled           = "hub_webhook_disabled_total"
-	MetricNameWebhookDispatchErrors     = "hub_webhook_dispatch_errors_total"
-	MetricNameWebhookDeliveryDuration   = "hub_webhook_delivery_duration_seconds"
+	// MetricNameEnrichmentTerminalTotal and MetricNameEnrichmentFailedRecords carry the enrichment
+	// as a LABEL rather than in the name, unlike the four per-type families below — already the
+	// shape a consolidation would move those to.
+	MetricNameEnrichmentTerminalTotal = "hub_enrichment_terminal_total"
+	MetricNameEnrichmentFailedRecords = "hub_enrichment_failed_records"
+	MetricNameWebhookJobsEnqueued     = "hub_webhook_jobs_enqueued_total"
+	MetricNameWebhookProviderErrors   = "hub_webhook_provider_errors_total"
+	MetricNameWebhookDeliveries       = "hub_webhook_deliveries_total"
+	MetricNameWebhookDisabled         = "hub_webhook_disabled_total"
+	MetricNameWebhookDispatchErrors   = "hub_webhook_dispatch_errors_total"
+	MetricNameWebhookDeliveryDuration = "hub_webhook_delivery_duration_seconds"
 
 	// MetricNameEmbeddingJobsEnqueued and related embedding pipeline metrics.
 	MetricNameEmbeddingJobsEnqueued   = "hub_embedding_jobs_enqueued_total"

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -52,36 +52,16 @@ type Client struct {
 	// temperatureUnsupported latches once the configured model rejects the temperature
 	// parameter (reasoning models do), so later calls omit it instead of failing.
 	temperatureUnsupported atomic.Bool
+	// usage receives one record per provider call. nil disables recording entirely, which is how
+	// the backfill commands and the unit tests opt out.
+	usage llm.UsageRecorder
 }
 
-// ClientOption configures the Client.
-type ClientOption func(*Client)
-
-// WithDimensions sets the requested embedding dimension (must match DB column).
-func WithDimensions(dim int) ClientOption {
+// WithUsageRecorder attaches a recorder that receives each call's token counts and duration. The
+// provider returns those numbers on every response; without this they are decoded and dropped.
+func WithUsageRecorder(recorder llm.UsageRecorder) ClientOption {
 	return func(c *Client) {
-		c.dimensions = dim
-	}
-}
-
-// WithModel sets the embedding model name. Empty uses default.
-func WithModel(model string) ClientOption {
-	return func(c *Client) {
-		c.model = model
-	}
-}
-
-// WithBaseURL sets a custom OpenAI-compatible base URL (for example a self-hosted embeddings runtime).
-func WithBaseURL(baseURL string) ClientOption {
-	return func(c *Client) {
-		c.baseURL = baseURL
-	}
-}
-
-// WithNormalize enables L2 normalization of the embedding vector before returning (e.g. before storing or caching).
-func WithNormalize(normalize bool) ClientOption {
-	return func(c *Client) {
-		c.normalize = normalize
+		c.usage = recorder
 	}
 }
 
@@ -128,6 +108,8 @@ func (c *Client) CreateEmbedding(ctx context.Context, input string) ([]float32, 
 
 	model := c.model
 
+	started := time.Now()
+
 	resp, err := c.sdk.Embeddings.New(ctx, openaisdk.EmbeddingNewParams{
 		Input: openaisdk.EmbeddingNewParamsInputUnion{
 			OfString: param.NewOpt(input),
@@ -135,6 +117,15 @@ func (c *Client) CreateEmbedding(ctx context.Context, input string) ([]float32, 
 		Model:      model,
 		Dimensions: param.NewOpt(int64(c.dimensions)),
 	})
+
+	var promptTokens int64
+
+	if resp != nil {
+		promptTokens = resp.Usage.PromptTokens
+	}
+
+	c.recordUsage(ctx, llm.OperationEmbeddings, started, promptTokens, 0, err)
+
 	if err != nil {
 		return nil, wrapOpenAIError("openai embedding", err)
 	}
@@ -167,6 +158,8 @@ func (c *Client) CreateEmbeddings(ctx context.Context, inputs []string) ([][]flo
 		return nil, ErrInvalidDims
 	}
 
+	started := time.Now()
+
 	resp, err := c.sdk.Embeddings.New(ctx, openaisdk.EmbeddingNewParams{
 		Input: openaisdk.EmbeddingNewParamsInputUnion{
 			OfArrayOfStrings: trimmed,
@@ -174,6 +167,15 @@ func (c *Client) CreateEmbeddings(ctx context.Context, inputs []string) ([][]flo
 		Model:      c.model,
 		Dimensions: param.NewOpt(int64(c.dimensions)),
 	})
+
+	var promptTokens int64
+
+	if resp != nil {
+		promptTokens = resp.Usage.PromptTokens
+	}
+
+	c.recordUsage(ctx, llm.OperationEmbeddings, started, promptTokens, 0, err)
+
 	if err != nil {
 		return nil, wrapOpenAIError("openai embeddings batch", err)
 	}
@@ -301,6 +303,26 @@ func (c *Client) CompleteJSON(ctx context.Context, systemPrompt, userText string
 // temperatureUnsupported, so every later call skips it — self-healing, with no model list to
 // maintain.
 func (c *Client) createChatCompletion(
+	ctx context.Context, params openaisdk.ChatCompletionNewParams,
+) (*openaisdk.ChatCompletion, error) {
+	started := time.Now()
+
+	resp, err := c.chatCompletionCall(ctx, params)
+
+	var inputTokens, outputTokens int64
+
+	if resp != nil {
+		inputTokens, outputTokens = resp.Usage.PromptTokens, resp.Usage.CompletionTokens
+	}
+
+	c.recordUsage(ctx, llm.OperationChat, started, inputTokens, outputTokens, err)
+
+	return resp, err
+}
+
+// chatCompletionCall is the original body, kept intact so the temperature-retry logic below is
+// unchanged; createChatCompletion wraps it purely to time and record the call.
+func (c *Client) chatCompletionCall(
 	ctx context.Context, params openaisdk.ChatCompletionNewParams,
 ) (*openaisdk.ChatCompletion, error) {
 	if !c.temperatureUnsupported.Load() {
@@ -441,4 +463,79 @@ func openaiRetryAfter(apiErr *openaisdk.Error) time.Duration {
 	}
 
 	return 0
+}
+
+// recordUsage reports one call. Split out so every provider entry point records the same shape,
+// and so a nil recorder is checked in exactly one place.
+func (c *Client) recordUsage(
+	ctx context.Context, operation llm.Operation, started time.Time, inputTokens, outputTokens int64, err error,
+) {
+	if c.usage == nil {
+		return
+	}
+
+	c.usage.RecordUsage(ctx, llm.Usage{
+		Operation:    operation,
+		Provider:     llm.ProviderOpenAI,
+		Model:        c.model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		Duration:     time.Since(started),
+		ErrorType:    errorTypeOf(err),
+	})
+}
+
+// errorTypeOf maps an error to the BOUNDED error.type attribute. An HTTP status becomes its
+// number, everything else a coarse class — never the provider's message, which is unbounded and
+// would blow up metric cardinality the first time a provider echoed user input back in an error.
+func errorTypeOf(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var apiErr *openaisdk.Error
+	if errors.As(err, &apiErr) && apiErr.StatusCode != 0 {
+		return strconv.Itoa(apiErr.StatusCode)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return "cancelled"
+	}
+
+	return "other"
+}
+
+// ClientOption configures the Client.
+type ClientOption func(*Client)
+
+// WithDimensions sets the requested embedding dimension (must match DB column).
+func WithDimensions(dim int) ClientOption {
+	return func(c *Client) {
+		c.dimensions = dim
+	}
+}
+
+// WithModel sets the embedding model name. Empty uses default.
+func WithModel(model string) ClientOption {
+	return func(c *Client) {
+		c.model = model
+	}
+}
+
+// WithBaseURL sets a custom OpenAI-compatible base URL (for example a self-hosted embeddings runtime).
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
+// WithNormalize enables L2 normalization of the embedding vector before returning (e.g. before storing or caching).
+func WithNormalize(normalize bool) ClientOption {
+	return func(c *Client) {
+		c.normalize = normalize
+	}
 }

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -349,6 +349,16 @@ func completionText(resp *openaisdk.ChatCompletion) (string, error) {
 
 	choice := resp.Choices[0]
 
+	// Checked BEFORE the content, because a length-capped response usually carries partial text
+	// rather than none. Returning that would hand back a half-finished translation to be stored as
+	// complete, or a truncated JSON object that fails to parse and looks like a transient provider
+	// glitch — retried to exhaustion and recorded as transient, when it is permanent for this text
+	// at this model. A truncated result is not a result.
+	if choice.FinishReason == "length" {
+		return "", huberrors.NewTerminalProviderError(huberrors.TerminalReasonLength,
+			fmt.Errorf("%w: finish reason %q", ErrNoCompletionInResponse, choice.FinishReason))
+	}
+
 	out := strings.TrimSpace(choice.Message.Content)
 	if out == "" {
 		if refusal := strings.TrimSpace(choice.Message.Refusal); refusal != "" {

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -352,17 +352,42 @@ func completionText(resp *openaisdk.ChatCompletion) (string, error) {
 	out := strings.TrimSpace(choice.Message.Content)
 	if out == "" {
 		if refusal := strings.TrimSpace(choice.Message.Refusal); refusal != "" {
-			return "", fmt.Errorf("%w: model refused: %.256s", ErrNoCompletionInResponse, refusal)
+			return "", huberrors.NewTerminalProviderError(huberrors.TerminalReasonRefusal,
+				fmt.Errorf("%w: model refused: %.256s", ErrNoCompletionInResponse, refusal))
 		}
 
 		if choice.FinishReason != "" && choice.FinishReason != "stop" {
-			return "", fmt.Errorf("%w: finish reason %q", ErrNoCompletionInResponse, choice.FinishReason)
+			err := fmt.Errorf("%w: finish reason %q", ErrNoCompletionInResponse, choice.FinishReason)
+
+			if reason, terminal := terminalFinishReason(choice.FinishReason); terminal {
+				return "", huberrors.NewTerminalProviderError(reason, err)
+			}
+
+			return "", err
 		}
 
 		return "", ErrNoCompletionInResponse
 	}
 
 	return out, nil
+}
+
+// terminalFinishReason classifies a non-stop finish reason as permanent for this input, or leaves
+// it retryable.
+//
+// Only the two reasons determined by the CONTENT are terminal. Everything else — including an
+// empty response with no reason at all, and tool/function finishes we do not request — stays
+// retryable on purpose: a false terminal abandons a record for good, while a false transient
+// costs a few wasted calls. When in doubt, retry.
+func terminalFinishReason(finish string) (huberrors.TerminalReason, bool) {
+	switch finish {
+	case "content_filter":
+		return huberrors.TerminalReasonContentFilter, true
+	case "length":
+		return huberrors.TerminalReasonLength, true
+	default:
+		return "", false
+	}
 }
 
 // wrapChatCompletionError wraps a chat-completion SDK error, mapping a 429 to a

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -474,43 +474,22 @@ func openaiRetryAfter(apiErr *openaisdk.Error) time.Duration {
 func (c *Client) recordUsage(
 	ctx context.Context, operation llm.Operation, started time.Time, inputTokens, outputTokens int64, err error,
 ) {
-	if c.usage == nil {
-		return
-	}
-
-	c.usage.RecordUsage(ctx, llm.Usage{
-		Operation:    operation,
-		Provider:     llm.ProviderOpenAI,
-		Model:        c.model,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-		Duration:     time.Since(started),
-		ErrorType:    errorTypeOf(err),
-	})
+	llm.Record(ctx, c.usage, operation, llm.ProviderOpenAI, c.model,
+		started, inputTokens, outputTokens, errorTypeOf(err))
 }
 
-// errorTypeOf maps an error to the BOUNDED error.type attribute. An HTTP status becomes its
-// number, everything else a coarse class — never the provider's message, which is unbounded and
-// would blow up metric cardinality the first time a provider echoed user input back in an error.
+// errorTypeOf maps an error to the BOUNDED error.type attribute. Only the status extraction is
+// OpenAI-specific; the rest of the classification is shared so the two clients cannot disagree on
+// what "timeout" means.
 func errorTypeOf(err error) string {
-	if err == nil {
-		return ""
-	}
+	return llm.ClassifyError(err, func(err error) (int, bool) {
+		var apiErr *openaisdk.Error
+		if errors.As(err, &apiErr) {
+			return apiErr.StatusCode, true
+		}
 
-	var apiErr *openaisdk.Error
-	if errors.As(err, &apiErr) && apiErr.StatusCode != 0 {
-		return strconv.Itoa(apiErr.StatusCode)
-	}
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		return "timeout"
-	}
-
-	if errors.Is(err, context.Canceled) {
-		return "cancelled"
-	}
-
-	return "other"
+		return 0, false
+	})
 }
 
 // ClientOption configures the Client.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -322,6 +322,10 @@ func (c *Client) createChatCompletion(
 
 // chatCompletionCall is the original body, kept intact so the temperature-retry logic below is
 // unchanged; createChatCompletion wraps it purely to time and record the call.
+//
+// One record covers the whole sequence, including the reasoning-model temperature retry inside:
+// the token counts come from the successful request, but the duration spans both. That inflates a
+// single call's latency at most once per client per process, since the rejection latches.
 func (c *Client) chatCompletionCall(
 	ctx context.Context, params openaisdk.ChatCompletionNewParams,
 ) (*openaisdk.ChatCompletion, error) {

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -369,8 +369,13 @@ func completionText(resp *openaisdk.ChatCompletion) (string, error) {
 		if choice.FinishReason != "" && choice.FinishReason != "stop" {
 			err := fmt.Errorf("%w: finish reason %q", ErrNoCompletionInResponse, choice.FinishReason)
 
-			if reason, terminal := terminalFinishReason(choice.FinishReason); terminal {
-				return "", huberrors.NewTerminalProviderError(reason, err)
+			// content_filter is the only terminal reason reachable here: length returns above,
+			// before the content is read, because it usually truncates rather than blanks the
+			// output. Everything else — including the tool finishes we never request — stays
+			// retryable, since a false terminal abandons a record while a false transient only
+			// costs a few calls.
+			if choice.FinishReason == "content_filter" {
+				return "", huberrors.NewTerminalProviderError(huberrors.TerminalReasonContentFilter, err)
 			}
 
 			return "", err
@@ -380,24 +385,6 @@ func completionText(resp *openaisdk.ChatCompletion) (string, error) {
 	}
 
 	return out, nil
-}
-
-// terminalFinishReason classifies a non-stop finish reason as permanent for this input, or leaves
-// it retryable.
-//
-// Only the two reasons determined by the CONTENT are terminal. Everything else — including an
-// empty response with no reason at all, and tool/function finishes we do not request — stays
-// retryable on purpose: a false terminal abandons a record for good, while a false transient
-// costs a few wasted calls. When in doubt, retry.
-func terminalFinishReason(finish string) (huberrors.TerminalReason, bool) {
-	switch finish {
-	case "content_filter":
-		return huberrors.TerminalReasonContentFilter, true
-	case "length":
-		return huberrors.TerminalReasonLength, true
-	default:
-		return "", false
-	}
 }
 
 // wrapChatCompletionError wraps a chat-completion SDK error, mapping a 429 to a

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -619,6 +619,15 @@ func TestCompletionTextTerminalClassification(t *testing.T) {
 			"length is terminal", completion("", "", "length"),
 			huberrors.TerminalReasonLength, true,
 		},
+		// The case a length cap actually produces: truncated output, not blank output. Returning
+		// the partial text would store a half-finished translation as complete, or hand back a
+		// truncated JSON that fails to parse and reads as a transient glitch rather than as
+		// permanent for this input.
+		{
+			"length with truncated content is still terminal",
+			completion(`{"sentiment":"posi`, "", "length"),
+			huberrors.TerminalReasonLength, true,
+		},
 		// We never request tools, so this should not occur — but if it does, retrying is the
 		// cheaper mistake.
 		{"an unknown finish reason stays retryable", completion("", "", "tool_calls"), "", false},

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -587,3 +587,80 @@ func TestCreateEmbedding_RateLimitReturnsRateLimitError(t *testing.T) {
 	require.ErrorAs(t, err, &rateLimited, "an embedding 429 must surface as a rate-limit error")
 	assert.Equal(t, 9*time.Second, rateLimited.RetryAfter)
 }
+
+// TestCompletionTextTerminalClassification pins which empty-completion outcomes are permanent for
+// the input and which stay retryable. The asymmetry is deliberate: a false terminal abandons a
+// record for good, a false transient costs a few wasted calls.
+func TestCompletionTextTerminalClassification(t *testing.T) {
+	completion := func(content, refusal, finish string) *openaisdk.ChatCompletion {
+		return &openaisdk.ChatCompletion{
+			Choices: []openaisdk.ChatCompletionChoice{{
+				Message:      openaisdk.ChatCompletionMessage{Content: content, Refusal: refusal},
+				FinishReason: finish,
+			}},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		resp       *openaisdk.ChatCompletion
+		wantReason huberrors.TerminalReason
+		terminal   bool
+	}{
+		{
+			"refusal is terminal", completion("", "I can't help with that.", "content_filter"),
+			huberrors.TerminalReasonRefusal, true,
+		},
+		{
+			"content_filter is terminal", completion("", "", "content_filter"),
+			huberrors.TerminalReasonContentFilter, true,
+		},
+		{
+			"length is terminal", completion("", "", "length"),
+			huberrors.TerminalReasonLength, true,
+		},
+		// We never request tools, so this should not occur — but if it does, retrying is the
+		// cheaper mistake.
+		{"an unknown finish reason stays retryable", completion("", "", "tool_calls"), "", false},
+		{"empty with no reason stays retryable", completion("", "", "stop"), "", false},
+		{"no choices at all stays retryable", &openaisdk.ChatCompletion{}, "", false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := completionText(testCase.resp)
+			require.Error(t, err)
+
+			reason, ok := huberrors.TerminalReasonOf(err)
+			require.Equal(t, testCase.terminal, ok, "terminality of %v", err)
+
+			if testCase.terminal {
+				assert.Equal(t, testCase.wantReason, reason)
+			} else {
+				assert.NotErrorIs(t, err, huberrors.ErrTerminalProvider)
+			}
+		})
+	}
+}
+
+// TestCompleteJSONRefusalIsTerminalThroughTheSDK drives the real SDK against a stub so the
+// classification is proven on a decoded wire response, not on a hand-built struct — a refusal is
+// an HTTP 200, which is exactly why it is easy to mistake for a usable result.
+func TestCompleteJSONRefusalIsTerminalThroughTheSDK(t *testing.T) {
+	server := newChatCompletionServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"c","object":"chat.completion","created":1,"model":"m",
+			"choices":[{"index":0,"finish_reason":"content_filter",
+			"message":{"role":"assistant","content":"","refusal":"I can't help with that."}}]}`))
+	})
+
+	client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithModel("test-model"))
+
+	_, err := client.CompleteJSON(context.Background(), "system", "hello", llm.Schema{Name: "s"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, huberrors.ErrTerminalProvider)
+
+	reason, ok := huberrors.TerminalReasonOf(err)
+	require.True(t, ok)
+	assert.Equal(t, huberrors.TerminalReasonRefusal, reason)
+}

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -673,3 +673,75 @@ func TestCompleteJSONRefusalIsTerminalThroughTheSDK(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, huberrors.TerminalReasonRefusal, reason)
 }
+
+// recordingUsage captures what the client reports for each provider call.
+type recordingUsage struct{ calls []llm.Usage }
+
+func (r *recordingUsage) RecordUsage(_ context.Context, u llm.Usage) { r.calls = append(r.calls, u) }
+
+// TestUsageIsRecordedForChatCompletions covers the reason this exists: the provider returns token
+// counts on every response and the client used to decode and drop them, so there was no way to
+// answer what enrichment costs. Failures are recorded too — a provider outage that burns input
+// tokens is exactly when the number matters.
+func TestUsageIsRecordedForChatCompletions(t *testing.T) {
+	t.Run("success carries token counts", func(t *testing.T) {
+		server := newChatCompletionServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"c","object":"chat.completion","created":1,"model":"m",
+				"choices":[{"index":0,"finish_reason":"stop",
+				"message":{"role":"assistant","content":"hallo"}}],
+				"usage":{"prompt_tokens":31,"completion_tokens":7,"total_tokens":38}}`))
+		})
+
+		usage := &recordingUsage{}
+		client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithModel("test-model"),
+			WithUsageRecorder(usage))
+
+		_, err := client.Translate(context.Background(), "system", "hello")
+		require.NoError(t, err)
+
+		require.Len(t, usage.calls, 1)
+		got := usage.calls[0]
+		assert.Equal(t, llm.OperationChat, got.Operation)
+		assert.Equal(t, llm.ProviderOpenAI, got.Provider)
+		assert.Equal(t, "test-model", got.Model)
+		assert.Equal(t, int64(31), got.InputTokens)
+		assert.Equal(t, int64(7), got.OutputTokens)
+		assert.Empty(t, got.ErrorType, "a successful call carries no error.type")
+		assert.Positive(t, got.Duration)
+	})
+
+	t.Run("failure records a bounded error type", func(t *testing.T) {
+		server := newChatCompletionServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		usage := &recordingUsage{}
+		client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithModel("test-model"),
+			WithUsageRecorder(usage))
+
+		_, err := client.Translate(context.Background(), "system", "hello")
+		require.Error(t, err)
+
+		require.Len(t, usage.calls, 1, "a failed call must still be recorded")
+		// The status code, never the provider's message — an unbounded error.type would blow up
+		// cardinality the first time a provider echoed user input back in an error body.
+		assert.Equal(t, "500", usage.calls[0].ErrorType)
+		assert.Zero(t, usage.calls[0].InputTokens, "no usage block means no token counts")
+	})
+
+	t.Run("a nil recorder is a no-op", func(t *testing.T) {
+		server := newChatCompletionServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"c","object":"chat.completion","created":1,"model":"m",
+				"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"x"}}]}`))
+		})
+
+		client := NewClient("sk-test", WithBaseURL(server.URL+"/v1"), WithModel("m"))
+
+		require.NotPanics(t, func() {
+			_, err := client.Translate(context.Background(), "system", "hello")
+			require.NoError(t, err)
+		})
+	})
+}

--- a/internal/repository/enrichment_failures_repository.go
+++ b/internal/repository/enrichment_failures_repository.go
@@ -30,6 +30,10 @@ func NewEnrichmentFailuresRepository(db *pgxpool.Pool) *EnrichmentFailuresReposi
 	return &EnrichmentFailuresRepository{db: db}
 }
 
+// enrichmentFailureLockKeyParam is the placeholder carrying the tenant write-lock key, after the
+// six inserted values.
+const enrichmentFailureLockKeyParam = 7
+
 // recordEnrichmentFailureSQL upserts the marker for one (record, enrichment).
 //
 // Upsert rather than insert because a record can fail again after a later edit re-enqueues it, and
@@ -41,10 +45,6 @@ func NewEnrichmentFailuresRepository(db *pgxpool.Pool) *EnrichmentFailuresReposi
 // deliberately NOT updated on conflict — a record cannot change tenant, so an incoming value that
 // disagreed with the stored one would be a bug worth preserving the evidence of rather than
 // silently overwriting.
-// enrichmentFailureLockKeyParam is the placeholder carrying the tenant write-lock key, after the
-// six inserted values.
-const enrichmentFailureLockKeyParam = 7
-
 // A var rather than a const because tenantWriteLockGate is a function call; built once at package
 // init, and every fragment is a compile-time literal, never caller input.
 var recordEnrichmentFailureSQL = `
@@ -60,11 +60,17 @@ var recordEnrichmentFailureSQL = `
 
 // RecordFailure persists one enrichment failure.
 //
-// Two outcomes are reported as ErrTenantWriteConflict rather than as errors of their own, because
-// both mean "the record is going away and the marker is moot": the tenant write lock being refused
-// (a purge is running), and the foreign key failing (the record was deleted between the enrichment
-// attempt and this write). Callers treat that as a benign skip — a marker is bookkeeping, and
-// failing an enrichment job over it would be the wrong trade.
+// Two outcomes are benign skips rather than errors worth failing a job over, and they are reported
+// SEPARATELY because the rest of the worker treats them differently:
+//
+//   - ErrTenantWriteConflict — the tenant write lock was refused, so a purge is running. Elsewhere
+//     in this worker that error means "retry".
+//   - ErrNotFound — the foreign key failed, so the record was deleted between the enrichment
+//     attempt and this write. Retrying that could only fail again.
+//
+// markFailed swallows both today, but collapsing them into one type would leave a trap for the
+// next caller that propagates instead of swallowing: a deleted record would read as a transient
+// conflict and be retried forever.
 func (r *EnrichmentFailuresRepository) RecordFailure(ctx context.Context, failure models.EnrichmentFailure) error {
 	tag, err := r.db.Exec(ctx, recordEnrichmentFailureSQL,
 		failure.FeedbackRecordID,
@@ -78,7 +84,7 @@ func (r *EnrichmentFailuresRepository) RecordFailure(ctx context.Context, failur
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == foreignKeyViolationSQLState {
-			return huberrors.NewTenantWriteConflictError("feedback record no longer exists; failure marker skipped")
+			return huberrors.NewNotFoundError("feedback record", "feedback record no longer exists; failure marker skipped")
 		}
 
 		return fmt.Errorf("record enrichment failure: %w", err)

--- a/internal/repository/enrichment_failures_repository.go
+++ b/internal/repository/enrichment_failures_repository.go
@@ -63,8 +63,10 @@ var recordEnrichmentFailureSQL = `
 // Two outcomes are benign skips rather than errors worth failing a job over, and they are reported
 // SEPARATELY because the rest of the worker treats them differently:
 //
-//   - ErrTenantWriteConflict — the tenant write lock was refused, so a purge is running. Elsewhere
-//     in this worker that error means "retry".
+//   - ErrTenantWriteConflict — the tenant write lock was refused, so a purge is running. Which
+//     purge matters: the offboarding one takes the whole tenant, but the records-scoped one spares
+//     records newer than its high-water mark, so this does NOT imply the record is going away.
+//     Elsewhere in this worker that error means "retry".
 //   - ErrNotFound — the foreign key failed, so the record was deleted between the enrichment
 //     attempt and this write. Retrying that could only fail again.
 //
@@ -91,7 +93,8 @@ func (r *EnrichmentFailuresRepository) RecordFailure(ctx context.Context, failur
 	}
 
 	if tag.RowsAffected() == 0 {
-		return huberrors.NewTenantWriteConflictError("tenant data purge in progress for this tenant; failure marker skipped")
+		return huberrors.NewTenantWriteConflictError(
+			"a purge holds this tenant's write lock; failure marker skipped")
 	}
 
 	return nil

--- a/internal/repository/enrichment_failures_repository.go
+++ b/internal/repository/enrichment_failures_repository.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/models"
+)
+
+// foreignKeyViolationSQLState is the SQLSTATE Postgres reports when a referenced row is missing.
+// Here it means the feedback record was deleted between the enrichment attempt and the marker
+// write, which is a benign race rather than an error worth failing a job over.
+const foreignKeyViolationSQLState = "23503"
+
+// EnrichmentFailuresRepository writes the durable failure markers the status endpoint counts and
+// the reconciler reads. It is deliberately separate from FeedbackRecordsRepository: this is
+// bookkeeping about a record rather than the record itself, and keeping it apart stops the
+// primary records repository growing another concern.
+type EnrichmentFailuresRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewEnrichmentFailuresRepository creates an enrichment failures repository.
+func NewEnrichmentFailuresRepository(db *pgxpool.Pool) *EnrichmentFailuresRepository {
+	return &EnrichmentFailuresRepository{db: db}
+}
+
+// recordEnrichmentFailureSQL upserts the marker for one (record, enrichment).
+//
+// Upsert rather than insert because a record can fail again after a later edit re-enqueues it, and
+// the newest outcome is the one worth keeping — including a transition from terminal back to
+// transient, or the reverse, when the text changed.
+//
+// The tenant write-lock gate follows the convention for inserts whose tenant is known up front
+// (see tenant_write_lock.go): zero rows means a purge holds the tenant exclusively. tenant_id is
+// deliberately NOT updated on conflict — a record cannot change tenant, so an incoming value that
+// disagreed with the stored one would be a bug worth preserving the evidence of rather than
+// silently overwriting.
+// enrichmentFailureLockKeyParam is the placeholder carrying the tenant write-lock key, after the
+// six inserted values.
+const enrichmentFailureLockKeyParam = 7
+
+// A var rather than a const because tenantWriteLockGate is a function call; built once at package
+// init, and every fragment is a compile-time literal, never caller input.
+var recordEnrichmentFailureSQL = `
+	INSERT INTO feedback_record_enrichment_failures
+		(feedback_record_id, enrichment, tenant_id, failed_at, attempts, terminal, reason)
+	SELECT $1, $2, $3, NOW(), $4, $5, $6
+	WHERE ` + tenantWriteLockGate(enrichmentFailureLockKeyParam) + `
+	ON CONFLICT (feedback_record_id, enrichment) DO UPDATE SET
+		failed_at = NOW(),
+		attempts  = EXCLUDED.attempts,
+		terminal  = EXCLUDED.terminal,
+		reason    = EXCLUDED.reason`
+
+// RecordFailure persists one enrichment failure.
+//
+// Two outcomes are reported as ErrTenantWriteConflict rather than as errors of their own, because
+// both mean "the record is going away and the marker is moot": the tenant write lock being refused
+// (a purge is running), and the foreign key failing (the record was deleted between the enrichment
+// attempt and this write). Callers treat that as a benign skip — a marker is bookkeeping, and
+// failing an enrichment job over it would be the wrong trade.
+func (r *EnrichmentFailuresRepository) RecordFailure(ctx context.Context, failure models.EnrichmentFailure) error {
+	tag, err := r.db.Exec(ctx, recordEnrichmentFailureSQL,
+		failure.FeedbackRecordID,
+		failure.Enrichment,
+		failure.TenantID,
+		failure.Attempts,
+		failure.Terminal,
+		failure.Reason,
+		TenantWriteLockKey(failure.TenantID),
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == foreignKeyViolationSQLState {
+			return huberrors.NewTenantWriteConflictError("feedback record no longer exists; failure marker skipped")
+		}
+
+		return fmt.Errorf("record enrichment failure: %w", err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		return huberrors.NewTenantWriteConflictError("tenant data purge in progress for this tenant; failure marker skipped")
+	}
+
+	return nil
+}

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -109,10 +109,15 @@ const (
 	enrichmentTranslationNotDone = `(fr.translation_lang_key IS DISTINCT FROM ` + enrichmentEffectiveTarget + `)`
 )
 
-// enrichmentCountSelect is the shared twelve-column SELECT list — {sentiment, emotions,
-// translation} × {eligible, done, failed, failed_terminal} — used by both the per-tenant and
-// aggregate queries so the predicates can't drift between them. Column order must match the
-// EnrichmentStatusCounts scan order below. All fragments are static constants (never user input).
+// enrichmentCountSelect is the shared six-column SELECT list — {sentiment, emotions, translation}
+// × {eligible, done} — used by BOTH the per-tenant and aggregate queries so those predicates can't
+// drift between them. Column order must match the EnrichmentStatusCounts scan order below. All
+// fragments are static constants (never user input).
+//
+// The failure columns are deliberately NOT here. They are appended only to the per-tenant query
+// (see countEnrichmentStatusSQL), because the aggregate's only consumer — the backlog gauge —
+// reads eligible and done and nothing else. Sharing them would make the one query documented as a
+// full sequential scan build and probe three hash tables per poll and discard every result.
 var enrichmentCountSelect = `
 		COUNT(*) FILTER (WHERE ` + enrichmentEligibleText + ` AND ` + enrichmentSentimentOn + `),
 		COUNT(*) FILTER (WHERE ` + enrichmentEligibleText + ` AND ` + enrichmentSentimentOn + ` AND fr.sentiment IS NOT NULL),
@@ -122,8 +127,7 @@ var enrichmentCountSelect = `
 		COUNT(*) FILTER (
 			WHERE ` + enrichmentEligibleText + `
 			AND ` + enrichmentEffectiveTarget + ` <> ''
-			AND fr.translation_lang_key = ` + enrichmentEffectiveTarget + `),` +
-	failureCountColumns()
+			AND fr.translation_lang_key = ` + enrichmentEffectiveTarget + `)`
 
 // failureCountColumns renders the six failure columns, in the same {sentiment, emotions,
 // translation} order as the eligible/done columns above. Each pair is gated by the same
@@ -155,7 +159,21 @@ func failureCountColumns() string {
 // the boundary has exactly one source of truth. See migration 022.
 const enrichmentCountFrom = `
 	FROM feedback_records fr
-	LEFT JOIN tenant_settings ts ON ts.tenant_id = fr.tenant_id
+	LEFT JOIN tenant_settings ts ON ts.tenant_id = fr.tenant_id`
+
+// enrichmentFailureJoins attaches the marker rows, one join per enrichment. Appended ONLY to the
+// per-tenant query: the aggregate does not read the failure columns, and adding three joins to a
+// whole-table sequential scan to discard the results is the kind of cost that only shows up in
+// production.
+//
+// Each join hits the markers' primary key (feedback_record_id, enrichment) and can match at most
+// one row, so this stays a lookup rather than a fan-out — the eligible and done counts would be
+// wrong if it did not.
+//
+// The join is on feedback_record_id ALONE. The markers carry a tenant_id column, but it exists for
+// its own index and is never the tenant boundary: that stays fr.tenant_id in the outer WHERE, so
+// the boundary has exactly one source of truth. See migration 022.
+const enrichmentFailureJoins = `
 	LEFT JOIN feedback_record_enrichment_failures fs
 		ON fs.feedback_record_id = fr.id AND fs.enrichment = 'sentiment'
 	LEFT JOIN feedback_record_enrichment_failures fe
@@ -170,7 +188,8 @@ const enrichmentCountFrom = `
 // countEnrichmentStatusSQL counts eligible/done per enrichment for ONE tenant. $1 = deployment
 // default target language, $2 = tenant_id. The (tenant_id, field_type) pair matches
 // idx_feedback_records_tenant_field_type, so cost scales with the tenant's text-record count.
-var countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
+var countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + `,` + failureCountColumns() +
+	enrichmentCountFrom + enrichmentFailureJoins + `
 	WHERE fr.tenant_id = $2 AND fr.field_type = 'text'`
 
 // countEnrichmentBacklogAggregateSQL is the same SELECT without the tenant filter: it sums
@@ -238,7 +257,7 @@ const (
 func (r *EnrichmentStatusRepository) CountEnrichmentStatus(
 	ctx context.Context, tenantID, defaultLang string,
 ) (EnrichmentStatusCounts, error) {
-	return scanEnrichmentCounts(
+	return scanEnrichmentCountsWithFailures(
 		r.db.QueryRow(ctx, countEnrichmentStatusSQL, defaultLang, tenantID), "count enrichment status")
 }
 
@@ -418,8 +437,27 @@ func (l *EnrichmentBacklogLeader) execDetached(
 	return nil
 }
 
-// scanEnrichmentCounts reads the six-column count row; the scan order matches enrichmentCountSelect.
+// scanEnrichmentCounts reads the six-column eligible/done row; the scan order matches
+// enrichmentCountSelect. Used by the aggregate query, which selects only those columns.
 func scanEnrichmentCounts(row pgx.Row, what string) (EnrichmentStatusCounts, error) {
+	var counts EnrichmentStatusCounts
+
+	if err := row.Scan(
+		&counts.SentimentEligible, &counts.SentimentDone,
+		&counts.EmotionsEligible, &counts.EmotionsDone,
+		&counts.TranslationEligible, &counts.TranslationDone,
+	); err != nil {
+		return EnrichmentStatusCounts{}, fmt.Errorf("%s: %w", what, err)
+	}
+
+	return counts, nil
+}
+
+// scanEnrichmentCountsWithFailures reads the twelve-column row the per-tenant query returns: the
+// six above followed by failureCountColumns, in the same {sentiment, emotions, translation} order.
+// The two scanners exist because only the per-tenant query selects the failure half — see
+// enrichmentCountSelect.
+func scanEnrichmentCountsWithFailures(row pgx.Row, what string) (EnrichmentStatusCounts, error) {
 	var counts EnrichmentStatusCounts
 
 	if err := row.Scan(

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -27,12 +27,23 @@ func NewEnrichmentStatusRepository(db *pgxpool.Pool) *EnrichmentStatusRepository
 // switched on, translation only records with a resolvable effective target language. The
 // deployment-level (provider/model) gate is applied by the caller.
 type EnrichmentStatusCounts struct {
-	TranslationEligible      int64
-	TranslationDone          int64
-	SentimentEligible        int64
-	SentimentDone            int64
-	EmotionsEligible         int64
-	EmotionsDone             int64
+	TranslationEligible int64
+	TranslationDone     int64
+	SentimentEligible   int64
+	SentimentDone       int64
+	EmotionsEligible    int64
+	EmotionsDone        int64
+
+	// Failed counts records whose last enrichment attempt gave up and which are STILL un-enriched,
+	// split by whether retrying could ever help. FailedTerminal is a property of the record's own
+	// text, so it will not resolve on its own; Failed can, and is what a retry acts on.
+	TranslationFailed         int64
+	TranslationFailedTerminal int64
+	SentimentFailed           int64
+	SentimentFailedTerminal   int64
+	EmotionsFailed            int64
+	EmotionsFailedTerminal    int64
+
 	TaxonomyEmbeddingPending int64
 }
 
@@ -78,11 +89,31 @@ const (
 // the classify backfill re-processes them.
 const enrichmentEmotionsDone = `(fr.emotions_classified_at IS NOT NULL OR fr.emotions IS NOT NULL)`
 
-// enrichmentCountSelect is the shared six-column SELECT list — {sentiment, emotions, translation} ×
-// {eligible, done} — used by both the per-tenant and aggregate queries so the predicates can't
-// drift between them. Column order must match the EnrichmentStatusCounts scan order below. All
-// fragments are static constants (never user input).
-const enrichmentCountSelect = `
+// enrichmentFailedFor builds the two failure predicates for one enrichment from its already-joined
+// marker row and its own done-predicate.
+//
+// A failure counts only while the record is still UN-ENRICHED. That is what makes the marker rows
+// advisory rather than authoritative: a later success needs no cleanup write, because a stale row
+// stops counting the moment the record is done. It also means the count can never contradict the
+// record itself.
+func enrichmentFailedFor(alias, notDone string) (failed, terminal string) {
+	present := alias + ".feedback_record_id IS NOT NULL AND " + notDone
+
+	return present + " AND NOT " + alias + ".terminal", present + " AND " + alias + ".terminal"
+}
+
+// The three done-predicates, negated, as used by the failure counts above.
+const (
+	enrichmentSentimentNotDone   = `fr.sentiment IS NULL`
+	enrichmentEmotionsNotDone    = `NOT ` + enrichmentEmotionsDone
+	enrichmentTranslationNotDone = `(fr.translation_lang_key IS DISTINCT FROM ` + enrichmentEffectiveTarget + `)`
+)
+
+// enrichmentCountSelect is the shared twelve-column SELECT list — {sentiment, emotions,
+// translation} × {eligible, done, failed, failed_terminal} — used by both the per-tenant and
+// aggregate queries so the predicates can't drift between them. Column order must match the
+// EnrichmentStatusCounts scan order below. All fragments are static constants (never user input).
+var enrichmentCountSelect = `
 		COUNT(*) FILTER (WHERE ` + enrichmentEligibleText + ` AND ` + enrichmentSentimentOn + `),
 		COUNT(*) FILTER (WHERE ` + enrichmentEligibleText + ` AND ` + enrichmentSentimentOn + ` AND fr.sentiment IS NOT NULL),
 		COUNT(*) FILTER (WHERE ` + enrichmentEligibleText + ` AND ` + enrichmentEmotionsOn + `),
@@ -91,11 +122,46 @@ const enrichmentCountSelect = `
 		COUNT(*) FILTER (
 			WHERE ` + enrichmentEligibleText + `
 			AND ` + enrichmentEffectiveTarget + ` <> ''
-			AND fr.translation_lang_key = ` + enrichmentEffectiveTarget + `)`
+			AND fr.translation_lang_key = ` + enrichmentEffectiveTarget + `),` +
+	failureCountColumns()
 
+// failureCountColumns renders the six failure columns, in the same {sentiment, emotions,
+// translation} order as the eligible/done columns above. Each pair is gated by the same
+// eligibility and per-tenant switch as its enrichment, so a tenant that switched sentiment off
+// never reports sentiment failures for work that will not run.
+func failureCountColumns() string {
+	sentimentFailed, sentimentTerminal := enrichmentFailedFor("fs", enrichmentSentimentNotDone)
+	emotionsFailed, emotionsTerminal := enrichmentFailedFor("fe", enrichmentEmotionsNotDone)
+	translationFailed, translationTerminal := enrichmentFailedFor("ft", enrichmentTranslationNotDone)
+
+	col := func(gate, predicate string) string {
+		return "\n\t\tCOUNT(*) FILTER (WHERE " + enrichmentEligibleText + " AND " + gate + " AND " + predicate + ")"
+	}
+
+	return col(enrichmentSentimentOn, sentimentFailed) + "," +
+		col(enrichmentSentimentOn, sentimentTerminal) + "," +
+		col(enrichmentEmotionsOn, emotionsFailed) + "," +
+		col(enrichmentEmotionsOn, emotionsTerminal) + "," +
+		col(enrichmentEffectiveTarget+" <> ''", translationFailed) + "," +
+		col(enrichmentEffectiveTarget+" <> ''", translationTerminal)
+}
+
+// enrichmentCountFrom joins the failure markers once per enrichment. Each join hits the table's
+// primary key (feedback_record_id, enrichment) and can match at most one row, so this stays a
+// lookup rather than a fan-out — the counts would be wrong if it did not.
+//
+// The join is on feedback_record_id ONLY. The markers carry a tenant_id column, but it exists for
+// its own index and is never the tenant boundary: that stays fr.tenant_id in the outer WHERE, so
+// the boundary has exactly one source of truth. See migration 022.
 const enrichmentCountFrom = `
 	FROM feedback_records fr
-	LEFT JOIN tenant_settings ts ON ts.tenant_id = fr.tenant_id`
+	LEFT JOIN tenant_settings ts ON ts.tenant_id = fr.tenant_id
+	LEFT JOIN feedback_record_enrichment_failures fs
+		ON fs.feedback_record_id = fr.id AND fs.enrichment = 'sentiment'
+	LEFT JOIN feedback_record_enrichment_failures fe
+		ON fe.feedback_record_id = fr.id AND fe.enrichment = 'emotions'
+	LEFT JOIN feedback_record_enrichment_failures ft
+		ON ft.feedback_record_id = fr.id AND ft.enrichment = 'translation'`
 
 // The `fr.field_type = 'text'` predicate in the outer WHERE of both queries below is redundant
 // with enrichmentEligibleText inside every FILTER (so it can never change a count); it is hoisted
@@ -104,7 +170,7 @@ const enrichmentCountFrom = `
 // countEnrichmentStatusSQL counts eligible/done per enrichment for ONE tenant. $1 = deployment
 // default target language, $2 = tenant_id. The (tenant_id, field_type) pair matches
 // idx_feedback_records_tenant_field_type, so cost scales with the tenant's text-record count.
-const countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
+var countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
 	WHERE fr.tenant_id = $2 AND fr.field_type = 'text'`
 
 // countEnrichmentBacklogAggregateSQL is the same SELECT without the tenant filter: it sums
@@ -121,7 +187,7 @@ const countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + enrichmentC
 // for a whole-table aggregate.) The cost is instead bounded by running the scan infrequently
 // (enrichmentBacklogInterval), under a statement timeout, and on exactly ONE replica via the
 // leader election below.
-const countEnrichmentBacklogAggregateSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
+var countEnrichmentBacklogAggregateSQL = `SELECT ` + enrichmentCountSelect + enrichmentCountFrom + `
 	WHERE fr.field_type = 'text'`
 
 // countTaxonomyEmbeddingBacklogAggregateSQL counts text records eligible for the
@@ -360,6 +426,9 @@ func scanEnrichmentCounts(row pgx.Row, what string) (EnrichmentStatusCounts, err
 		&counts.SentimentEligible, &counts.SentimentDone,
 		&counts.EmotionsEligible, &counts.EmotionsDone,
 		&counts.TranslationEligible, &counts.TranslationDone,
+		&counts.SentimentFailed, &counts.SentimentFailedTerminal,
+		&counts.EmotionsFailed, &counts.EmotionsFailedTerminal,
+		&counts.TranslationFailed, &counts.TranslationFailedTerminal,
 	); err != nil {
 		return EnrichmentStatusCounts{}, fmt.Errorf("%s: %w", what, err)
 	}

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -92,10 +92,19 @@ const enrichmentEmotionsDone = `(fr.emotions_classified_at IS NOT NULL OR fr.emo
 // enrichmentFailedFor builds the two failure predicates for one enrichment from its already-joined
 // marker row and its own done-predicate.
 //
-// A failure counts only while the record is still UN-ENRICHED. That is what makes the marker rows
-// advisory rather than authoritative: a later success needs no cleanup write, because a stale row
-// stops counting the moment the record is done. It also means the count can never contradict the
-// record itself.
+// A failure counts only while the record is still UN-ENRICHED, and the marker itself is DELETED by
+// the successful write (see clearEnrichmentFailure). Both, because they fail differently: the
+// delete is what stops a resolved failure resurrecting when a record is later un-enriched — a text
+// edit nulls the translation columns, a target_language change shifts the effective target — and
+// the un-enriched test is what keeps a marker from contradicting a record that is plainly done.
+//
+// An earlier attempt used a timestamp instead: count a marker only while failed_at is newer than
+// the record's updated_at. It is wrong, and wrong in the direction that hides work. updated_at is
+// RECORD-level while markers are per (record, enrichment), so a successful sentiment write bumps
+// the timestamp for the emotions and translation markers too and silently drops them from the
+// counts. Measured on a real run: 7% of records fell out of the accounted set entirely, which is
+// the exact failure this feature exists to prevent. Any future currency rule has to be
+// per-enrichment or it will do the same.
 func enrichmentFailedFor(alias, notDone string) (failed, terminal string) {
 	present := alias + ".feedback_record_id IS NOT NULL AND " + notDone
 
@@ -502,22 +511,39 @@ type FailedRecordCount struct {
 	Count      int64
 }
 
-// countFailedRecordsAggregateSQL counts failure markers whose record is STILL un-enriched, across
-// all tenants, grouped by enrichment and permanence.
+// countFailedRecordsAggregateSQL counts failure markers whose record is STILL un-enriched and still
+// owed the enrichment, across all tenants, grouped by enrichment and permanence.
 //
-// The un-enriched condition is what keeps the markers advisory: a record that later succeeded
-// keeps its row, and that row must stop counting.
+// Gated the same three ways the endpoint and the neighbouring backlog gauge are, because a gauge
+// that counts work nobody will ever do is worse than no gauge: an operator sees failures that the
+// status endpoint reports as zero for the same tenant and has no way to reconcile the two.
 //
-// Cheap relative to the eligible/done aggregate above. That one must scan every feedback record;
-// here the driving table is the small one — the markers, of which there are by definition few —
-// so it is a scan of failures with a primary-key lookup back to the record.
-const countFailedRecordsAggregateSQL = `
+//   - eligibility (enrichmentEligibleText) — a record whose text was blanked is owed nothing
+//   - the tenant switch — sentiment/emotions turned off for a directory means those failures are
+//     not work, they are history
+//
+// Translation's un-enriched test stays deliberately weaker than the endpoint's: that one compares
+// against the tenant's EFFECTIVE target, which needs the deployment default, and a gauge summed
+// across tenants has no single target to compare against. It asks only whether the record has any
+// translation at all. A record translated into a since-changed target therefore counts as done here
+// while the endpoint counts it as pending — acceptable deployment-wide, and written down so the two
+// disagreeing is not mistaken for a bug. The switch and eligibility gates carry no such excuse,
+// which is why they are here.
+//
+// Still cheap relative to the eligible/done aggregate above. That one must scan every feedback
+// record; here the driving table is the small one — the markers, of which there are by definition
+// few — so it stays a scan of failures with primary-key lookups back to the record and its
+// settings.
+var countFailedRecordsAggregateSQL = `
 	SELECT f.enrichment, f.terminal, COUNT(*)
 	FROM feedback_record_enrichment_failures f
 	JOIN feedback_records fr ON fr.id = f.feedback_record_id
-	WHERE (f.enrichment = 'sentiment'   AND fr.sentiment IS NULL)
-	   OR (f.enrichment = 'emotions'    AND fr.emotions_classified_at IS NULL AND fr.emotions IS NULL)
-	   OR (f.enrichment = 'translation' AND fr.translation_lang_key IS NULL)
+	LEFT JOIN tenant_settings ts ON ts.tenant_id = fr.tenant_id
+	WHERE ` + enrichmentEligibleText + `
+	  AND ((f.enrichment = 'sentiment'   AND fr.sentiment IS NULL AND ` + enrichmentSentimentOn + `)
+	    OR (f.enrichment = 'emotions'    AND fr.emotions_classified_at IS NULL AND fr.emotions IS NULL
+	                                     AND ` + enrichmentEmotionsOn + `)
+	    OR (f.enrichment = 'translation' AND fr.translation_lang_key IS NULL))
 	GROUP BY f.enrichment, f.terminal`
 
 // CountFailedRecordsAggregate returns the cross-tenant failed-record counts per enrichment.

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -473,3 +473,64 @@ func scanEnrichmentCountsWithFailures(row pgx.Row, what string) (EnrichmentStatu
 
 	return counts, nil
 }
+
+// FailedRecordCount is one (enrichment, terminal) bucket of the cross-tenant failure gauge.
+type FailedRecordCount struct {
+	Enrichment string
+	Terminal   bool
+	Count      int64
+}
+
+// countFailedRecordsAggregateSQL counts failure markers whose record is STILL un-enriched, across
+// all tenants, grouped by enrichment and permanence.
+//
+// The un-enriched condition is what keeps the markers advisory: a record that later succeeded
+// keeps its row, and that row must stop counting.
+//
+// Cheap relative to the eligible/done aggregate above. That one must scan every feedback record;
+// here the driving table is the small one — the markers, of which there are by definition few —
+// so it is a scan of failures with a primary-key lookup back to the record.
+const countFailedRecordsAggregateSQL = `
+	SELECT f.enrichment, f.terminal, COUNT(*)
+	FROM feedback_record_enrichment_failures f
+	JOIN feedback_records fr ON fr.id = f.feedback_record_id
+	WHERE (f.enrichment = 'sentiment'   AND fr.sentiment IS NULL)
+	   OR (f.enrichment = 'emotions'    AND fr.emotions_classified_at IS NULL AND fr.emotions IS NULL)
+	   OR (f.enrichment = 'translation' AND fr.translation_lang_key IS NULL)
+	GROUP BY f.enrichment, f.terminal`
+
+// CountFailedRecordsAggregate returns the cross-tenant failed-record counts per enrichment.
+//
+// Translation's un-enriched test is deliberately weaker than the per-tenant endpoint's: that one
+// compares against the tenant's EFFECTIVE target, which needs the settings join and the deployment
+// default. A gauge summed across tenants has no single target to compare against, so it asks only
+// whether the record has any translation at all. The consequence is that a record translated into
+// a since-changed target counts as done here while the endpoint counts it as pending — acceptable
+// for a deployment-wide gauge, and written down so the two are not mistaken for a bug when they
+// disagree.
+func (r *EnrichmentStatusRepository) CountFailedRecordsAggregate(
+	ctx context.Context,
+) ([]FailedRecordCount, error) {
+	rows, err := r.db.Query(ctx, countFailedRecordsAggregateSQL)
+	if err != nil {
+		return nil, fmt.Errorf("count failed records: %w", err)
+	}
+	defer rows.Close()
+
+	var counts []FailedRecordCount
+
+	for rows.Next() {
+		var count FailedRecordCount
+		if scanErr := rows.Scan(&count.Enrichment, &count.Terminal, &count.Count); scanErr != nil {
+			return nil, fmt.Errorf("scan failed records: %w", scanErr)
+		}
+
+		counts = append(counts, count)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read failed records: %w", err)
+	}
+
+	return counts, nil
+}

--- a/internal/repository/enrichment_status_repository.go
+++ b/internal/repository/enrichment_status_repository.go
@@ -170,16 +170,37 @@ const enrichmentCountFrom = `
 // one row, so this stays a lookup rather than a fan-out — the eligible and done counts would be
 // wrong if it did not.
 //
-// The join is on feedback_record_id ALONE. The markers carry a tenant_id column, but it exists for
-// its own index and is never the tenant boundary: that stays fr.tenant_id in the outer WHERE, so
-// the boundary has exactly one source of truth. See migration 022.
-const enrichmentFailureJoins = `
-	LEFT JOIN feedback_record_enrichment_failures fs
-		ON fs.feedback_record_id = fr.id AND fs.enrichment = 'sentiment'
-	LEFT JOIN feedback_record_enrichment_failures fe
-		ON fe.feedback_record_id = fr.id AND fe.enrichment = 'emotions'
-	LEFT JOIN feedback_record_enrichment_failures ft
-		ON ft.feedback_record_id = fr.id AND ft.enrichment = 'translation'`
+// THE TENANT BOUNDARY IS STILL fr.tenant_id IN THE OUTER WHERE. The markers' own tenant_id appears
+// here too, and the distinction matters: it is an ADDITIONAL predicate, never a replacement. A
+// join predicate can only narrow which marker attaches to a record, so it cannot pull in another
+// tenant's row; drop `fr.tenant_id = $n` and filter on the stamp instead and the boundary moves to
+// a denormalized column that is only as good as the write path that filled it. See migration 022.
+//
+// It is here for the index. Without it the planner has no tenant-side selectivity on the marker
+// table and hash-joins the WHOLE table three times, so a tenant with 2,500 records and no failures
+// of its own pays for every other tenant's: measured at 1M records / 300k markers, 3ms on the
+// pre-failure query became 32ms, scaling with the GLOBAL marker count rather than the tenant's.
+// One tenant's provider outage slowing everyone else's status endpoint is the part that made this
+// worth a predicate. With it, idx_enrichment_failures_tenant_enrichment applies and the same query
+// is 6ms.
+//
+// The trade is that a marker whose stamp disagreed with its record's tenant would stop being
+// counted. Nothing can produce that — one write site, tenant read from the record, and ON CONFLICT
+// does not update it — and under-counting is the safe direction: the record simply reads as still
+// in progress, which is what re-enqueueing it will fix.
+//
+// tenantParam must be the placeholder the outer WHERE uses for the tenant, so the two cannot drift.
+func enrichmentFailureJoins(tenantParam string) string {
+	join := func(alias, enrichment string) string {
+		return `
+	LEFT JOIN feedback_record_enrichment_failures ` + alias + `
+		ON ` + alias + `.feedback_record_id = fr.id
+		AND ` + alias + `.tenant_id = ` + tenantParam + `
+		AND ` + alias + `.enrichment = '` + enrichment + `'`
+	}
+
+	return join("fs", "sentiment") + join("fe", "emotions") + join("ft", "translation")
+}
 
 // The `fr.field_type = 'text'` predicate in the outer WHERE of both queries below is redundant
 // with enrichmentEligibleText inside every FILTER (so it can never change a count); it is hoisted
@@ -189,7 +210,7 @@ const enrichmentFailureJoins = `
 // default target language, $2 = tenant_id. The (tenant_id, field_type) pair matches
 // idx_feedback_records_tenant_field_type, so cost scales with the tenant's text-record count.
 var countEnrichmentStatusSQL = `SELECT ` + enrichmentCountSelect + `,` + failureCountColumns() +
-	enrichmentCountFrom + enrichmentFailureJoins + `
+	enrichmentCountFrom + enrichmentFailureJoins(`$2`) + `
 	WHERE fr.tenant_id = $2 AND fr.field_type = 'text'`
 
 // countEnrichmentBacklogAggregateSQL is the same SELECT without the tenant filter: it sums

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -300,7 +300,9 @@ func (r *FeedbackRecordsRepository) SetTranslation(
 				return fmt.Errorf("clear feedback record translation: %w", err)
 			}
 
-			return nil
+			// The record now has no translation and, with empty text, is owed none — so a marker
+			// describing a failed attempt on the old text has nothing left to describe.
+			return clearEnrichmentFailure(ctx, dbTx, feedbackRecordID, models.EnrichmentNameTranslation)
 		}
 
 		// Setting a translation persists only while langKey still equals the tenant's current
@@ -335,7 +337,7 @@ func (r *FeedbackRecordsRepository) SetTranslation(
 			return huberrors.ErrTranslationSuperseded
 		}
 
-		return nil
+		return clearEnrichmentFailure(ctx, dbTx, feedbackRecordID, models.EnrichmentNameTranslation)
 	})
 }
 
@@ -396,7 +398,7 @@ func (r *FeedbackRecordsRepository) SetSentiment(
 			return huberrors.NewNotFoundError("feedback record", "feedback record not found")
 		}
 
-		return nil
+		return clearEnrichmentFailure(ctx, dbTx, feedbackRecordID, models.EnrichmentNameSentiment)
 	})
 }
 
@@ -1204,6 +1206,41 @@ func (r *FeedbackRecordsRepository) writeEmotions(
 			return huberrors.NewNotFoundError("feedback record", "feedback record not found")
 		}
 
-		return nil
+		return clearEnrichmentFailure(ctx, dbTx, feedbackRecordID, models.EnrichmentNameEmotions)
 	})
+}
+
+// clearEnrichmentFailure removes the failure marker for one (record, enrichment) as part of the
+// successful write that resolved it.
+//
+// The markers were designed as advisory — write-free on success, on the reasoning that "a stale
+// row stops counting the moment the record is done". That has a hole: done is not permanent.
+// Editing value_text nulls the translation columns, and changing a tenant's target_language shifts
+// the effective target so an already-translated record stops matching it. Either revives a marker
+// from a failure resolved long ago, and the endpoint then reports `failed` for work that is merely
+// re-queued — the wrong-progress symptom the whole feature exists to remove.
+//
+// So success cleans up after itself. One indexed delete against the primary key, inside a
+// transaction the write already opens, and a no-op probe when there is no marker — the
+// overwhelmingly common case, since most records never fail.
+//
+// A timestamp comparison was tried first and is the wrong shape: updated_at is RECORD-level while
+// markers are per (record, enrichment), so a successful sentiment write would invalidate the
+// emotions and translation markers too. On a real run that silently dropped 7% of records out of
+// the accounted set.
+//
+// This does NOT run on the failure paths, which upsert: the newest outcome for a (record,
+// enrichment) is the one worth keeping.
+func clearEnrichmentFailure(
+	ctx context.Context, dbTx tenantWriteTx, feedbackRecordID uuid.UUID, enrichment string,
+) error {
+	if _, err := dbTx.Exec(ctx, `
+		DELETE FROM feedback_record_enrichment_failures
+		WHERE feedback_record_id = $1 AND enrichment = $2`,
+		feedbackRecordID, enrichment,
+	); err != nil {
+		return fmt.Errorf("clear enrichment failure marker: %w", err)
+	}
+
+	return nil
 }

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -239,7 +239,11 @@ func (r *TenantDataRepository) feedbackRecordsHighWaterMark(
 // the caller's final phase once the records are gone — see PurgeFeedbackRecordsByTenant. What this
 // purge never touches is webhooks and tenant_settings: those are tenant configuration, not tenant
 // data. Enrichment output (sentiment, emotions, translations) needs no statement of its own — it
-// lives in columns on feedback_records and goes with the row.
+// lives in columns on feedback_records and goes with the row. Enrichment FAILURE markers
+// (feedback_record_enrichment_failures, migration 022) do have a table of their own but are left
+// to ON DELETE CASCADE: they are internal derived state, and unlike the tables above no caller has
+// a use for a count of them. That makes them the one derived table here whose removal nothing
+// would notice, so an integration test asserts it — see tests/feedback_records_purge_test.go.
 func purgeFeedbackRecordsBatchInTx(
 	ctx context.Context, transaction tenantWriteTx, tenantID string, highWaterMark uuid.UUID, limit int,
 ) (*models.FeedbackRecordsPurgeCounts, error) {

--- a/internal/service/client_factory_usage_parity_test.go
+++ b/internal/service/client_factory_usage_parity_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryProviderClientRecordsUsage walks the factories' own source and asserts that every
+// provider-client construction passes a usage recorder.
+//
+// This is a parity check rather than a behavioural one because the failure it guards against is
+// SILENT. A factory that forgets the recorder still builds, still enriches, still passes every
+// other test — it just stops reporting what it costs, and nobody notices until someone asks why
+// the token dashboard is empty for half the deployments. That is exactly what happened: the
+// recorder was threaded through the OpenAI factories and not the Google ones, so any deployment on
+// google or google-gemini recorded nothing at all.
+//
+// Reading the AST rather than grepping means a renamed option or a construction split across lines
+// is still matched, and adding a fifth enrichment fails here rather than in production silence.
+func TestEveryProviderClientRecordsUsage(t *testing.T) {
+	constructors := map[string]bool{
+		"openai.NewClient":               true,
+		"googleai.NewClient":             true,
+		"googleai.NewGoogleGeminiClient": true,
+	}
+
+	files, err := filepath.Glob("*_client_factory.go")
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "the factories must be where this test expects them")
+
+	fset := token.NewFileSet()
+	found := 0
+
+	for _, file := range files {
+		parsed, parseErr := parser.ParseFile(fset, file, nil, parser.ParseComments)
+		require.NoError(t, parseErr)
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, isCall := node.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+
+			name := callName(call.Fun)
+			if !constructors[name] {
+				return true
+			}
+
+			found++
+
+			require.True(t, passesUsageRecorder(call),
+				"%s: %s at line %d constructs a provider client without a usage recorder; "+
+					"its tokens and durations would go unreported",
+				file, name, fset.Position(call.Pos()).Line)
+
+			return true
+		})
+	}
+
+	// A guard that matches nothing passes vacuously, which is the failure mode of every
+	// source-reading test. Pin the count so a rename that stops matching is itself a failure.
+	require.GreaterOrEqual(t, found, 12,
+		"expected at least the four OpenAI and eight Google construction sites, found %d — "+
+			"if a constructor was renamed, update this test rather than deleting it", found)
+}
+
+// callName renders a selector call such as googleai.NewClient as "googleai.NewClient".
+func callName(fun ast.Expr) string {
+	selector, isSelector := fun.(*ast.SelectorExpr)
+	if !isSelector {
+		return ""
+	}
+
+	pkg, isIdent := selector.X.(*ast.Ident)
+	if !isIdent {
+		return ""
+	}
+
+	return pkg.Name + "." + selector.Sel.Name
+}
+
+// passesUsageRecorder reports whether any argument is a WithUsageRecorder option.
+func passesUsageRecorder(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		inner, isCall := arg.(*ast.CallExpr)
+		if !isCall {
+			continue
+		}
+
+		if strings.HasSuffix(callName(inner.Fun), ".WithUsageRecorder") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/service/embedding_client_factory.go
+++ b/internal/service/embedding_client_factory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/formbricks/hub/internal/googleai"
+	"github.com/formbricks/hub/internal/llm"
 	"github.com/formbricks/hub/internal/openai"
 )
 
@@ -37,6 +38,8 @@ type EmbeddingClientConfig struct {
 	Normalize           bool
 	GoogleCloudProject  string
 	GoogleCloudLocation string
+	// UsageRecorder receives each provider call's token counts and duration. nil disables it.
+	UsageRecorder llm.UsageRecorder
 }
 
 func (c EmbeddingClientConfig) clientProvider() string            { return c.Provider }
@@ -71,6 +74,7 @@ func openAIEmbeddingFactory(_ context.Context, cfg EmbeddingClientConfig) (Embed
 	return openai.NewClient(cfg.ProviderAPIKey,
 		openai.WithModel(cfg.Model),
 		openai.WithBaseURL(cfg.BaseURL),
+		openai.WithUsageRecorder(cfg.UsageRecorder),
 		openai.WithNormalize(cfg.Normalize),
 	), nil
 }

--- a/internal/service/embedding_client_factory.go
+++ b/internal/service/embedding_client_factory.go
@@ -83,6 +83,7 @@ func googleEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig) (Emb
 	client, err := googleai.NewClient(ctx, cfg.ProviderAPIKey,
 		googleai.WithModel(cfg.Model),
 		googleai.WithNormalize(cfg.Normalize),
+		googleai.WithUsageRecorder(cfg.UsageRecorder),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create google embedding client: %w", err)
@@ -95,6 +96,7 @@ func googleGeminiEmbeddingFactory(ctx context.Context, cfg EmbeddingClientConfig
 	client, err := googleai.NewGoogleGeminiClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
 		googleai.WithModel(cfg.Model),
 		googleai.WithNormalize(cfg.Normalize),
+		googleai.WithUsageRecorder(cfg.UsageRecorder),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create google-gemini embedding client: %w", err)

--- a/internal/service/emotions_client_factory.go
+++ b/internal/service/emotions_client_factory.go
@@ -51,7 +51,8 @@ func openAIEmotionsFactory(_ context.Context, cfg EmotionsClientConfig) (Emotion
 }
 
 func googleEmotionsFactory(ctx context.Context, cfg EmotionsClientConfig) (EmotionsClient, error) {
-	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey, googleai.WithModel(cfg.Model))
+	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey,
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google emotions client: %w", err)
 	}
@@ -61,7 +62,7 @@ func googleEmotionsFactory(ctx context.Context, cfg EmotionsClientConfig) (Emoti
 
 func googleGeminiEmotionsFactory(ctx context.Context, cfg EmotionsClientConfig) (EmotionsClient, error) {
 	raw, err := googleai.NewGoogleGeminiClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
-		googleai.WithModel(cfg.Model))
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google-gemini emotions client: %w", err)
 	}

--- a/internal/service/emotions_client_factory.go
+++ b/internal/service/emotions_client_factory.go
@@ -44,6 +44,7 @@ func openAIEmotionsFactory(_ context.Context, cfg EmotionsClientConfig) (Emotion
 	raw := openai.NewClient(cfg.ProviderAPIKey,
 		openai.WithModel(cfg.Model),
 		openai.WithBaseURL(cfg.BaseURL),
+		openai.WithUsageRecorder(cfg.UsageRecorder),
 	)
 
 	return promptEmotionsClient{raw: raw}, nil

--- a/internal/service/enrichment_client_factory.go
+++ b/internal/service/enrichment_client_factory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/formbricks/hub/internal/llm"
 )
 
 // Provider identifiers shared by every enrichment client — sentiment, translation, and
@@ -29,6 +31,9 @@ type EnrichmentClientConfig struct {
 	BaseURL             string
 	GoogleCloudProject  string
 	GoogleCloudLocation string
+	// UsageRecorder receives each provider call's token counts and duration. nil disables
+	// recording; the backfill commands and tests leave it unset.
+	UsageRecorder llm.UsageRecorder
 }
 
 func (c EnrichmentClientConfig) clientProvider() string            { return c.Provider }

--- a/internal/service/enrichment_status_service.go
+++ b/internal/service/enrichment_status_service.go
@@ -79,25 +79,71 @@ func (s *EnrichmentStatusService) GetEnrichmentStatus(
 		return nil, fmt.Errorf("count enrichment status: %w", err)
 	}
 
-	translationEnabled := s.translationConfigured &&
-		resolveTargetLang(settings.Settings.TargetLanguage, s.defaultLang) != ""
+	// Stamped after the count returns, so AsOf describes when the numbers were true rather than
+	// when the response happened to be written. UTC because it crosses a process boundary.
+	asOf := time.Now().UTC()
 
 	return &models.EnrichmentStatusResponse{
 		TenantID: normalizedTenantID,
-		Translation: enrichmentTypeStatus(translationEnabled,
+		AsOf:     asOf,
+		Translation: enrichmentTypeStatus(
+			translationDisabledReason(s.translationConfigured,
+				resolveTargetLang(settings.Settings.TargetLanguage, s.defaultLang)),
 			counts.TranslationEligible, counts.TranslationDone),
-		Sentiment: enrichmentTypeStatus(s.sentimentConfigured && settings.Settings.SentimentEnrichmentEnabled(),
+		Sentiment: enrichmentTypeStatus(
+			switchedEnrichmentDisabledReason(s.sentimentConfigured,
+				settings.Settings.SentimentEnrichmentEnabled()),
 			counts.SentimentEligible, counts.SentimentDone),
-		Emotions: enrichmentTypeStatus(s.emotionsConfigured && settings.Settings.EmotionsEnrichmentEnabled(),
+		Emotions: enrichmentTypeStatus(
+			switchedEnrichmentDisabledReason(s.emotionsConfigured,
+				settings.Settings.EmotionsEnrichmentEnabled()),
 			counts.EmotionsEligible, counts.EmotionsDone),
 	}, nil
 }
 
-// enrichmentTypeStatus assembles one enrichment's status, zeroing the counts when it is not
-// enabled for the tenant so the API never reports a backlog for work that will never run.
-func enrichmentTypeStatus(enabled bool, eligible, done int64) models.EnrichmentTypeStatus {
-	if !enabled {
-		return models.EnrichmentTypeStatus{Enabled: false}
+// switchedEnrichmentDisabledReason resolves the two gates guarding sentiment and emotions:
+// the deployment provider+model gate, then the tenant's tri-state switch. An empty result means
+// the enrichment is enabled.
+//
+// The deployment gate is reported first when both are closed. It is the outer gate and the one an
+// operator can act on; telling a tenant "you switched it off" when no provider is configured at all
+// would send them to a setting that changes nothing.
+func switchedEnrichmentDisabledReason(configured, switchedOn bool) models.DisabledReason {
+	switch {
+	case !configured:
+		return models.DisabledReasonNotConfigured
+	case !switchedOn:
+		return models.DisabledReasonSwitchedOff
+	default:
+		return ""
+	}
+}
+
+// translationDisabledReason resolves translation's gates: the deployment provider+model gate, then
+// a resolvable effective target language (the tenant's own, else the deployment default). An empty
+// result means translation is enabled.
+//
+// Translation has no on/off switch, so it can never report switched_off — an unresolvable target
+// IS its off state, and that is what no_target_language says.
+func translationDisabledReason(configured bool, effectiveTarget string) models.DisabledReason {
+	switch {
+	case !configured:
+		return models.DisabledReasonNotConfigured
+	case effectiveTarget == "":
+		return models.DisabledReasonNoTargetLanguage
+	default:
+		return ""
+	}
+}
+
+// enrichmentTypeStatus assembles one enrichment's status from the gate decision, zeroing the counts
+// when it is not enabled so the API never reports a backlog for work that will never run.
+//
+// Enabled and DisabledReason are derived from the same value here rather than passed separately, so
+// the response cannot carry an enabled enrichment with a reason, or a disabled one without.
+func enrichmentTypeStatus(reason models.DisabledReason, eligible, done int64) models.EnrichmentTypeStatus {
+	if reason != "" {
+		return models.EnrichmentTypeStatus{Enabled: false, DisabledReason: reason}
 	}
 
 	return models.EnrichmentTypeStatus{Enabled: true, Eligible: eligible, Done: done}

--- a/internal/service/enrichment_status_service.go
+++ b/internal/service/enrichment_status_service.go
@@ -89,15 +89,24 @@ func (s *EnrichmentStatusService) GetEnrichmentStatus(
 		Translation: enrichmentTypeStatus(
 			translationDisabledReason(s.translationConfigured,
 				resolveTargetLang(settings.Settings.TargetLanguage, s.defaultLang)),
-			counts.TranslationEligible, counts.TranslationDone),
+			enrichmentCounts{
+				eligible: counts.TranslationEligible, done: counts.TranslationDone,
+				failed: counts.TranslationFailed, failedTerminal: counts.TranslationFailedTerminal,
+			}),
 		Sentiment: enrichmentTypeStatus(
 			switchedEnrichmentDisabledReason(s.sentimentConfigured,
 				settings.Settings.SentimentEnrichmentEnabled()),
-			counts.SentimentEligible, counts.SentimentDone),
+			enrichmentCounts{
+				eligible: counts.SentimentEligible, done: counts.SentimentDone,
+				failed: counts.SentimentFailed, failedTerminal: counts.SentimentFailedTerminal,
+			}),
 		Emotions: enrichmentTypeStatus(
 			switchedEnrichmentDisabledReason(s.emotionsConfigured,
 				settings.Settings.EmotionsEnrichmentEnabled()),
-			counts.EmotionsEligible, counts.EmotionsDone),
+			enrichmentCounts{
+				eligible: counts.EmotionsEligible, done: counts.EmotionsDone,
+				failed: counts.EmotionsFailed, failedTerminal: counts.EmotionsFailedTerminal,
+			}),
 	}, nil
 }
 
@@ -141,10 +150,25 @@ func translationDisabledReason(configured bool, effectiveTarget string) models.D
 //
 // Enabled and DisabledReason are derived from the same value here rather than passed separately, so
 // the response cannot carry an enabled enrichment with a reason, or a disabled one without.
-func enrichmentTypeStatus(reason models.DisabledReason, eligible, done int64) models.EnrichmentTypeStatus {
+// enrichmentCounts groups one enrichment's four numbers so they travel together. Passing them as
+// four positional int64s invited a silent transposition every time another pair was added.
+type enrichmentCounts struct {
+	eligible       int64
+	done           int64
+	failed         int64
+	failedTerminal int64
+}
+
+func enrichmentTypeStatus(reason models.DisabledReason, counts enrichmentCounts) models.EnrichmentTypeStatus {
 	if reason != "" {
 		return models.EnrichmentTypeStatus{Enabled: false, DisabledReason: reason}
 	}
 
-	return models.EnrichmentTypeStatus{Enabled: true, Eligible: eligible, Done: done}
+	return models.EnrichmentTypeStatus{
+		Enabled:        true,
+		Eligible:       counts.eligible,
+		Done:           counts.done,
+		Failed:         counts.failed,
+		FailedTerminal: counts.failedTerminal,
+	}
 }

--- a/internal/service/enrichment_status_service_test.go
+++ b/internal/service/enrichment_status_service_test.go
@@ -179,7 +179,6 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 
 			svc := NewEnrichmentStatusService(params)
 
-			before := time.Now().UTC()
 			got, err := svc.GetEnrichmentStatus(context.Background(), "  tenant-1 ")
 			require.NoError(t, err)
 
@@ -189,11 +188,15 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			assert.Equal(t, testCase.wantSent, got.Sentiment)
 			assert.Equal(t, testCase.wantEmotion, got.Emotions)
 
-			// AsOf must be a real stamp taken during the call, not a zero value the JSON encoder
-			// would happily render as year 1 — a client differencing two of those gets nonsense.
+			// AsOf must be a real stamp, not the zero value the JSON encoder would happily render as
+			// year 1 — a client differencing two of those gets nonsense.
+			//
+			// Bounded generously rather than pinned between two time.Now() reads taken around the
+			// call: .UTC() strips the monotonic clock reading, so tight bounds are pure wall-clock
+			// and an NTP step backwards mid-test would fail them with no defect in the code. An hour
+			// still catches a zero value or a wrong clock source, and cannot flake.
 			assert.False(t, got.AsOf.IsZero(), "as_of is stamped")
-			assert.False(t, got.AsOf.Before(before), "as_of is taken during the call")
-			assert.False(t, got.AsOf.After(time.Now().UTC()), "as_of is not in the future")
+			assert.WithinDuration(t, time.Now().UTC(), got.AsOf, time.Hour, "as_of is a current stamp")
 			assert.Equal(t, time.UTC, got.AsOf.Location(), "as_of is UTC")
 
 			// enabled and disabled_reason are derived from one decision, so they can never disagree.

--- a/internal/service/enrichment_status_service_test.go
+++ b/internal/service/enrichment_status_service_test.go
@@ -52,6 +52,11 @@ var fullCounts = repository.EnrichmentStatusCounts{
 	TranslationEligible: 10, TranslationDone: 4,
 	SentimentEligible: 8, SentimentDone: 3,
 	EmotionsEligible: 6, EmotionsDone: 2,
+	// Distinct values per bucket so a transposition between failed and failed_terminal, or across
+	// enrichments, shows up as a wrong number rather than a coincidence.
+	TranslationFailed: 5, TranslationFailedTerminal: 1,
+	SentimentFailed: 4, SentimentFailedTerminal: 2,
+	EmotionsFailed: 3, EmotionsFailedTerminal: 7,
 }
 
 func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
@@ -72,9 +77,9 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
 			},
 			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3, Failed: 4, FailedTerminal: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			name: "sentiment not deployment-configured is zeroed",
@@ -82,11 +87,11 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: false, EmotionsConfigured: true,
 			},
 			settings:  &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
-			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
 			wantSent: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
 			},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			name: "tenant emotions switch off is zeroed",
@@ -96,8 +101,8 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
 				TargetLanguage: "de-DE", EmotionsEnabled: &emotionsOff,
 			}},
-			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:  models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
+			wantSent:  models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3, Failed: 4, FailedTerminal: 2},
 			wantEmotion: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
 			},
@@ -111,8 +116,8 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			wantTrans: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonNoTargetLanguage,
 			},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3, Failed: 4, FailedTerminal: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			// Translation has a perfectly good target, so only the deployment gate can be the
@@ -125,8 +130,8 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			wantTrans: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
 			},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3, Failed: 4, FailedTerminal: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			name: "tenant sentiment switch off is reported as switched_off",
@@ -136,11 +141,11 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
 				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
 			}},
-			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
 			wantSent: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
 			},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			// Both gates closed at once. The deployment gate must win: sending a tenant to a switch
@@ -152,11 +157,11 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
 				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
 			}},
-			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
 			wantSent: models.EnrichmentTypeStatus{
 				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
 			},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 		{
 			name: "translation enabled via default-language fallback",
@@ -164,9 +169,9 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
 			},
 			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4, Failed: 5, FailedTerminal: 1},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3, Failed: 4, FailedTerminal: 2},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2, Failed: 3, FailedTerminal: 7},
 		},
 	}
 
@@ -198,6 +203,17 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			assert.False(t, got.AsOf.IsZero(), "as_of is stamped")
 			assert.WithinDuration(t, time.Now().UTC(), got.AsOf, time.Hour, "as_of is a current stamp")
 			assert.Equal(t, time.UTC, got.AsOf.Location(), "as_of is UTC")
+
+			// A disabled enrichment reports no counts at all, including failures: the API must not
+			// show a backlog of failed work for a pipeline that will never run.
+			for name, status := range map[string]models.EnrichmentTypeStatus{
+				"translation": got.Translation, "sentiment": got.Sentiment, "emotions": got.Emotions,
+			} {
+				if !status.Enabled {
+					assert.Zero(t, status.Failed, "%s: disabled must report no failures", name)
+					assert.Zero(t, status.FailedTerminal, "%s: disabled must report no terminal failures", name)
+				}
+			}
 
 			// enabled and disabled_reason are derived from one decision, so they can never disagree.
 			for name, status := range map[string]models.EnrichmentTypeStatus{

--- a/internal/service/enrichment_status_service_test.go
+++ b/internal/service/enrichment_status_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,7 @@ var fullCounts = repository.EnrichmentStatusCounts{
 
 func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 	emotionsOff := false
+	sentimentOff := false
 
 	cases := []struct {
 		name        string
@@ -79,9 +81,11 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			params: NewEnrichmentStatusServiceParams{
 				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: false, EmotionsConfigured: true,
 			},
-			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: false},
+			settings:  &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
 		},
 		{
@@ -92,18 +96,66 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
 				TargetLanguage: "de-DE", EmotionsEnabled: &emotionsOff,
 			}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
-			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
-			wantEmotion: models.EnrichmentTypeStatus{Enabled: false},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent:  models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
 		},
 		{
 			name: "translation with no target and no default is zeroed",
 			params: NewEnrichmentStatusServiceParams{
 				DefaultLang: "", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
 			},
-			settings:    &models.TenantSettings{Settings: models.EnrichmentSettings{}},
-			wantTrans:   models.EnrichmentTypeStatus{Enabled: false},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{}},
+			wantTrans: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNoTargetLanguage,
+			},
 			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			// Translation has a perfectly good target, so only the deployment gate can be the
+			// reason — proves the target check does not shadow it.
+			name: "translation not deployment-configured reports not_configured, not no_target_language",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: false, SentimentConfigured: true, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{TargetLanguage: "de-DE"}},
+			wantTrans: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
+			wantSent:    models.EnrichmentTypeStatus{Enabled: true, Eligible: 8, Done: 3},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			name: "tenant sentiment switch off is reported as switched_off",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: true, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
+				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
+			}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonSwitchedOff,
+			},
+			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
+		},
+		{
+			// Both gates closed at once. The deployment gate must win: sending a tenant to a switch
+			// that changes nothing (because no provider is configured at all) is the wrong fix.
+			name: "both gates closed reports the deployment gate, not the tenant switch",
+			params: NewEnrichmentStatusServiceParams{
+				DefaultLang: "en-US", TranslationConfigured: true, SentimentConfigured: false, EmotionsConfigured: true,
+			},
+			settings: &models.TenantSettings{Settings: models.EnrichmentSettings{
+				TargetLanguage: "de-DE", SentimentEnabled: &sentimentOff,
+			}},
+			wantTrans: models.EnrichmentTypeStatus{Enabled: true, Eligible: 10, Done: 4},
+			wantSent: models.EnrichmentTypeStatus{
+				Enabled: false, DisabledReason: models.DisabledReasonNotConfigured,
+			},
 			wantEmotion: models.EnrichmentTypeStatus{Enabled: true, Eligible: 6, Done: 2},
 		},
 		{
@@ -127,6 +179,7 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 
 			svc := NewEnrichmentStatusService(params)
 
+			before := time.Now().UTC()
 			got, err := svc.GetEnrichmentStatus(context.Background(), "  tenant-1 ")
 			require.NoError(t, err)
 
@@ -135,6 +188,24 @@ func TestEnrichmentStatusService_GetEnrichmentStatus(t *testing.T) {
 			assert.Equal(t, testCase.wantTrans, got.Translation)
 			assert.Equal(t, testCase.wantSent, got.Sentiment)
 			assert.Equal(t, testCase.wantEmotion, got.Emotions)
+
+			// AsOf must be a real stamp taken during the call, not a zero value the JSON encoder
+			// would happily render as year 1 — a client differencing two of those gets nonsense.
+			assert.False(t, got.AsOf.IsZero(), "as_of is stamped")
+			assert.False(t, got.AsOf.Before(before), "as_of is taken during the call")
+			assert.False(t, got.AsOf.After(time.Now().UTC()), "as_of is not in the future")
+			assert.Equal(t, time.UTC, got.AsOf.Location(), "as_of is UTC")
+
+			// enabled and disabled_reason are derived from one decision, so they can never disagree.
+			for name, status := range map[string]models.EnrichmentTypeStatus{
+				"translation": got.Translation, "sentiment": got.Sentiment, "emotions": got.Emotions,
+			} {
+				if status.Enabled {
+					assert.Empty(t, status.DisabledReason, "%s: enabled must carry no reason", name)
+				} else {
+					assert.NotEmpty(t, status.DisabledReason, "%s: disabled must carry a reason", name)
+				}
+			}
 		})
 	}
 }

--- a/internal/service/sentiment_client_factory.go
+++ b/internal/service/sentiment_client_factory.go
@@ -51,7 +51,8 @@ func openAISentimentFactory(_ context.Context, cfg SentimentClientConfig) (Senti
 }
 
 func googleSentimentFactory(ctx context.Context, cfg SentimentClientConfig) (SentimentClient, error) {
-	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey, googleai.WithModel(cfg.Model))
+	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey,
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google sentiment client: %w", err)
 	}
@@ -61,7 +62,7 @@ func googleSentimentFactory(ctx context.Context, cfg SentimentClientConfig) (Sen
 
 func googleGeminiSentimentFactory(ctx context.Context, cfg SentimentClientConfig) (SentimentClient, error) {
 	raw, err := googleai.NewGoogleGeminiClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
-		googleai.WithModel(cfg.Model))
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google-gemini sentiment client: %w", err)
 	}

--- a/internal/service/sentiment_client_factory.go
+++ b/internal/service/sentiment_client_factory.go
@@ -44,6 +44,7 @@ func openAISentimentFactory(_ context.Context, cfg SentimentClientConfig) (Senti
 	raw := openai.NewClient(cfg.ProviderAPIKey,
 		openai.WithModel(cfg.Model),
 		openai.WithBaseURL(cfg.BaseURL),
+		openai.WithUsageRecorder(cfg.UsageRecorder),
 	)
 
 	return promptSentimentClient{raw: raw}, nil

--- a/internal/service/translation_client_factory.go
+++ b/internal/service/translation_client_factory.go
@@ -96,6 +96,7 @@ func openAITranslationFactory(_ context.Context, cfg TranslationClientConfig) (T
 	raw := openai.NewClient(cfg.ProviderAPIKey,
 		openai.WithModel(cfg.Model),
 		openai.WithBaseURL(cfg.BaseURL),
+		openai.WithUsageRecorder(cfg.UsageRecorder),
 	)
 
 	return promptTranslationClient{raw: raw}, nil

--- a/internal/service/translation_client_factory.go
+++ b/internal/service/translation_client_factory.go
@@ -103,7 +103,8 @@ func openAITranslationFactory(_ context.Context, cfg TranslationClientConfig) (T
 }
 
 func googleTranslationFactory(ctx context.Context, cfg TranslationClientConfig) (TranslationClient, error) {
-	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey, googleai.WithModel(cfg.Model))
+	raw, err := googleai.NewClient(ctx, cfg.ProviderAPIKey,
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google translation client: %w", err)
 	}
@@ -113,7 +114,7 @@ func googleTranslationFactory(ctx context.Context, cfg TranslationClientConfig) 
 
 func googleGeminiTranslationFactory(ctx context.Context, cfg TranslationClientConfig) (TranslationClient, error) {
 	raw, err := googleai.NewGoogleGeminiClient(ctx, cfg.GoogleCloudProject, cfg.GoogleCloudLocation,
-		googleai.WithModel(cfg.Model))
+		googleai.WithModel(cfg.Model), googleai.WithUsageRecorder(cfg.UsageRecorder))
 	if err != nil {
 		return nil, fmt.Errorf("create google-gemini translation client: %w", err)
 	}

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -374,6 +374,11 @@ func (w *enrichmentWorker[A, R]) markFailed(
 		return
 	}
 
+	// Counted, not just logged. This is the one path that silently degrades the feature: the
+	// enrichment outcome is unaffected, the job finishes normally, and the only symptom is a
+	// status endpoint quietly under-reporting failures. Without a counter nothing is alertable
+	// and the gap is invisible until somebody notices the arithmetic does not close.
+	w.cfg.metrics.workerError(ctx, "failure_marker_write_failed")
 	log.Error(w.cfg.name+": could not record enrichment failure; the API will under-report it",
 		"terminal", terminal, "reason", reason, "error", err)
 }

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/formbricks/hub/internal/huberrors"
 	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/observability"
 )
 
 // enrichmentWorkerMetrics records the worker-side metrics as function fields rather than an
@@ -105,6 +106,10 @@ type enrichmentWorkerConfig[A river.JobArgs, R any] struct {
 	// what failed and anything re-enqueueing unfinished work knows what to skip. nil disables
 	// recording, which is how the embedding pipeline and the unit tests opt out.
 	failures FailureRecorder
+	// failureMetrics counts permanent give-ups by cause. Separate from the marker: the marker is
+	// per-record state the API reads, this is an aggregate signal for whoever watches the
+	// deployment. nil disables it.
+	failureMetrics observability.EnrichmentFailureMetrics
 
 	metrics enrichmentWorkerMetrics
 }
@@ -283,6 +288,11 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 	// is pointless.
 	if reason, terminal := huberrors.TerminalReasonOf(err); terminal {
 		w.markFailed(ctx, log, record, job.Attempt, true, string(reason))
+
+		if cfg.failureMetrics != nil {
+			cfg.failureMetrics.RecordTerminalFailure(ctx, cfg.name, string(reason))
+		}
+
 		w.recordOutcome(ctx, "failed_final", start)
 		log.Error(cfg.name+": provider failed permanently for this record, not retrying",
 			"reason", string(reason), "attempt", job.Attempt, "error", err)

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -41,9 +41,15 @@ type FailureRecorder interface {
 	RecordFailure(ctx context.Context, failure models.EnrichmentFailure) error
 }
 
-// enrichmentFailureWriteTimeout bounds the detached marker write. Short on purpose: it runs after
-// a job has already failed, often while the provider is unhealthy, and must not extend the job.
-const enrichmentFailureWriteTimeout = 5 * time.Second
+// enrichmentFailureWriteTimeout bounds the detached marker write.
+//
+// It DOES extend the failing job by up to this long, because the write runs inside Work() before
+// it returns. That is the cost of recording the failure at all, and it is bounded deliberately:
+// the write happens only on a final or terminal attempt, and a correlated outage — a provider
+// failing every call while the database is also slow — is exactly when many jobs reach that point
+// at once and worker slots are scarcest. One second is enough for a healthy write and cheap to
+// lose when nothing is healthy.
+const enrichmentFailureWriteTimeout = time.Second
 
 // enrichmentJobTimeout limits one enrichment job run; shared by all four pipelines (LLM and
 // embedding calls dominate, and every provider client keeps its own shorter HTTP timeout).
@@ -332,7 +338,9 @@ func (w *enrichmentWorker[A, R]) markFailed(
 		return
 	}
 
-	if errors.Is(err, huberrors.ErrTenantWriteConflict) {
+	// Both mean the record is going away, so there is nothing left to describe: a purge holds the
+	// tenant, or the record was deleted between the enrichment attempt and this write.
+	if errors.Is(err, huberrors.ErrTenantWriteConflict) || errors.Is(err, huberrors.ErrNotFound) {
 		log.Info(w.cfg.name+": failure marker skipped, record or tenant is going away", "error", err)
 
 		return

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -290,13 +290,16 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 	// attempts, and cancel rather than error so River does not schedule a retry it already knows
 	// is pointless.
 	if reason, terminal := huberrors.TerminalReasonOf(err); terminal {
-		w.markFailed(ctx, log, record, job.Attempt, true, string(reason))
-
 		if cfg.failureMetrics != nil {
 			cfg.failureMetrics.RecordTerminalFailure(ctx, cfg.name, string(reason))
 		}
 
+		// Outcome BEFORE the marker write. recordOutcome measures time.Since(start), and markFailed
+		// blocks for up to enrichmentFailureWriteTimeout, so writing the marker first would let a
+		// slow database add a second to the duration histogram — making a database incident read as
+		// a slow provider, which is the one confusion these metrics exist to prevent.
 		w.recordOutcome(ctx, "failed_final", start)
+		w.markFailed(ctx, log, record, job.Attempt, true, string(reason))
 		log.Error(cfg.name+": provider failed permanently for this record, not retrying",
 			"reason", string(reason), "attempt", job.Attempt, "error", err)
 
@@ -305,8 +308,8 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 	}
 
 	if job.Attempt >= job.MaxAttempts {
-		w.markFailed(ctx, log, record, job.Attempt, false, models.EnrichmentFailureReasonProviderError)
 		w.recordOutcome(ctx, "failed_final", start)
+		w.markFailed(ctx, log, record, job.Attempt, false, models.EnrichmentFailureReasonProviderError)
 		log.Error(cfg.name+": provider failed (final attempt)", "error", err)
 
 		return fmt.Errorf("%s (final attempt): %w", cfg.classifyErrVerb, err)
@@ -427,6 +430,11 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 		// alerts on one-off DB blips.)
 		outcome := retryOutcome(isLastAttempt)
 
+		// Outcome before the marker write, for the reason given on the terminal classify path:
+		// markFailed can block for up to a second and would otherwise land in this histogram.
+		cfg.metrics.workerError(ctx, "update_failed")
+		w.recordOutcome(ctx, outcome, start)
+
 		if isLastAttempt {
 			// Best-effort, and most likely to fail exactly when it matters: if the database is
 			// what broke, this write breaks too. It still earns its place — a write failure
@@ -435,8 +443,6 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 			w.markFailed(ctx, log, record, attempt, false, models.EnrichmentFailureReasonWriteFailed)
 		}
 
-		cfg.metrics.workerError(ctx, "update_failed")
-		w.recordOutcome(ctx, outcome, start)
 		log.Error(cfg.name+": set result failed",
 			"final_attempt", isLastAttempt, "error", err)
 

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -34,6 +34,17 @@ var noopEnrichmentWorkerMetrics = enrichmentWorkerMetrics{
 	workerError: func(context.Context, string) {},
 }
 
+// FailureRecorder persists a durable marker for an enrichment that gave up on a record. Satisfied
+// by repository.EnrichmentFailuresRepository; declared here so the worker depends on the behaviour
+// rather than on the repository.
+type FailureRecorder interface {
+	RecordFailure(ctx context.Context, failure models.EnrichmentFailure) error
+}
+
+// enrichmentFailureWriteTimeout bounds the detached marker write. Short on purpose: it runs after
+// a job has already failed, often while the provider is unhealthy, and must not extend the job.
+const enrichmentFailureWriteTimeout = 5 * time.Second
+
 // enrichmentJobTimeout limits one enrichment job run; shared by all four pipelines (LLM and
 // embedding calls dominate, and every provider client keeps its own shorter HTTP timeout).
 const enrichmentJobTimeout = 30 * time.Second
@@ -83,6 +94,11 @@ type enrichmentWorkerConfig[A river.JobArgs, R any] struct {
 	// logResult returns extra slog attributes for the classify-success log (e.g. the sentiment
 	// label and score), or nil to log only the record id.
 	logResult func(result R) []any
+
+	// failures records a durable marker when a classify attempt gives up, so the API can report
+	// what failed and anything re-enqueueing unfinished work knows what to skip. nil disables
+	// recording, which is how the embedding pipeline and the unit tests opt out.
+	failures FailureRecorder
 
 	metrics enrichmentWorkerMetrics
 }
@@ -213,7 +229,7 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 
 	result, err := cfg.classify(ctx, record, job.Args)
 	if err != nil {
-		return w.handleClassifyError(ctx, err, log, start, job)
+		return w.handleClassifyError(ctx, err, log, start, job, record)
 	}
 
 	if err := cfg.persist(ctx, record, job.Args, &result); err != nil {
@@ -236,7 +252,8 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 // snoozes (re-queues without consuming an attempt, so a burst defers rather than drops work); any
 // other error retries until the attempts are spent, then fails.
 func (w *enrichmentWorker[A, R]) handleClassifyError(
-	ctx context.Context, err error, log *slog.Logger, start time.Time, job *river.Job[A],
+	ctx context.Context, err error, log *slog.Logger, start time.Time,
+	job *river.Job[A], record *models.FeedbackRecord,
 ) error {
 	cfg := w.cfg
 
@@ -252,11 +269,24 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 		}
 	}
 
-	isLastAttempt := job.Attempt >= job.MaxAttempts
-
 	cfg.metrics.workerError(ctx, cfg.apiErrorReason)
 
-	if isLastAttempt {
+	// A terminal failure is a property of the record's text, so further attempts would fail
+	// identically and cost a provider call each. Give up NOW rather than after the remaining
+	// attempts, and cancel rather than error so River does not schedule a retry it already knows
+	// is pointless.
+	if reason, terminal := huberrors.TerminalReasonOf(err); terminal {
+		w.markFailed(ctx, log, record, job.Attempt, true, string(reason))
+		w.recordOutcome(ctx, "failed_final", start)
+		log.Error(cfg.name+": provider failed permanently for this record, not retrying",
+			"reason", string(reason), "attempt", job.Attempt, "error", err)
+
+		//nolint:wrapcheck // river sentinel: JobCancel must be returned for River to stop retrying
+		return river.JobCancel(fmt.Errorf("%s (terminal, %s): %w", cfg.classifyErrVerb, reason, err))
+	}
+
+	if job.Attempt >= job.MaxAttempts {
+		w.markFailed(ctx, log, record, job.Attempt, false, models.EnrichmentFailureReasonProviderError)
 		w.recordOutcome(ctx, "failed_final", start)
 		log.Error(cfg.name+": provider failed (final attempt)", "error", err)
 
@@ -266,6 +296,50 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 	w.recordOutcome(ctx, "retry", start)
 
 	return fmt.Errorf("%s: %w", cfg.classifyErrVerb, err)
+}
+
+// markFailed writes the durable failure marker. It never changes the job's outcome: the marker is
+// bookkeeping, and failing an enrichment over it would trade a reported failure for an unreported
+// one.
+//
+// The context is detached. By the time this runs the job's own context is frequently ALREADY
+// cancelled — a provider timeout is one of the commonest ways to reach a final attempt, and it
+// cancels ctx on the way out — so writing with it would silently drop exactly the markers that
+// matter most.
+//
+// A tenant write conflict is expected rather than exceptional: it means a purge is running or the
+// record has already been deleted, in which case there is nothing left to describe.
+func (w *enrichmentWorker[A, R]) markFailed(
+	ctx context.Context, log *slog.Logger, record *models.FeedbackRecord,
+	attempts int, terminal bool, reason string,
+) {
+	if w.cfg.failures == nil || record == nil {
+		return
+	}
+
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), enrichmentFailureWriteTimeout)
+	defer cancel()
+
+	err := w.cfg.failures.RecordFailure(writeCtx, models.EnrichmentFailure{
+		FeedbackRecordID: record.ID,
+		TenantID:         record.TenantID,
+		Enrichment:       w.cfg.name,
+		Terminal:         terminal,
+		Reason:           reason,
+		Attempts:         attempts,
+	})
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, huberrors.ErrTenantWriteConflict) {
+		log.Info(w.cfg.name+": failure marker skipped, record or tenant is going away", "error", err)
+
+		return
+	}
+
+	log.Error(w.cfg.name+": could not record enrichment failure; the API will under-report it",
+		"terminal", terminal, "reason", reason, "error", err)
 }
 
 // handlePersistError maps a write failure to an outcome: a missing record or a superseded result

--- a/internal/workers/enrichment_worker.go
+++ b/internal/workers/enrichment_worker.go
@@ -229,7 +229,10 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 	// than classify empty text.
 	if !cfg.hasContent(record) {
 		if err := cfg.persist(ctx, record, job.Args, nil); err != nil {
-			return w.handlePersistError(ctx, err, log, start, job.Attempt >= job.MaxAttempts)
+			// nil record: this is the CLEAR path, for a record whose content became empty. Such a
+			// record is not eligible for any enrichment, so a failure marker on it could never be
+			// counted — markFailed no-ops on a nil record rather than writing a row nothing reads.
+			return w.handlePersistError(ctx, err, log, start, nil, job.Attempt, job.Attempt >= job.MaxAttempts)
 		}
 
 		w.recordOutcome(ctx, "success", start)
@@ -244,7 +247,7 @@ func (w *enrichmentWorker[A, R]) Work(ctx context.Context, job *river.Job[A]) er
 	}
 
 	if err := cfg.persist(ctx, record, job.Args, &result); err != nil {
-		return w.handlePersistError(ctx, err, log, start, job.Attempt >= job.MaxAttempts)
+		return w.handlePersistError(ctx, err, log, start, record, job.Attempt, job.Attempt >= job.MaxAttempts)
 	}
 
 	w.recordOutcome(ctx, "success", start)
@@ -323,8 +326,8 @@ func (w *enrichmentWorker[A, R]) handleClassifyError(
 // cancels ctx on the way out — so writing with it would silently drop exactly the markers that
 // matter most.
 //
-// A tenant write conflict is expected rather than exceptional: it means a purge is running or the
-// record has already been deleted, in which case there is nothing left to describe.
+// A refused write is expected rather than exceptional, and the two refusals mean different things:
+// the record is already gone, or a purge holds the tenant. Neither is worth failing a job over.
 func (w *enrichmentWorker[A, R]) markFailed(
 	ctx context.Context, log *slog.Logger, record *models.FeedbackRecord,
 	attempts int, terminal bool, reason string,
@@ -348,10 +351,22 @@ func (w *enrichmentWorker[A, R]) markFailed(
 		return
 	}
 
-	// Both mean the record is going away, so there is nothing left to describe: a purge holds the
-	// tenant, or the record was deleted between the enrichment attempt and this write.
-	if errors.Is(err, huberrors.ErrTenantWriteConflict) || errors.Is(err, huberrors.ErrNotFound) {
-		log.Info(w.cfg.name+": failure marker skipped, record or tenant is going away", "error", err)
+	// The record was deleted between the enrichment attempt and this write. Nothing left to
+	// describe.
+	if errors.Is(err, huberrors.ErrNotFound) {
+		log.Info(w.cfg.name + ": failure marker skipped, the record no longer exists")
+
+		return
+	}
+
+	// A purge holds the tenant lock. Deliberately NOT phrased as "the record is going away": the
+	// records-scoped purge spares everything newer than the high-water mark it took at the start,
+	// and the tenant itself survives it entirely, so the record this marker describes may well
+	// still be here afterwards — un-enriched, and now with nothing recording that it failed. The
+	// count under-reports it until something re-enqueues the record and it fails again.
+	if errors.Is(err, huberrors.ErrTenantWriteConflict) {
+		log.Info(w.cfg.name + ": failure marker skipped, a purge holds this tenant; " +
+			"the failure will be under-reported until the record is retried")
 
 		return
 	}
@@ -363,8 +378,15 @@ func (w *enrichmentWorker[A, R]) markFailed(
 // handlePersistError maps a write failure to an outcome: a missing record or a superseded result
 // completes the job (nothing to write), a tenant write conflict retries (the post-purge attempt
 // finds the record gone), and anything else fails the job.
+//
+// On a final-attempt write failure it also records the durable marker, for the same reason the
+// classify path does. A record whose result cannot be WRITTEN is exactly as un-enriched as one the
+// provider refused, and the counts do not care which half of the job failed: without a marker it
+// is reported as neither done nor failed, which is the spinning-forever state this table exists to
+// end. record may be nil (the clear path), in which case markFailed no-ops.
 func (w *enrichmentWorker[A, R]) handlePersistError(
-	ctx context.Context, err error, log *slog.Logger, start time.Time, isLastAttempt bool,
+	ctx context.Context, err error, log *slog.Logger, start time.Time,
+	record *models.FeedbackRecord, attempt int, isLastAttempt bool,
 ) error {
 	cfg := w.cfg
 
@@ -384,6 +406,11 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 
 		return nil
 	case errors.Is(err, huberrors.ErrTenantWriteConflict):
+		// No marker here, not even on the final attempt: writing one takes the same tenant lock
+		// that just refused this write, so it would be refused too. Either the record is inside
+		// the purge and there is nothing left to describe, or it is outside it (the records purge
+		// spares anything newer than its high-water mark) and survives un-enriched — in which case
+		// it stays eligible-and-not-done, and re-enqueueing it is what closes the gap.
 		outcome := retryOutcome(isLastAttempt)
 
 		cfg.metrics.workerError(ctx, "tenant_write_conflict")
@@ -399,6 +426,14 @@ func (w *enrichmentWorker[A, R]) handlePersistError(
 		// attempt here, double-counting a later success and falsely tripping final-failure
 		// alerts on one-off DB blips.)
 		outcome := retryOutcome(isLastAttempt)
+
+		if isLastAttempt {
+			// Best-effort, and most likely to fail exactly when it matters: if the database is
+			// what broke, this write breaks too. It still earns its place — a write failure
+			// specific to one row (a constraint violation, a serialization failure that outlasted
+			// every attempt) leaves the database perfectly healthy and the record stranded.
+			w.markFailed(ctx, log, record, attempt, false, models.EnrichmentFailureReasonWriteFailed)
+		}
 
 		cfg.metrics.workerError(ctx, "update_failed")
 		w.recordOutcome(ctx, outcome, start)

--- a/internal/workers/feedback_emotions.go
+++ b/internal/workers/feedback_emotions.go
@@ -41,10 +41,11 @@ type tenantSettingsReader interface {
 // and stores the emotion labels. metrics may be nil when metrics are disabled.
 func NewFeedbackEmotionsWorker(
 	svc emotionsWorkerService, resolver tenantSettingsReader,
-	client service.EmotionsClient, metrics observability.EmotionsMetrics,
+	client service.EmotionsClient, metrics observability.EmotionsMetrics, failures FailureRecorder,
 ) *FeedbackEmotionsWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackEmotionsArgs, service.EmotionsResult]{
 		name:         "emotions",
+		failures:     failures,
 		timeout:      enrichmentJobTimeout,
 		recordID:     func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.FeedbackRecordID },
 		eventID:      func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.EventID },

--- a/internal/workers/feedback_emotions.go
+++ b/internal/workers/feedback_emotions.go
@@ -42,17 +42,19 @@ type tenantSettingsReader interface {
 func NewFeedbackEmotionsWorker(
 	svc emotionsWorkerService, resolver tenantSettingsReader,
 	client service.EmotionsClient, metrics observability.EmotionsMetrics, failures FailureRecorder,
+	failureMetrics observability.EnrichmentFailureMetrics,
 ) *FeedbackEmotionsWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackEmotionsArgs, service.EmotionsResult]{
-		name:         "emotions",
-		failures:     failures,
-		timeout:      enrichmentJobTimeout,
-		recordID:     func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.FeedbackRecordID },
-		eventID:      func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.EventID },
-		getRecord:    svc.GetFeedbackRecord,
-		eligible:     (*models.FeedbackRecord).IsTextField,
-		hasContent:   (*models.FeedbackRecord).HasOpenText,
-		checkEnabled: settingsGate(resolver, models.EnrichmentSettings.EmotionsEnrichmentEnabled),
+		name:           "emotions",
+		failures:       failures,
+		failureMetrics: failureMetrics,
+		timeout:        enrichmentJobTimeout,
+		recordID:       func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:        func(args service.FeedbackEmotionsArgs) uuid.UUID { return args.EventID },
+		getRecord:      svc.GetFeedbackRecord,
+		eligible:       (*models.FeedbackRecord).IsTextField,
+		hasContent:     (*models.FeedbackRecord).HasOpenText,
+		checkEnabled:   settingsGate(resolver, models.EnrichmentSettings.EmotionsEnrichmentEnabled),
 		classify: func(ctx context.Context, record *models.FeedbackRecord, _ service.FeedbackEmotionsArgs) (service.EmotionsResult, error) {
 			sourceLang := ""
 			if record.Language != nil {

--- a/internal/workers/feedback_emotions_test.go
+++ b/internal/workers/feedback_emotions_test.go
@@ -132,7 +132,7 @@ func TestFeedbackEmotionsWorker_Success(t *testing.T) {
 	client := &stubEmotionsClient{result: service.EmotionsResult{
 		Labels: []models.EmotionValue{models.EmotionJoy, models.EmotionFear},
 	}}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -158,7 +158,7 @@ func TestFeedbackEmotionsWorker_EmptyResultClears(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{result: service.EmotionsResult{Labels: nil}}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -187,7 +187,7 @@ func TestFeedbackEmotionsWorker_EmptyValueTextClears(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			svc := &mockEmotionsWorkerService{record: record}
 			client := &stubEmotionsClient{}
-			worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, newCountingEmotionsMetrics())
+			worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, newCountingEmotionsMetrics(), nil)
 
 			if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 				t.Fatalf("Work() error = %v", err)
@@ -215,7 +215,7 @@ func TestFeedbackEmotionsWorker_NonTextFieldSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{record: &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeNumber}}
 	client := &stubEmotionsClient{}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -233,7 +233,7 @@ func TestFeedbackEmotionsWorker_NonTextFieldSkips(t *testing.T) {
 func TestFeedbackEmotionsWorker_RecordGoneSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{getErr: huberrors.ErrNotFound}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{}, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{}, metrics, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a record gone before classify is a benign skip)", err)
@@ -249,7 +249,7 @@ func TestFeedbackEmotionsWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
 
 	err := worker.Work(context.Background(), emotionsJob(1))
 
@@ -276,7 +276,7 @@ func TestFeedbackEmotionsWorker_ClassifyFailsOnFinalAttempt(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{err: errors.New("provider down")}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
 
 	err := worker.Work(context.Background(), emotionsJob(3)) // attempt == MaxAttempts
 	if err == nil {
@@ -296,7 +296,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("record gone before write is a benign skip", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrNotFound}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -310,7 +310,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("content-superseded write is a benign skip", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrClassificationSuperseded}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil (superseded is a skip, not a failure)", err)
@@ -325,7 +325,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("tenant write conflict retries", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrTenantWriteConflict}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a retryable error")
@@ -340,7 +340,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("other write error retries, failing on the final attempt", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: errors.New("db unavailable")}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a failure")
@@ -369,7 +369,7 @@ func TestFeedbackEmotionsWorker_DisabledForTenantSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{enabled: &off}, client, metrics)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{enabled: &off}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a disabled tenant is a benign skip)", err)
@@ -404,7 +404,7 @@ func TestFeedbackEmotionsWorker_SettingsReadErrorRetriesThenFailsFinal(t *testin
 			client := &stubEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
 			metrics := newCountingEmotionsMetrics()
 			worker := NewFeedbackEmotionsWorker(
-				svc, stubEmotionsSettings{err: errors.New("db unavailable")}, client, metrics)
+				svc, stubEmotionsSettings{err: errors.New("db unavailable")}, client, metrics, nil)
 
 			if err := worker.Work(context.Background(), emotionsJob(testCase.attempt)); err == nil {
 				t.Fatal("Work() error = nil, want a settings-read failure")

--- a/internal/workers/feedback_emotions_test.go
+++ b/internal/workers/feedback_emotions_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/formbricks/hub/internal/huberrors"
 	"github.com/formbricks/hub/internal/models"
@@ -114,8 +116,16 @@ func (s stubEmotionsSettings) GetSettings(_ context.Context, tenantID string) (*
 	return &models.TenantSettings{TenantID: tenantID, Settings: models.EnrichmentSettings{EmotionsEnabled: s.enabled}}, nil
 }
 
+// Carries a tenant for the same reason the sentiment fixture does: the failure marker copies the
+// record's ID and TenantID, and those drive the foreign key and the tenant write lock, so a zero
+// value would let a regression that stopped copying either one pass unnoticed.
 func emotionsTextRecord(valueText *string) *models.FeedbackRecord {
-	return &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeText, ValueText: valueText}
+	return &models.FeedbackRecord{
+		ID:        uuid.Must(uuid.NewV7()),
+		TenantID:  "tenant-emotions-test",
+		FieldType: models.FieldTypeText,
+		ValueText: valueText,
+	}
 }
 
 func emotionsJob(attempt int) *river.Job[service.FeedbackEmotionsArgs] {
@@ -425,4 +435,24 @@ func TestFeedbackEmotionsWorker_SettingsReadErrorRetriesThenFailsFinal(t *testin
 			}
 		})
 	}
+}
+
+// TestFeedbackEmotionsWorker_TerminalFailureIsRecorded is the emotions half of the same wiring
+// check — see the translation worker's version for why each pipeline needs its own.
+func TestFeedbackEmotionsWorker_TerminalFailureIsRecorded(t *testing.T) {
+	text := "something the model refuses"
+	record := emotionsTextRecord(&text)
+	svc := &mockEmotionsWorkerService{record: record}
+	failures := &recordingFailureRecorder{}
+	client := &stubEmotionsClient{err: huberrors.NewTerminalProviderError(
+		huberrors.TerminalReasonContentFilter, errors.New("blocked"))}
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, nil, failures, nil)
+
+	require.Error(t, worker.Work(context.Background(), emotionsJob(1)))
+
+	require.Len(t, failures.calls, 1, "the emotions pipeline must record its failures too")
+	assert.Equal(t, "emotions", failures.calls[0].Enrichment)
+	assert.Equal(t, record.ID, failures.calls[0].FeedbackRecordID)
+	assert.Equal(t, record.TenantID, failures.calls[0].TenantID)
+	assert.True(t, failures.calls[0].Terminal)
 }

--- a/internal/workers/feedback_emotions_test.go
+++ b/internal/workers/feedback_emotions_test.go
@@ -132,7 +132,7 @@ func TestFeedbackEmotionsWorker_Success(t *testing.T) {
 	client := &stubEmotionsClient{result: service.EmotionsResult{
 		Labels: []models.EmotionValue{models.EmotionJoy, models.EmotionFear},
 	}}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -158,7 +158,7 @@ func TestFeedbackEmotionsWorker_EmptyResultClears(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{result: service.EmotionsResult{Labels: nil}}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -187,7 +187,7 @@ func TestFeedbackEmotionsWorker_EmptyValueTextClears(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			svc := &mockEmotionsWorkerService{record: record}
 			client := &stubEmotionsClient{}
-			worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, newCountingEmotionsMetrics(), nil)
+			worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, newCountingEmotionsMetrics(), nil, nil)
 
 			if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 				t.Fatalf("Work() error = %v", err)
@@ -215,7 +215,7 @@ func TestFeedbackEmotionsWorker_NonTextFieldSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{record: &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeNumber}}
 	client := &stubEmotionsClient{}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -233,7 +233,7 @@ func TestFeedbackEmotionsWorker_NonTextFieldSkips(t *testing.T) {
 func TestFeedbackEmotionsWorker_RecordGoneSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{getErr: huberrors.ErrNotFound}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{}, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{}, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a record gone before classify is a benign skip)", err)
@@ -249,7 +249,7 @@ func TestFeedbackEmotionsWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil, nil)
 
 	err := worker.Work(context.Background(), emotionsJob(1))
 
@@ -276,7 +276,7 @@ func TestFeedbackEmotionsWorker_ClassifyFailsOnFinalAttempt(t *testing.T) {
 	metrics := newCountingEmotionsMetrics()
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{err: errors.New("provider down")}
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, client, metrics, nil, nil)
 
 	err := worker.Work(context.Background(), emotionsJob(3)) // attempt == MaxAttempts
 	if err == nil {
@@ -296,7 +296,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("record gone before write is a benign skip", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrNotFound}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -310,7 +310,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("content-superseded write is a benign skip", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrClassificationSuperseded}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil (superseded is a skip, not a failure)", err)
@@ -325,7 +325,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("tenant write conflict retries", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: huberrors.ErrTenantWriteConflict}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a retryable error")
@@ -340,7 +340,7 @@ func TestFeedbackEmotionsWorker_SetEmotionsErrors(t *testing.T) {
 	t.Run("other write error retries, failing on the final attempt", func(t *testing.T) {
 		svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text), setErr: errors.New("db unavailable")}
 		metrics := newCountingEmotionsMetrics()
-		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil)
+		worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{}, &stubEmotionsClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), emotionsJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a failure")
@@ -369,7 +369,7 @@ func TestFeedbackEmotionsWorker_DisabledForTenantSkips(t *testing.T) {
 	svc := &mockEmotionsWorkerService{record: emotionsTextRecord(&text)}
 	client := &stubEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
 	metrics := newCountingEmotionsMetrics()
-	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{enabled: &off}, client, metrics, nil)
+	worker := NewFeedbackEmotionsWorker(svc, stubEmotionsSettings{enabled: &off}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), emotionsJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a disabled tenant is a benign skip)", err)
@@ -404,7 +404,7 @@ func TestFeedbackEmotionsWorker_SettingsReadErrorRetriesThenFailsFinal(t *testin
 			client := &stubEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
 			metrics := newCountingEmotionsMetrics()
 			worker := NewFeedbackEmotionsWorker(
-				svc, stubEmotionsSettings{err: errors.New("db unavailable")}, client, metrics, nil)
+				svc, stubEmotionsSettings{err: errors.New("db unavailable")}, client, metrics, nil, nil)
 
 			if err := worker.Work(context.Background(), emotionsJob(testCase.attempt)); err == nil {
 				t.Fatal("Work() error = nil, want a settings-read failure")

--- a/internal/workers/feedback_sentiment.go
+++ b/internal/workers/feedback_sentiment.go
@@ -31,17 +31,19 @@ type sentimentWorkerService interface {
 func NewFeedbackSentimentWorker(
 	svc sentimentWorkerService, resolver tenantSettingsReader,
 	client service.SentimentClient, metrics observability.SentimentMetrics, failures FailureRecorder,
+	failureMetrics observability.EnrichmentFailureMetrics,
 ) *FeedbackSentimentWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackSentimentArgs, service.SentimentResult]{
-		name:         "sentiment",
-		failures:     failures,
-		timeout:      enrichmentJobTimeout,
-		recordID:     func(args service.FeedbackSentimentArgs) uuid.UUID { return args.FeedbackRecordID },
-		eventID:      func(args service.FeedbackSentimentArgs) uuid.UUID { return args.EventID },
-		getRecord:    svc.GetFeedbackRecord,
-		eligible:     (*models.FeedbackRecord).IsTextField,
-		hasContent:   (*models.FeedbackRecord).HasOpenText,
-		checkEnabled: settingsGate(resolver, models.EnrichmentSettings.SentimentEnrichmentEnabled),
+		name:           "sentiment",
+		failures:       failures,
+		failureMetrics: failureMetrics,
+		timeout:        enrichmentJobTimeout,
+		recordID:       func(args service.FeedbackSentimentArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:        func(args service.FeedbackSentimentArgs) uuid.UUID { return args.EventID },
+		getRecord:      svc.GetFeedbackRecord,
+		eligible:       (*models.FeedbackRecord).IsTextField,
+		hasContent:     (*models.FeedbackRecord).HasOpenText,
+		checkEnabled:   settingsGate(resolver, models.EnrichmentSettings.SentimentEnrichmentEnabled),
 		classify: func(ctx context.Context, record *models.FeedbackRecord, _ service.FeedbackSentimentArgs) (service.SentimentResult, error) {
 			sourceLang := ""
 			if record.Language != nil {

--- a/internal/workers/feedback_sentiment.go
+++ b/internal/workers/feedback_sentiment.go
@@ -30,10 +30,11 @@ type sentimentWorkerService interface {
 // and stores the result. metrics may be nil when metrics are disabled.
 func NewFeedbackSentimentWorker(
 	svc sentimentWorkerService, resolver tenantSettingsReader,
-	client service.SentimentClient, metrics observability.SentimentMetrics,
+	client service.SentimentClient, metrics observability.SentimentMetrics, failures FailureRecorder,
 ) *FeedbackSentimentWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackSentimentArgs, service.SentimentResult]{
 		name:         "sentiment",
+		failures:     failures,
 		timeout:      enrichmentJobTimeout,
 		recordID:     func(args service.FeedbackSentimentArgs) uuid.UUID { return args.FeedbackRecordID },
 		eventID:      func(args service.FeedbackSentimentArgs) uuid.UUID { return args.EventID },

--- a/internal/workers/feedback_sentiment_test.go
+++ b/internal/workers/feedback_sentiment_test.go
@@ -111,8 +111,16 @@ func (s stubSentimentSettings) GetSettings(_ context.Context, tenantID string) (
 	return &models.TenantSettings{TenantID: tenantID, Settings: models.EnrichmentSettings{SentimentEnabled: s.enabled}}, nil
 }
 
+// sentimentTextRecord carries a tenant deliberately. The failure marker copies the record's ID and
+// TenantID, and those two drive the foreign key and the tenant write lock, so a fixture that left
+// them zero would let a regression that stopped copying either one pass unnoticed.
 func sentimentTextRecord(valueText *string) *models.FeedbackRecord {
-	return &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeText, ValueText: valueText}
+	return &models.FeedbackRecord{
+		ID:        uuid.Must(uuid.NewV7()),
+		TenantID:  "tenant-sentiment-test",
+		FieldType: models.FieldTypeText,
+		ValueText: valueText,
+	}
 }
 
 func sentimentJob(attempt int) *river.Job[service.FeedbackSentimentArgs] {
@@ -457,6 +465,11 @@ func TestFeedbackSentimentWorker_TerminalFailureCancelsImmediately(t *testing.T)
 		"a terminal failure must cancel the job, not return a plain error River would retry")
 
 	require.Len(t, failures.calls, 1, "the failure must be recorded")
+	// The identity fields, not just the classification: a marker written against the wrong record
+	// is a foreign-key rejection, and one written against the wrong tenant is a mis-scoped row that
+	// the counting queries would attribute to somebody else.
+	assert.Equal(t, svc.record.ID, failures.calls[0].FeedbackRecordID)
+	assert.Equal(t, svc.record.TenantID, failures.calls[0].TenantID)
 	assert.True(t, failures.calls[0].Terminal)
 	assert.Equal(t, string(huberrors.TerminalReasonContentFilter), failures.calls[0].Reason)
 	assert.Equal(t, "sentiment", failures.calls[0].Enrichment)

--- a/internal/workers/feedback_sentiment_test.go
+++ b/internal/workers/feedback_sentiment_test.go
@@ -127,7 +127,7 @@ func TestFeedbackSentimentWorker_Success(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 0.5}}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -160,7 +160,7 @@ func TestFeedbackSentimentWorker_EmptyValueTextClears(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			svc := &mockSentimentWorkerService{record: record}
 			client := &stubSentimentClient{}
-			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, newCountingSentimentMetrics(), nil)
+			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, newCountingSentimentMetrics(), nil, nil)
 
 			if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 				t.Fatalf("Work() error = %v", err)
@@ -181,7 +181,7 @@ func TestFeedbackSentimentWorker_NonTextFieldSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{record: &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeNumber}}
 	client := &stubSentimentClient{}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -199,7 +199,7 @@ func TestFeedbackSentimentWorker_NonTextFieldSkips(t *testing.T) {
 func TestFeedbackSentimentWorker_RecordGoneSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{getErr: huberrors.ErrNotFound}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a record gone before classify is a benign skip)", err)
@@ -215,7 +215,7 @@ func TestFeedbackSentimentWorker_GetRecordFailsRetriesThenFailsFinal(t *testing.
 	// counts as failed_final on the last attempt, so failed_final is not overcounted.
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{getErr: errors.New("db unavailable")}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 		t.Fatal("Work() error = nil, want a get-record failure returned for retry")
@@ -240,7 +240,7 @@ func TestFeedbackSentimentWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(1))
 
@@ -268,7 +268,7 @@ func TestFeedbackSentimentWorker_ClassifyFailsOnFinalAttempt(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: errors.New("provider down")}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(3)) // attempt == MaxAttempts
 	if err == nil {
@@ -288,7 +288,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("record gone before write is a benign skip", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrNotFound}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -302,7 +302,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("content-superseded write is a benign skip", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrClassificationSuperseded}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil (superseded is a skip, not a failure)", err)
@@ -317,7 +317,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("tenant write conflict retries", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrTenantWriteConflict}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a retryable error")
@@ -332,7 +332,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("other write error retries, failing on the final attempt", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: errors.New("db unavailable")}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a failure")
@@ -361,7 +361,7 @@ func TestFeedbackSentimentWorker_DisabledForTenantSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{enabled: &off}, client, metrics, nil)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{enabled: &off}, client, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a disabled tenant is a benign skip)", err)
@@ -396,7 +396,7 @@ func TestFeedbackSentimentWorker_SettingsReadErrorRetriesThenFailsFinal(t *testi
 			client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
 			metrics := newCountingSentimentMetrics()
 			worker := NewFeedbackSentimentWorker(
-				svc, stubSentimentSettings{err: errors.New("db unavailable")}, client, metrics, nil)
+				svc, stubSentimentSettings{err: errors.New("db unavailable")}, client, metrics, nil, nil)
 
 			if err := worker.Work(context.Background(), sentimentJob(testCase.attempt)); err == nil {
 				t.Fatal("Work() error = nil, want a settings-read failure")
@@ -446,7 +446,7 @@ func TestFeedbackSentimentWorker_TerminalFailureCancelsImmediately(t *testing.T)
 	failures := &recordingFailureRecorder{}
 	client := &stubSentimentClient{err: huberrors.NewTerminalProviderError(
 		huberrors.TerminalReasonContentFilter, errors.New("blocked"))}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures, nil)
 
 	// Attempt 1 of 3: there are attempts left, and a transient failure here would merely retry.
 	err := worker.Work(context.Background(), sentimentJob(1))
@@ -473,7 +473,7 @@ func TestFeedbackSentimentWorker_TransientFailureRecordsOnlyOnFinalAttempt(t *te
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: errors.New("provider down")}
 	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client,
-		newCountingSentimentMetrics(), failures)
+		newCountingSentimentMetrics(), failures, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(1)) // attempts remain
 	require.Error(t, err)
@@ -497,7 +497,7 @@ func TestFeedbackSentimentWorker_FailureMarkerSurvivesCancelledContext(t *testin
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: errors.New("context deadline exceeded")}
 	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client,
-		newCountingSentimentMetrics(), failures)
+		newCountingSentimentMetrics(), failures, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // the job's context is already dead by the time the failure is handled
@@ -518,7 +518,7 @@ func TestFeedbackSentimentWorker_FailureMarkerErrorDoesNotChangeOutcome(t *testi
 	failures := &recordingFailureRecorder{err: errors.New("database unreachable")}
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: errors.New("provider down")}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(3))
 	require.Error(t, err)
@@ -542,7 +542,7 @@ func TestFeedbackSentimentWorker_MarkerSkipConditionsAreBenign(t *testing.T) {
 			failures := &recordingFailureRecorder{err: recorderErr}
 			svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 			client := &stubSentimentClient{err: errors.New("provider down")}
-			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures, nil)
 
 			err := worker.Work(context.Background(), sentimentJob(3))
 			require.Error(t, err)

--- a/internal/workers/feedback_sentiment_test.go
+++ b/internal/workers/feedback_sentiment_test.go
@@ -526,3 +526,30 @@ func TestFeedbackSentimentWorker_FailureMarkerErrorDoesNotChangeOutcome(t *testi
 		"the job must fail for the provider reason, not the bookkeeping one")
 	assert.Equal(t, 1, metrics.outcomes["failed_final"])
 }
+
+// TestFeedbackSentimentWorker_MarkerSkipConditionsAreBenign covers both ways the marker write can
+// legitimately not happen. They are distinct error types on purpose — elsewhere in this worker a
+// tenant write conflict means "retry" while a missing record means "skip" — but for bookkeeping
+// both are benign, and neither may change the job's outcome.
+func TestFeedbackSentimentWorker_MarkerSkipConditionsAreBenign(t *testing.T) {
+	for name, recorderErr := range map[string]error{
+		"purge holds the tenant": huberrors.NewTenantWriteConflictError("purge in progress"),
+		"record already deleted": huberrors.NewNotFoundError("feedback record", "gone"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			text := "Bonjour"
+			metrics := newCountingSentimentMetrics()
+			failures := &recordingFailureRecorder{err: recorderErr}
+			svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
+			client := &stubSentimentClient{err: errors.New("provider down")}
+			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+
+			err := worker.Work(context.Background(), sentimentJob(3))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "provider down",
+				"the job still fails for the provider reason")
+			assert.Equal(t, 1, metrics.outcomes["failed_final"],
+				"a skipped marker must not change the recorded outcome")
+		})
+	}
+}

--- a/internal/workers/feedback_sentiment_test.go
+++ b/internal/workers/feedback_sentiment_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/formbricks/hub/internal/huberrors"
 	"github.com/formbricks/hub/internal/models"
@@ -125,7 +127,7 @@ func TestFeedbackSentimentWorker_Success(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 0.5}}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -158,7 +160,7 @@ func TestFeedbackSentimentWorker_EmptyValueTextClears(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			svc := &mockSentimentWorkerService{record: record}
 			client := &stubSentimentClient{}
-			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, newCountingSentimentMetrics())
+			worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, newCountingSentimentMetrics(), nil)
 
 			if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 				t.Fatalf("Work() error = %v", err)
@@ -179,7 +181,7 @@ func TestFeedbackSentimentWorker_NonTextFieldSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{record: &models.FeedbackRecord{ID: uuid.Must(uuid.NewV7()), FieldType: models.FieldTypeNumber}}
 	client := &stubSentimentClient{}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -197,7 +199,7 @@ func TestFeedbackSentimentWorker_NonTextFieldSkips(t *testing.T) {
 func TestFeedbackSentimentWorker_RecordGoneSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{getErr: huberrors.ErrNotFound}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a record gone before classify is a benign skip)", err)
@@ -213,7 +215,7 @@ func TestFeedbackSentimentWorker_GetRecordFailsRetriesThenFailsFinal(t *testing.
 	// counts as failed_final on the last attempt, so failed_final is not overcounted.
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{getErr: errors.New("db unavailable")}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{}, metrics, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 		t.Fatal("Work() error = nil, want a get-record failure returned for retry")
@@ -238,7 +240,7 @@ func TestFeedbackSentimentWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(1))
 
@@ -266,7 +268,7 @@ func TestFeedbackSentimentWorker_ClassifyFailsOnFinalAttempt(t *testing.T) {
 	metrics := newCountingSentimentMetrics()
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{err: errors.New("provider down")}
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, nil)
 
 	err := worker.Work(context.Background(), sentimentJob(3)) // attempt == MaxAttempts
 	if err == nil {
@@ -286,7 +288,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("record gone before write is a benign skip", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrNotFound}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -300,7 +302,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("content-superseded write is a benign skip", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrClassificationSuperseded}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil (superseded is a skip, not a failure)", err)
@@ -315,7 +317,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("tenant write conflict retries", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: huberrors.ErrTenantWriteConflict}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a retryable error")
@@ -330,7 +332,7 @@ func TestFeedbackSentimentWorker_SetSentimentErrors(t *testing.T) {
 	t.Run("other write error retries, failing on the final attempt", func(t *testing.T) {
 		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: errors.New("db unavailable")}
 		metrics := newCountingSentimentMetrics()
-		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics)
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, &stubSentimentClient{result: result}, metrics, nil)
 
 		if err := worker.Work(context.Background(), sentimentJob(1)); err == nil {
 			t.Fatal("Work() error = nil, want a failure")
@@ -359,7 +361,7 @@ func TestFeedbackSentimentWorker_DisabledForTenantSkips(t *testing.T) {
 	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
 	client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
 	metrics := newCountingSentimentMetrics()
-	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{enabled: &off}, client, metrics)
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{enabled: &off}, client, metrics, nil)
 
 	if err := worker.Work(context.Background(), sentimentJob(1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (a disabled tenant is a benign skip)", err)
@@ -394,7 +396,7 @@ func TestFeedbackSentimentWorker_SettingsReadErrorRetriesThenFailsFinal(t *testi
 			client := &stubSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
 			metrics := newCountingSentimentMetrics()
 			worker := NewFeedbackSentimentWorker(
-				svc, stubSentimentSettings{err: errors.New("db unavailable")}, client, metrics)
+				svc, stubSentimentSettings{err: errors.New("db unavailable")}, client, metrics, nil)
 
 			if err := worker.Work(context.Background(), sentimentJob(testCase.attempt)); err == nil {
 				t.Fatal("Work() error = nil, want a settings-read failure")
@@ -415,4 +417,112 @@ func TestFeedbackSentimentWorker_SettingsReadErrorRetriesThenFailsFinal(t *testi
 			}
 		})
 	}
+}
+
+// recordingFailureRecorder captures marker writes and can be told to fail, so a test can assert
+// that bookkeeping never changes a job's outcome.
+type recordingFailureRecorder struct {
+	calls []models.EnrichmentFailure
+	// ctxDone records whether the context handed to RecordFailure was already cancelled. The
+	// marker write happens on a path where the job context frequently is.
+	ctxDone []bool
+	err     error
+}
+
+func (r *recordingFailureRecorder) RecordFailure(ctx context.Context, f models.EnrichmentFailure) error {
+	r.calls = append(r.calls, f)
+	r.ctxDone = append(r.ctxDone, ctx.Err() != nil)
+
+	return r.err
+}
+
+// TestFeedbackSentimentWorker_TerminalFailureCancelsImmediately pins the behaviour that makes the
+// whole taxonomy worth having: a failure caused by the record's own text must not consume the
+// remaining attempts, because every one of them would fail identically and cost a provider call.
+func TestFeedbackSentimentWorker_TerminalFailureCancelsImmediately(t *testing.T) {
+	text := "something the model refuses"
+	metrics := newCountingSentimentMetrics()
+	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
+	failures := &recordingFailureRecorder{}
+	client := &stubSentimentClient{err: huberrors.NewTerminalProviderError(
+		huberrors.TerminalReasonContentFilter, errors.New("blocked"))}
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+
+	// Attempt 1 of 3: there are attempts left, and a transient failure here would merely retry.
+	err := worker.Work(context.Background(), sentimentJob(1))
+	require.Error(t, err)
+
+	var cancelErr *river.JobCancelError
+	require.ErrorAs(t, err, &cancelErr,
+		"a terminal failure must cancel the job, not return a plain error River would retry")
+
+	require.Len(t, failures.calls, 1, "the failure must be recorded")
+	assert.True(t, failures.calls[0].Terminal)
+	assert.Equal(t, string(huberrors.TerminalReasonContentFilter), failures.calls[0].Reason)
+	assert.Equal(t, "sentiment", failures.calls[0].Enrichment)
+	assert.Equal(t, 1, failures.calls[0].Attempts, "gave up on the first attempt, not the last")
+	assert.Equal(t, 1, metrics.outcomes["failed_final"])
+}
+
+// TestFeedbackSentimentWorker_TransientFailureRecordsOnlyOnFinalAttempt guards the other half: a
+// provider outage must still use its retry budget, and must not leave a marker behind on an
+// attempt that could yet succeed.
+func TestFeedbackSentimentWorker_TransientFailureRecordsOnlyOnFinalAttempt(t *testing.T) {
+	text := "Bonjour"
+	failures := &recordingFailureRecorder{}
+	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
+	client := &stubSentimentClient{err: errors.New("provider down")}
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client,
+		newCountingSentimentMetrics(), failures)
+
+	err := worker.Work(context.Background(), sentimentJob(1)) // attempts remain
+	require.Error(t, err)
+	require.NotErrorIs(t, err, huberrors.ErrTerminalProvider)
+	assert.Empty(t, failures.calls, "a retryable attempt must not record a failure")
+
+	err = worker.Work(context.Background(), sentimentJob(3)) // attempt == MaxAttempts
+	require.Error(t, err)
+	require.Len(t, failures.calls, 1)
+	assert.False(t, failures.calls[0].Terminal)
+	assert.Equal(t, models.EnrichmentFailureReasonProviderError, failures.calls[0].Reason)
+}
+
+// TestFeedbackSentimentWorker_FailureMarkerSurvivesCancelledContext covers the reason the write is
+// detached. A provider timeout is one of the commonest routes to a final attempt and it cancels
+// the job context on the way out, so writing with that context would drop exactly the markers that
+// matter most.
+func TestFeedbackSentimentWorker_FailureMarkerSurvivesCancelledContext(t *testing.T) {
+	text := "Bonjour"
+	failures := &recordingFailureRecorder{}
+	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
+	client := &stubSentimentClient{err: errors.New("context deadline exceeded")}
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client,
+		newCountingSentimentMetrics(), failures)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the job's context is already dead by the time the failure is handled
+
+	err := worker.Work(ctx, sentimentJob(3))
+	require.Error(t, err)
+
+	require.Len(t, failures.calls, 1, "the marker must still be written on a cancelled context")
+	assert.False(t, failures.ctxDone[0], "the write context must be detached, not the dead job context")
+}
+
+// TestFeedbackSentimentWorker_FailureMarkerErrorDoesNotChangeOutcome: the marker is bookkeeping.
+// Failing an enrichment because its failure could not be recorded would trade a reported failure
+// for an unreported one.
+func TestFeedbackSentimentWorker_FailureMarkerErrorDoesNotChangeOutcome(t *testing.T) {
+	text := "Bonjour"
+	metrics := newCountingSentimentMetrics()
+	failures := &recordingFailureRecorder{err: errors.New("database unreachable")}
+	svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text)}
+	client := &stubSentimentClient{err: errors.New("provider down")}
+	worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{}, client, metrics, failures)
+
+	err := worker.Work(context.Background(), sentimentJob(3))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider down",
+		"the job must fail for the provider reason, not the bookkeeping one")
+	assert.Equal(t, 1, metrics.outcomes["failed_final"])
 }

--- a/internal/workers/feedback_sentiment_test.go
+++ b/internal/workers/feedback_sentiment_test.go
@@ -553,3 +553,82 @@ func TestFeedbackSentimentWorker_MarkerSkipConditionsAreBenign(t *testing.T) {
 		})
 	}
 }
+
+// TestFeedbackSentimentWorker_WriteFailureRecordsMarker covers the half of the job that is not the
+// provider. A record whose result classified fine but could never be WRITTEN is exactly as
+// un-enriched as one the provider refused, and the status counts do not care which half failed:
+// with no marker it is reported as neither done nor failed, which is the spinning-forever state
+// the markers exist to end.
+func TestFeedbackSentimentWorker_WriteFailureRecordsMarker(t *testing.T) {
+	text := "Great"
+	result := service.SentimentResult{Label: models.SentimentPositive, Score: 1}
+
+	newWorker := func(setErr error, failures *recordingFailureRecorder) *FeedbackSentimentWorker {
+		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&text), setErr: setErr}
+
+		return NewFeedbackSentimentWorker(svc, stubSentimentSettings{},
+			&stubSentimentClient{result: result}, newCountingSentimentMetrics(), failures, nil)
+	}
+
+	t.Run("final attempt records a non-terminal write failure", func(t *testing.T) {
+		failures := &recordingFailureRecorder{}
+		worker := newWorker(errors.New("db unavailable"), failures)
+
+		require.Error(t, worker.Work(context.Background(), sentimentJob(3)))
+		require.Len(t, failures.calls, 1, "a spent write failure must be recorded")
+		assert.False(t, failures.calls[0].Terminal, "a write failure is never the record's own fault")
+		assert.Equal(t, models.EnrichmentFailureReasonWriteFailed, failures.calls[0].Reason)
+		assert.Equal(t, "sentiment", failures.calls[0].Enrichment)
+		assert.Equal(t, 3, failures.calls[0].Attempts)
+	})
+
+	t.Run("an attempt that could still succeed records nothing", func(t *testing.T) {
+		failures := &recordingFailureRecorder{}
+		worker := newWorker(errors.New("db unavailable"), failures)
+
+		require.Error(t, worker.Work(context.Background(), sentimentJob(1)))
+		assert.Empty(t, failures.calls, "attempts remain, so the record is not yet given up on")
+	})
+
+	// A tenant write conflict is the one final-attempt failure that records nothing, and it has to
+	// be: the marker write takes the same tenant lock that just refused this write, so it would be
+	// refused too. Asserting it keeps a later "be consistent, mark here as well" from adding a
+	// round trip that can only fail.
+	t.Run("a tenant write conflict records nothing, even when spent", func(t *testing.T) {
+		failures := &recordingFailureRecorder{}
+		worker := newWorker(huberrors.ErrTenantWriteConflict, failures)
+
+		require.Error(t, worker.Work(context.Background(), sentimentJob(3)))
+		assert.Empty(t, failures.calls)
+	})
+
+	// Benign write outcomes complete the job, so there is nothing to describe.
+	t.Run("a benign skip records nothing", func(t *testing.T) {
+		for name, setErr := range map[string]error{
+			"record gone": huberrors.ErrNotFound,
+			"superseded":  huberrors.ErrClassificationSuperseded,
+		} {
+			t.Run(name, func(t *testing.T) {
+				failures := &recordingFailureRecorder{}
+				worker := newWorker(setErr, failures)
+
+				require.NoError(t, worker.Work(context.Background(), sentimentJob(3)))
+				assert.Empty(t, failures.calls)
+			})
+		}
+	})
+
+	// The clear path writes nil to a record whose content became empty. Such a record is not
+	// eligible for any enrichment, so a marker on it could never be counted — writing one would be
+	// a row nothing reads.
+	t.Run("a failed clear records nothing", func(t *testing.T) {
+		blank := "   "
+		failures := &recordingFailureRecorder{}
+		svc := &mockSentimentWorkerService{record: sentimentTextRecord(&blank), setErr: errors.New("db unavailable")}
+		worker := NewFeedbackSentimentWorker(svc, stubSentimentSettings{},
+			&stubSentimentClient{result: result}, newCountingSentimentMetrics(), failures, nil)
+
+		require.Error(t, worker.Work(context.Background(), sentimentJob(3)))
+		assert.Empty(t, failures.calls, "a record with no content is not eligible, so nothing is owed")
+	})
+}

--- a/internal/workers/feedback_translation.go
+++ b/internal/workers/feedback_translation.go
@@ -34,9 +34,11 @@ type translationWorkerService interface {
 // metrics may be nil when metrics are disabled.
 func NewFeedbackTranslationWorker(
 	svc translationWorkerService, client service.TranslationClient, metrics observability.TranslationMetrics,
+	failures FailureRecorder,
 ) *FeedbackTranslationWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackTranslationArgs, string]{
 		name:       "translation",
+		failures:   failures,
 		timeout:    enrichmentJobTimeout,
 		recordID:   func(args service.FeedbackTranslationArgs) uuid.UUID { return args.FeedbackRecordID },
 		eventID:    func(args service.FeedbackTranslationArgs) uuid.UUID { return args.EventID },

--- a/internal/workers/feedback_translation.go
+++ b/internal/workers/feedback_translation.go
@@ -35,16 +35,18 @@ type translationWorkerService interface {
 func NewFeedbackTranslationWorker(
 	svc translationWorkerService, client service.TranslationClient, metrics observability.TranslationMetrics,
 	failures FailureRecorder,
+	failureMetrics observability.EnrichmentFailureMetrics,
 ) *FeedbackTranslationWorker {
 	return newEnrichmentWorker(enrichmentWorkerConfig[service.FeedbackTranslationArgs, string]{
-		name:       "translation",
-		failures:   failures,
-		timeout:    enrichmentJobTimeout,
-		recordID:   func(args service.FeedbackTranslationArgs) uuid.UUID { return args.FeedbackRecordID },
-		eventID:    func(args service.FeedbackTranslationArgs) uuid.UUID { return args.EventID },
-		getRecord:  svc.GetFeedbackRecord,
-		eligible:   (*models.FeedbackRecord).IsTextField,
-		hasContent: (*models.FeedbackRecord).HasOpenText,
+		name:           "translation",
+		failures:       failures,
+		failureMetrics: failureMetrics,
+		timeout:        enrichmentJobTimeout,
+		recordID:       func(args service.FeedbackTranslationArgs) uuid.UUID { return args.FeedbackRecordID },
+		eventID:        func(args service.FeedbackTranslationArgs) uuid.UUID { return args.EventID },
+		getRecord:      svc.GetFeedbackRecord,
+		eligible:       (*models.FeedbackRecord).IsTextField,
+		hasContent:     (*models.FeedbackRecord).HasOpenText,
 		classify: func(ctx context.Context, record *models.FeedbackRecord, args service.FeedbackTranslationArgs) (string, error) {
 			return translate(ctx, client, record, args.TargetLang, args.EventID)
 		},

--- a/internal/workers/feedback_translation_test.go
+++ b/internal/workers/feedback_translation_test.go
@@ -120,7 +120,7 @@ func translationJob(targetLang string, attempt int) *river.Job[service.FeedbackT
 func TestFeedbackTranslationWorker_TranslatesAndStores(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour le monde", "fr")}
 	client := &stubTranslationClient{out: "Hello world"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -139,7 +139,7 @@ func TestFeedbackTranslationWorker_TranslatesAndStores(t *testing.T) {
 func TestFeedbackTranslationWorker_SourceEqualsTargetCopies(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Hello", "en-US")}
 	client := &stubTranslationClient{out: "should-not-be-used"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-GB", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -157,7 +157,7 @@ func TestFeedbackTranslationWorker_SourceEqualsTargetCopies(t *testing.T) {
 func TestFeedbackTranslationWorker_ClearsWhenValueTextEmpty(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("   ", "fr")}
 	client := &stubTranslationClient{out: "x"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -178,7 +178,7 @@ func TestFeedbackTranslationWorker_UnsetSourceLanguageCopies(t *testing.T) {
 	// instead of round-tripping identical text through the LLM (e.g. English -> English).
 	svc := &mockTranslationWorkerService{record: translationRecord("Hello world", "")}
 	client := &stubTranslationClient{out: "should-not-be-used"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -198,7 +198,7 @@ func TestFeedbackTranslationWorker_UndeterminedSourceTranslates(t *testing.T) {
 	// "und" (undetermined) must not be treated as matching the target — translate, not copy.
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "und")}
 	client := &stubTranslationClient{out: "Hello"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -213,7 +213,7 @@ func TestFeedbackTranslationWorker_DifferentScriptTranslates(t *testing.T) {
 	// zh-Hans and zh-Hant share a base language but not a script: must translate, not copy.
 	svc := &mockTranslationWorkerService{record: translationRecord("simplified content", "zh-Hans")}
 	client := &stubTranslationClient{out: "translated"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("zh-Hant", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -227,7 +227,7 @@ func TestFeedbackTranslationWorker_DifferentScriptTranslates(t *testing.T) {
 func TestFeedbackTranslationWorker_NotFoundCompletes(t *testing.T) {
 	metrics := newCountingTranslationMetrics()
 	svc := &mockTranslationWorkerService{getErr: huberrors.NewNotFoundError("feedback record", "gone")}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (not-found completes)", err)
@@ -247,7 +247,7 @@ func TestFeedbackTranslationWorker_NotFoundCompletes(t *testing.T) {
 func TestFeedbackTranslationWorker_ProviderErrorRetriesThenFails(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: errors.New("api down")}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 		t.Fatal("Work() = nil on non-final attempt, want retry error")
@@ -267,7 +267,7 @@ func TestFeedbackTranslationWorker_TenantWriteConflictRetries(t *testing.T) {
 		record: translationRecord("Bonjour", "fr"),
 		setErr: huberrors.NewTenantWriteConflictError("purge in progress"),
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 		t.Fatal("Work() = nil, want retry on tenant write conflict")
@@ -279,7 +279,7 @@ func TestFeedbackTranslationWorker_RecordGoneOnWriteCompletes(t *testing.T) {
 		record: translationRecord("Bonjour", "fr"),
 		setErr: huberrors.NewNotFoundError("feedback record", "gone"),
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (record gone before write completes)", err)
@@ -292,7 +292,7 @@ func TestFeedbackTranslationWorker_SupersededWriteSkips(t *testing.T) {
 		record: translationRecord("Bonjour le monde", "fr"),
 		setErr: huberrors.ErrTranslationSuperseded,
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hello world"}, metrics, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hello world"}, metrics, nil, nil)
 
 	// A stale-target write (the tenant's target changed before this job's write landed) is a
 	// benign no-op: the worker completes the job and records it as skipped, not failed.
@@ -314,7 +314,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("success records outcome and duration", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -330,7 +330,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		record := translationRecord("hello", "fr")
 		record.FieldType = models.FieldTypeCategorical
-		worker := NewFeedbackTranslationWorker(&mockTranslationWorkerService{record: record}, &stubTranslationClient{}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(&mockTranslationWorkerService{record: record}, &stubTranslationClient{}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -344,7 +344,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("empty value_text clear records success", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("   ", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -358,7 +358,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("provider failure records worker error, retry then failed_final", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{err: errors.New("api down")}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{err: errors.New("api down")}, metrics, nil, nil)
 
 		_ = worker.Work(context.Background(), translationJob("en-US", 1)) // non-final -> retry
 		_ = worker.Work(context.Background(), translationJob("en-US", 3)) // final -> failed_final
@@ -378,7 +378,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 		// on the last attempt, so failed_final is not overcounted.
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{getErr: errors.New("db down")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 			t.Fatal("Work() = nil, want error on get failure")
@@ -404,7 +404,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: huberrors.NewTenantWriteConflictError("purge"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil, nil)
 
 		_ = worker.Work(context.Background(), translationJob("en-US", 1))
 
@@ -420,7 +420,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: errors.New("update boom"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil, nil)
 
 		// Non-final attempt: River retries, so the outcome is "retry", not failed_final.
 		_ = worker.Work(context.Background(), translationJob("en-US", 1))
@@ -443,7 +443,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: huberrors.NewNotFoundError("feedback record", "gone"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -459,7 +459,7 @@ func TestFeedbackTranslationWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingTranslationMetrics()
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackTranslationWorker(svc, client, metrics, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, metrics, nil, nil)
 
 	err := worker.Work(context.Background(), translationJob("en-US", 1))
 
@@ -489,7 +489,7 @@ func TestFeedbackTranslationWorker_RateLimitSnoozesOnLastAttempt(t *testing.T) {
 	// not consume an attempt, so a 429 defers work instead of being dropped as failed_final.
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: huberrors.NewRateLimitError(0, errors.New("429"))}
-	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil, nil)
 
 	err := worker.Work(context.Background(), translationJob("en-US", 3))
 

--- a/internal/workers/feedback_translation_test.go
+++ b/internal/workers/feedback_translation_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/formbricks/hub/internal/huberrors"
 	"github.com/formbricks/hub/internal/models"
@@ -93,9 +95,12 @@ func (s *stubTranslationClient) Translate(_ context.Context, req service.Transla
 	return s.out, s.err
 }
 
+// Carries a tenant for the same reason the sentiment and emotions fixtures do: the failure marker
+// copies the record's ID and TenantID, and those drive the foreign key and the tenant write lock.
 func translationRecord(valueText, sourceLang string) *models.FeedbackRecord {
 	record := &models.FeedbackRecord{
 		ID:        uuid.Must(uuid.NewV7()),
+		TenantID:  "tenant-translation-test",
 		FieldType: models.FieldTypeText,
 		ValueText: &valueText,
 	}
@@ -600,4 +605,25 @@ func TestSameLanguageAndScript(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFeedbackTranslationWorker_TerminalFailureIsRecorded pins the wiring, not the logic. All three
+// classify pipelines share enrichmentWorker.markFailed, so the behaviour is structurally identical
+// and covered in depth on the sentiment worker — but each constructor threads `failures` through
+// separately, and dropping it for one pipeline is a silent, per-pipeline hole in the counts.
+func TestFeedbackTranslationWorker_TerminalFailureIsRecorded(t *testing.T) {
+	record := translationRecord("Bonjour le monde", "fr")
+	svc := &mockTranslationWorkerService{record: record}
+	failures := &recordingFailureRecorder{}
+	client := &stubTranslationClient{err: huberrors.NewTerminalProviderError(
+		huberrors.TerminalReasonRefusal, errors.New("declined"))}
+	worker := NewFeedbackTranslationWorker(svc, client, nil, failures, nil)
+
+	require.Error(t, worker.Work(context.Background(), translationJob("en-US", 1)))
+
+	require.Len(t, failures.calls, 1, "the translation pipeline must record its failures too")
+	assert.Equal(t, "translation", failures.calls[0].Enrichment)
+	assert.Equal(t, record.ID, failures.calls[0].FeedbackRecordID)
+	assert.Equal(t, record.TenantID, failures.calls[0].TenantID)
+	assert.True(t, failures.calls[0].Terminal)
 }

--- a/internal/workers/feedback_translation_test.go
+++ b/internal/workers/feedback_translation_test.go
@@ -120,7 +120,7 @@ func translationJob(targetLang string, attempt int) *river.Job[service.FeedbackT
 func TestFeedbackTranslationWorker_TranslatesAndStores(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour le monde", "fr")}
 	client := &stubTranslationClient{out: "Hello world"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -139,7 +139,7 @@ func TestFeedbackTranslationWorker_TranslatesAndStores(t *testing.T) {
 func TestFeedbackTranslationWorker_SourceEqualsTargetCopies(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Hello", "en-US")}
 	client := &stubTranslationClient{out: "should-not-be-used"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-GB", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -157,7 +157,7 @@ func TestFeedbackTranslationWorker_SourceEqualsTargetCopies(t *testing.T) {
 func TestFeedbackTranslationWorker_ClearsWhenValueTextEmpty(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("   ", "fr")}
 	client := &stubTranslationClient{out: "x"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -178,7 +178,7 @@ func TestFeedbackTranslationWorker_UnsetSourceLanguageCopies(t *testing.T) {
 	// instead of round-tripping identical text through the LLM (e.g. English -> English).
 	svc := &mockTranslationWorkerService{record: translationRecord("Hello world", "")}
 	client := &stubTranslationClient{out: "should-not-be-used"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -198,7 +198,7 @@ func TestFeedbackTranslationWorker_UndeterminedSourceTranslates(t *testing.T) {
 	// "und" (undetermined) must not be treated as matching the target — translate, not copy.
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "und")}
 	client := &stubTranslationClient{out: "Hello"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -213,7 +213,7 @@ func TestFeedbackTranslationWorker_DifferentScriptTranslates(t *testing.T) {
 	// zh-Hans and zh-Hant share a base language but not a script: must translate, not copy.
 	svc := &mockTranslationWorkerService{record: translationRecord("simplified content", "zh-Hans")}
 	client := &stubTranslationClient{out: "translated"}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("zh-Hant", 1)); err != nil {
 		t.Fatalf("Work() error = %v", err)
@@ -227,7 +227,7 @@ func TestFeedbackTranslationWorker_DifferentScriptTranslates(t *testing.T) {
 func TestFeedbackTranslationWorker_NotFoundCompletes(t *testing.T) {
 	metrics := newCountingTranslationMetrics()
 	svc := &mockTranslationWorkerService{getErr: huberrors.NewNotFoundError("feedback record", "gone")}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (not-found completes)", err)
@@ -247,7 +247,7 @@ func TestFeedbackTranslationWorker_NotFoundCompletes(t *testing.T) {
 func TestFeedbackTranslationWorker_ProviderErrorRetriesThenFails(t *testing.T) {
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: errors.New("api down")}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 		t.Fatal("Work() = nil on non-final attempt, want retry error")
@@ -267,7 +267,7 @@ func TestFeedbackTranslationWorker_TenantWriteConflictRetries(t *testing.T) {
 		record: translationRecord("Bonjour", "fr"),
 		setErr: huberrors.NewTenantWriteConflictError("purge in progress"),
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 		t.Fatal("Work() = nil, want retry on tenant write conflict")
@@ -279,7 +279,7 @@ func TestFeedbackTranslationWorker_RecordGoneOnWriteCompletes(t *testing.T) {
 		record: translationRecord("Bonjour", "fr"),
 		setErr: huberrors.NewNotFoundError("feedback record", "gone"),
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, nil, nil)
 
 	if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 		t.Fatalf("Work() error = %v, want nil (record gone before write completes)", err)
@@ -292,7 +292,7 @@ func TestFeedbackTranslationWorker_SupersededWriteSkips(t *testing.T) {
 		record: translationRecord("Bonjour le monde", "fr"),
 		setErr: huberrors.ErrTranslationSuperseded,
 	}
-	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hello world"}, metrics)
+	worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hello world"}, metrics, nil)
 
 	// A stale-target write (the tenant's target changed before this job's write landed) is a
 	// benign no-op: the worker completes the job and records it as skipped, not failed.
@@ -314,7 +314,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("success records outcome and duration", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -330,7 +330,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		record := translationRecord("hello", "fr")
 		record.FieldType = models.FieldTypeCategorical
-		worker := NewFeedbackTranslationWorker(&mockTranslationWorkerService{record: record}, &stubTranslationClient{}, metrics)
+		worker := NewFeedbackTranslationWorker(&mockTranslationWorkerService{record: record}, &stubTranslationClient{}, metrics, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -344,7 +344,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("empty value_text clear records success", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("   ", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v", err)
@@ -358,7 +358,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 	t.Run("provider failure records worker error, retry then failed_final", func(t *testing.T) {
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{err: errors.New("api down")}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{err: errors.New("api down")}, metrics, nil)
 
 		_ = worker.Work(context.Background(), translationJob("en-US", 1)) // non-final -> retry
 		_ = worker.Work(context.Background(), translationJob("en-US", 3)) // final -> failed_final
@@ -378,7 +378,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 		// on the last attempt, so failed_final is not overcounted.
 		metrics := newCountingTranslationMetrics()
 		svc := &mockTranslationWorkerService{getErr: errors.New("db down")}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{}, metrics, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err == nil {
 			t.Fatal("Work() = nil, want error on get failure")
@@ -404,7 +404,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: huberrors.NewTenantWriteConflictError("purge"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
 
 		_ = worker.Work(context.Background(), translationJob("en-US", 1))
 
@@ -420,7 +420,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: errors.New("update boom"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
 
 		// Non-final attempt: River retries, so the outcome is "retry", not failed_final.
 		_ = worker.Work(context.Background(), translationJob("en-US", 1))
@@ -443,7 +443,7 @@ func TestFeedbackTranslationWorker_RecordsMetrics(t *testing.T) {
 			record: translationRecord("Bonjour", "fr"),
 			setErr: huberrors.NewNotFoundError("feedback record", "gone"),
 		}
-		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics)
+		worker := NewFeedbackTranslationWorker(svc, &stubTranslationClient{out: "Hi"}, metrics, nil)
 
 		if err := worker.Work(context.Background(), translationJob("en-US", 1)); err != nil {
 			t.Fatalf("Work() error = %v, want nil", err)
@@ -459,7 +459,7 @@ func TestFeedbackTranslationWorker_RateLimitSnoozes(t *testing.T) {
 	metrics := newCountingTranslationMetrics()
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: huberrors.NewRateLimitError(45*time.Second, errors.New("429"))}
-	worker := NewFeedbackTranslationWorker(svc, client, metrics)
+	worker := NewFeedbackTranslationWorker(svc, client, metrics, nil)
 
 	err := worker.Work(context.Background(), translationJob("en-US", 1))
 
@@ -489,7 +489,7 @@ func TestFeedbackTranslationWorker_RateLimitSnoozesOnLastAttempt(t *testing.T) {
 	// not consume an attempt, so a 429 defers work instead of being dropped as failed_final.
 	svc := &mockTranslationWorkerService{record: translationRecord("Bonjour", "fr")}
 	client := &stubTranslationClient{err: huberrors.NewRateLimitError(0, errors.New("429"))}
-	worker := NewFeedbackTranslationWorker(svc, client, nil)
+	worker := NewFeedbackTranslationWorker(svc, client, nil, nil)
 
 	err := worker.Work(context.Background(), translationJob("en-US", 3))
 

--- a/internal/workers/wiring.go
+++ b/internal/workers/wiring.go
@@ -49,6 +49,11 @@ type RiverDeps struct {
 	// Feedback-records purge worker (always registered; the purge is a core tenant operation, not
 	// an enrichment, so it has no client to gate on).
 	FeedbackRecordsPurgeService feedbackRecordsPurgeService
+
+	// Failures records the durable marker a classify worker writes when it gives up on a record.
+	// Shared by the three classify pipelines; nil disables recording, which leaves the API
+	// under-reporting failures but changes no enrichment behaviour.
+	Failures FailureRecorder
 }
 
 // NewRiverWorkersAndQueues builds River workers and queue config from cfg and deps. Each optional
@@ -93,7 +98,8 @@ func NewRiverWorkersAndQueues(
 	}
 
 	if deps.TranslationClient != nil {
-		translationWorker := NewFeedbackTranslationWorker(deps.TranslationService, deps.TranslationClient, deps.TranslationMetrics)
+		translationWorker := NewFeedbackTranslationWorker(deps.TranslationService, deps.TranslationClient, deps.TranslationMetrics,
+			deps.Failures)
 		river.AddWorker(workers, translationWorker)
 
 		queues[service.TranslationsQueueName] = river.QueueConfig{MaxWorkers: maxTranslation}
@@ -106,7 +112,8 @@ func NewRiverWorkersAndQueues(
 
 	if deps.SentimentClient != nil {
 		sentimentWorker := NewFeedbackSentimentWorker(
-			deps.SentimentService, deps.SentimentResolver, deps.SentimentClient, deps.SentimentMetrics)
+			deps.SentimentService, deps.SentimentResolver, deps.SentimentClient, deps.SentimentMetrics,
+			deps.Failures)
 		river.AddWorker(workers, sentimentWorker)
 
 		queues[service.SentimentsQueueName] = river.QueueConfig{MaxWorkers: maxSentiment}
@@ -114,7 +121,8 @@ func NewRiverWorkersAndQueues(
 
 	if deps.EmotionsClient != nil {
 		emotionsWorker := NewFeedbackEmotionsWorker(
-			deps.EmotionsService, deps.EmotionsResolver, deps.EmotionsClient, deps.EmotionsMetrics)
+			deps.EmotionsService, deps.EmotionsResolver, deps.EmotionsClient, deps.EmotionsMetrics,
+			deps.Failures)
 		river.AddWorker(workers, emotionsWorker)
 
 		queues[service.EmotionsQueueName] = river.QueueConfig{MaxWorkers: maxEmotions}

--- a/internal/workers/wiring.go
+++ b/internal/workers/wiring.go
@@ -54,6 +54,9 @@ type RiverDeps struct {
 	// Shared by the three classify pipelines; nil disables recording, which leaves the API
 	// under-reporting failures but changes no enrichment behaviour.
 	Failures FailureRecorder
+	// FailureMetrics counts permanent give-ups by cause, for whoever watches the deployment
+	// rather than a single tenant. nil disables it.
+	FailureMetrics observability.EnrichmentFailureMetrics
 }
 
 // NewRiverWorkersAndQueues builds River workers and queue config from cfg and deps. Each optional
@@ -99,7 +102,7 @@ func NewRiverWorkersAndQueues(
 
 	if deps.TranslationClient != nil {
 		translationWorker := NewFeedbackTranslationWorker(deps.TranslationService, deps.TranslationClient, deps.TranslationMetrics,
-			deps.Failures)
+			deps.Failures, deps.FailureMetrics)
 		river.AddWorker(workers, translationWorker)
 
 		queues[service.TranslationsQueueName] = river.QueueConfig{MaxWorkers: maxTranslation}
@@ -113,7 +116,7 @@ func NewRiverWorkersAndQueues(
 	if deps.SentimentClient != nil {
 		sentimentWorker := NewFeedbackSentimentWorker(
 			deps.SentimentService, deps.SentimentResolver, deps.SentimentClient, deps.SentimentMetrics,
-			deps.Failures)
+			deps.Failures, deps.FailureMetrics)
 		river.AddWorker(workers, sentimentWorker)
 
 		queues[service.SentimentsQueueName] = river.QueueConfig{MaxWorkers: maxSentiment}
@@ -122,7 +125,7 @@ func NewRiverWorkersAndQueues(
 	if deps.EmotionsClient != nil {
 		emotionsWorker := NewFeedbackEmotionsWorker(
 			deps.EmotionsService, deps.EmotionsResolver, deps.EmotionsClient, deps.EmotionsMetrics,
-			deps.Failures)
+			deps.Failures, deps.FailureMetrics)
 		river.AddWorker(workers, emotionsWorker)
 
 		queues[service.EmotionsQueueName] = river.QueueConfig{MaxWorkers: maxEmotions}

--- a/migrations/022_enrichment_failures.sql
+++ b/migrations/022_enrichment_failures.sql
@@ -65,13 +65,18 @@ ALTER TABLE feedback_record_enrichment_failures
 -- The reason set and the terminal flag are one decision, so the database enforces that they agree.
 -- Without this a bug could write terminal = true with reason 'provider_error', and the reconciler
 -- would then permanently skip a record whose only problem was a transient 503.
+--
+-- The non-terminal arm carries two values because a record can be left un-enriched by either half
+-- of the job: the provider never answered, or it answered and the result could not be written.
+-- Both are retryable and the counts treat them identically; they are distinguished because an
+-- operator seeing a spike of one should not go looking at the other.
 ALTER TABLE feedback_record_enrichment_failures
   DROP CONSTRAINT IF EXISTS feedback_record_enrichment_failures_reason_valid;
 ALTER TABLE feedback_record_enrichment_failures
   ADD CONSTRAINT feedback_record_enrichment_failures_reason_valid CHECK (
     (terminal AND reason IN ('content_filter', 'refusal', 'length', 'recitation'))
     OR
-    (NOT terminal AND reason = 'provider_error')
+    (NOT terminal AND reason IN ('provider_error', 'write_failed'))
   );
 
 -- Serves the per-tenant `failed` / `failed_terminal` counts. terminal is in the key rather than a

--- a/migrations/022_enrichment_failures.sql
+++ b/migrations/022_enrichment_failures.sql
@@ -1,0 +1,83 @@
+-- +goose NO TRANSACTION
+-- +goose up
+-- Durable, cause-classified record of enrichment failures (ENG-2375).
+--
+-- Failure state has until now lived only in River: a job that exhausts its attempts is discarded,
+-- and River reaps discarded rows after its retention window (7 days by default; the Hub overrides
+-- only CompletedJobRetentionPeriod). So "how many records failed" was a number that silently reset
+-- to zero, and "which of them can never succeed" could not be asked at all -- a content-filter
+-- block and a 503 were indistinguishable by the time anything read them.
+--
+-- Two things depend on being able to tell those apart. The API reports them separately, so the UI
+-- can say "3 failed -- retry" and "1 can't be processed" rather than showing a count that drains
+-- on its own. And the reconciler, which re-enqueues everything eligible-but-not-done, must exclude
+-- the permanent ones or it re-runs them on every tick, forever, at a provider call each time.
+--
+-- ROWS ARE ADVISORY, NOT AUTHORITATIVE. `failed` is reported as "a row exists AND the record is
+-- not done", never from this table alone. That is deliberate: a later success needs no cleanup
+-- write, so the enrichment hot path stays free of bookkeeping, and a stale row can never inflate
+-- the count. The sweeper garbage-collects dead rows lazily.
+--
+-- THE TENANT BOUNDARY IS feedback_records.tenant_id, NOT THE COLUMN HERE. tenant_id is
+-- denormalized onto this table solely so the per-tenant index below is possible. Counting queries
+-- join on feedback_record_id and keep `fr.tenant_id = $n` as their only tenant predicate. Do not
+-- "simplify" a query to filter on this column instead: that would give the tenant boundary two
+-- sources of truth, and the guard would only ever be as good as the write path that populated it.
+--
+-- ON DELETE CASCADE rather than an explicit delete in the tenant purge, which diverges from the
+-- convention in tenant_data_repository.go ("the purge never relies on cascades"). That rule exists
+-- for the taxonomy tables, which would be genuinely ORPHANED by a feedback_records delete because
+-- they do not cascade, and whose per-table counts are reported in the purge response. Neither
+-- applies here: this table cascades correctly, and a count of removed failure markers is internal
+-- derived state that no caller of the purge has a use for. Rows carry tenant_id, though, so a
+-- broken cascade would leave tenant-scoped data behind -- covered by an integration test asserting
+-- none survive a purge.
+--
+-- Runs without a transaction because of the CONCURRENTLY index build below.
+CREATE TABLE IF NOT EXISTS feedback_record_enrichment_failures (
+  feedback_record_id UUID        NOT NULL REFERENCES feedback_records(id) ON DELETE CASCADE,
+  -- Which enrichment failed. Matches the names used by the status endpoint and the metric label.
+  enrichment         VARCHAR(32) NOT NULL,
+  -- Denormalized for the index below only -- see the tenant-boundary note above.
+  tenant_id          VARCHAR(255) NOT NULL,
+  failed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- How many attempts were spent before giving up. Diagnostic only.
+  attempts           INTEGER     NOT NULL DEFAULT 0,
+  -- terminal = retrying cannot help, because the outcome is a property of the record's own text.
+  terminal           BOOLEAN     NOT NULL,
+  -- Bounded set, never the provider's error string. Refusal text is model-generated but routinely
+  -- paraphrases the input, so storing it would put customer feedback at rest here and from here
+  -- into the API. Raw provider text stays in logs, already truncated at the client.
+  reason             VARCHAR(32) NOT NULL,
+  PRIMARY KEY (feedback_record_id, enrichment)
+);
+
+ALTER TABLE feedback_record_enrichment_failures
+  DROP CONSTRAINT IF EXISTS feedback_record_enrichment_failures_enrichment_valid;
+ALTER TABLE feedback_record_enrichment_failures
+  ADD CONSTRAINT feedback_record_enrichment_failures_enrichment_valid CHECK (
+    enrichment IN ('translation', 'sentiment', 'emotions')
+  );
+
+-- The reason set and the terminal flag are one decision, so the database enforces that they agree.
+-- Without this a bug could write terminal = true with reason 'provider_error', and the reconciler
+-- would then permanently skip a record whose only problem was a transient 503.
+ALTER TABLE feedback_record_enrichment_failures
+  DROP CONSTRAINT IF EXISTS feedback_record_enrichment_failures_reason_valid;
+ALTER TABLE feedback_record_enrichment_failures
+  ADD CONSTRAINT feedback_record_enrichment_failures_reason_valid CHECK (
+    (terminal AND reason IN ('content_filter', 'refusal', 'length', 'recitation'))
+    OR
+    (NOT terminal AND reason = 'provider_error')
+  );
+
+-- Serves the per-tenant `failed` / `failed_terminal` counts. terminal is in the key rather than a
+-- predicate because both halves are queried; the table only ever holds failures, so there is no
+-- large uninteresting majority to exclude with a partial index.
+DROP INDEX CONCURRENTLY IF EXISTS idx_enrichment_failures_tenant_enrichment;
+CREATE INDEX CONCURRENTLY idx_enrichment_failures_tenant_enrichment
+  ON feedback_record_enrichment_failures (tenant_id, enrichment, terminal);
+
+-- +goose down
+DROP INDEX CONCURRENTLY IF EXISTS idx_enrichment_failures_tenant_enrichment;
+DROP TABLE IF EXISTS feedback_record_enrichment_failures;

--- a/migrations/022_enrichment_failures.sql
+++ b/migrations/022_enrichment_failures.sql
@@ -54,6 +54,9 @@ CREATE TABLE IF NOT EXISTS feedback_record_enrichment_failures (
 
 ALTER TABLE feedback_record_enrichment_failures
   DROP CONSTRAINT IF EXISTS feedback_record_enrichment_failures_enrichment_valid;
+-- Scoped to the three record-level enrichments the status endpoint reports. Embeddings is the
+-- fourth pipeline and shares these failure modes, so recording its failures here later is a
+-- plausible extension -- and would need a migration to widen this list, not just worker code.
 ALTER TABLE feedback_record_enrichment_failures
   ADD CONSTRAINT feedback_record_enrichment_failures_enrichment_valid CHECK (
     enrichment IN ('translation', 'sentiment', 'emotions')

--- a/migrations/022_enrichment_failures.sql
+++ b/migrations/022_enrichment_failures.sql
@@ -19,10 +19,17 @@
 -- the count. The sweeper garbage-collects dead rows lazily.
 --
 -- THE TENANT BOUNDARY IS feedback_records.tenant_id, NOT THE COLUMN HERE. tenant_id is
--- denormalized onto this table solely so the per-tenant index below is possible. Counting queries
--- join on feedback_record_id and keep `fr.tenant_id = $n` as their only tenant predicate. Do not
--- "simplify" a query to filter on this column instead: that would give the tenant boundary two
--- sources of truth, and the guard would only ever be as good as the write path that populated it.
+-- denormalized onto this table so the per-tenant index below is possible, and the counting queries
+-- do use it -- in the JOIN, alongside `fr.tenant_id = $n` in the outer WHERE, because without a
+-- tenant-side predicate the planner hash-joins this whole table and every tenant pays for every
+-- other tenant's failures.
+--
+-- The distinction that matters is ADDITIONAL versus INSTEAD OF. A join predicate can only narrow
+-- which marker attaches to a record, so it cannot pull in another tenant's row. Removing
+-- `fr.tenant_id = $n` and filtering on this column instead is the forbidden move: it would put the
+-- tenant boundary on a denormalized value that is only ever as good as the write path that filled
+-- it. Integration tests hold both halves -- a marker stamped with a foreign tenant must be
+-- invisible to that tenant, and the record-side predicate must be what makes it so.
 --
 -- ON DELETE CASCADE rather than an explicit delete in the tenant purge, which diverges from the
 -- convention in tenant_data_repository.go ("the purge never relies on cascades"). That rule exists

--- a/migrations/022_enrichment_failures.sql
+++ b/migrations/022_enrichment_failures.sql
@@ -54,7 +54,9 @@ CREATE TABLE IF NOT EXISTS feedback_record_enrichment_failures (
   terminal           BOOLEAN     NOT NULL,
   -- Bounded set, never the provider's error string. Refusal text is model-generated but routinely
   -- paraphrases the input, so storing it would put customer feedback at rest here and from here
-  -- into the API. Raw provider text stays in logs, already truncated at the client.
+  -- into the API. Raw provider text stays in logs, truncated at the client -- 256 chars for an
+  -- OpenAI refusal and for a Gemini block message, the two free-form strings either provider
+  -- returns. Everything else the clients surface is a bounded enum.
   reason             VARCHAR(32) NOT NULL,
   PRIMARY KEY (feedback_record_id, enrichment)
 );

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1598,7 +1598,10 @@ paths:
                 is active for the tenant (deployment-configured and switched on / with a resolvable
                 target language), and `eligible`/`done` are directory-level counts of feedback records
                 that qualify and that have been enriched — the UI derives "in progress" as
-                `eligible - done`. When an enrichment is not enabled its counts are zero. The response
+                `eligible - done`. When an enrichment is not enabled its counts are zero and
+                `disabled_reason` names the gate that closed it, so the UI can explain *why* rather than
+                silently hiding the enrichment. `as_of` is when the counts were computed, which lets a
+                polling client derive throughput and an ETA without the Hub computing either. The response
                 contains counts only (no record identifiers or content).
             operationId: get-enrichment-status
             parameters:
@@ -3936,6 +3939,20 @@ components:
                     type: integer
                     format: int64
                     description: Eligible records that have been enriched.
+                disabled_reason:
+                    type: string
+                    enum:
+                        - not_configured
+                        - switched_off
+                        - no_target_language
+                    description: |
+                        Which gate switched the enrichment off. Present exactly when `enabled` is false, and
+                        absent otherwise. `not_configured` — the deployment has no provider/model for this
+                        enrichment, so it is off for every tenant and only an operator can fix it.
+                        `switched_off` — the tenant turned it off (sentiment and emotions only).
+                        `no_target_language` — translation is configured but neither the tenant's
+                        `target_language` nor the deployment default resolves (translation only; it has no
+                        on/off switch, so an absent target is its off state).
             required:
                 - enabled
                 - eligible
@@ -3947,6 +3964,14 @@ components:
             properties:
                 tenant_id:
                     type: string
+                as_of:
+                    type: string
+                    format: date-time
+                    description: |
+                        When the counts were computed (UTC), not when the response was serialized. The
+                        endpoint is polled, so two responses are enough to derive throughput and an ETA
+                        client-side from the change in `done` over the change in `as_of` — the Hub computes
+                        neither.
                 translation:
                     $ref: '#/components/schemas/EnrichmentTypeStatus'
                 sentiment:
@@ -3955,6 +3980,7 @@ components:
                     $ref: '#/components/schemas/EnrichmentTypeStatus'
             required:
                 - tenant_id
+                - as_of
                 - translation
                 - sentiment
                 - emotions

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1598,7 +1598,8 @@ paths:
                 is active for the tenant (deployment-configured and switched on / with a resolvable
                 target language), and `eligible`/`done` are directory-level counts of feedback records
                 that qualify and that have been enriched — the UI derives "in progress" as
-                `eligible - done`. When an enrichment is not enabled its counts are zero and
+                `eligible - done`, of which `failed` is retryable and `failed_terminal` never will be.
+                When an enrichment is not enabled its counts are zero and
                 `disabled_reason` names the gate that closed it, so the UI can explain *why* rather than
                 silently hiding the enrichment. `as_of` is when the counts were computed, which lets a
                 polling client derive throughput and an ETA without the Hub computing either. The response
@@ -3939,6 +3940,20 @@ components:
                     type: integer
                     format: int64
                     description: Eligible records that have been enriched.
+                failed:
+                    type: integer
+                    format: int64
+                    description: |
+                        Eligible records whose last enrichment attempt gave up but which a retry could still
+                        rescue — a provider outage, a timeout. Counted only while the record is still
+                        un-enriched, so a later success removes it without any cleanup.
+                failed_terminal:
+                    type: integer
+                    format: int64
+                    description: |
+                        Eligible records the provider will never accept, because the outcome is a property of
+                        the record's own text — a content-policy block, a refusal, an input past the model's
+                        limit. Retrying these cannot help; they resolve only if the text changes.
                 disabled_reason:
                     type: string
                     enum:
@@ -3957,6 +3972,8 @@ components:
                 - enabled
                 - eligible
                 - done
+                - failed
+                - failed_terminal
         EnrichmentStatusOutputBody:
             type: object
             additionalProperties: false

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -84,3 +84,76 @@ func TestEnrichmentFailuresPurgedWithTenant(t *testing.T) {
 	_, err = tenantDataRepo.DeleteByTenant(ctx, other)
 	require.NoError(t, err)
 }
+
+// TestCountEnrichmentStatusCountsFailures exercises the failure columns against Postgres. The
+// service tests use a fake repository, so this is the only place the SQL itself is checked — and
+// the properties that matter here are all properties of the query: that the marker joins do not
+// fan out, that a failure stops counting once the record is enriched, and that the tenant boundary
+// comes from feedback_records rather than from the markers' own tenant_id column.
+func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	frepo := repository.NewFeedbackRecordsRepository(db)
+	statusRepo := repository.NewEnrichmentStatusRepository(db)
+	tenant := "enrichment-failed-counts-" + uuid.NewString()
+
+	mark := func(record *models.FeedbackRecord, enrichment string, terminal bool, reason string) {
+		t.Helper()
+
+		_, execErr := db.Exec(ctx, `
+			INSERT INTO feedback_record_enrichment_failures
+				(feedback_record_id, enrichment, tenant_id, terminal, reason)
+			VALUES ($1, $2, $3, $4, $5)`, record.ID, enrichment, tenant, terminal, reason)
+		require.NoError(t, execErr)
+	}
+
+	transient := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "transient failure")
+	mark(transient, "sentiment", false, "provider_error")
+
+	permanent := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "permanent failure")
+	mark(permanent, "sentiment", true, "content_filter")
+
+	// A record that failed once and later succeeded. Its marker is deliberately left behind — the
+	// design says a success writes no cleanup — so this proves the stale row stops counting.
+	recovered := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "failed then recovered")
+	mark(recovered, "sentiment", false, "provider_error")
+
+	label, score := models.SentimentPositive, 1.0
+	require.NoError(t, frepo.SetSentiment(ctx, recovered.ID, &label, &score, nil))
+
+	// Markers for two different enrichments on one record must not multiply its row.
+	both := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "failed twice over")
+	mark(both, "sentiment", false, "provider_error")
+	mark(both, "emotions", true, "refusal")
+
+	counts, err := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), counts.SentimentFailed, "transient + the multi-enrichment record")
+	assert.Equal(t, int64(1), counts.SentimentFailedTerminal, "the content-filtered one")
+	assert.Equal(t, int64(0), counts.EmotionsFailed)
+	assert.Equal(t, int64(1), counts.EmotionsFailedTerminal, "the multi-enrichment record's refusal")
+
+	// The joins must be lookups, not fan-out: four records in, four eligible out. If a record with
+	// markers for two enrichments were counted twice this would read 5.
+	assert.Equal(t, int64(4), counts.SentimentEligible, "marker joins must not multiply rows")
+
+	// The recovered record is enriched, so its stale marker contributes to nothing.
+	assert.Equal(t, int64(1), counts.SentimentDone)
+
+	// Another tenant's markers must be invisible even though the markers table carries a tenant_id
+	// of its own — the boundary is feedback_records.tenant_id.
+	otherTenant := "enrichment-failed-counts-other-" + uuid.NewString()
+	otherCounts, err := statusRepo.CountEnrichmentStatus(ctx, otherTenant, "")
+	require.NoError(t, err)
+	assert.Zero(t, otherCounts.SentimentFailed)
+	assert.Zero(t, otherCounts.SentimentFailedTerminal)
+}

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -181,19 +181,24 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 	mark(both, "sentiment", false, "provider_error")
 	mark(both, "emotions", true, "refusal")
 
-	// A record of THIS tenant whose marker is stamped with someone else's tenant_id. Migration 022
-	// says that column is there for its index and must never be a tenant predicate; this fixture
-	// is what enforces it. Gate any failure count on the marker's own tenant_id — the "obvious"
-	// optimization the migration warns about — and this record silently disappears from the tenant
-	// that actually owns it, while every other assertion here still passes.
+	// A record of THIS tenant whose marker is stamped with someone else's tenant_id. Nothing can
+	// produce that — the worker reads the tenant off the record — so it exists purely to pin which
+	// predicate governs.
+	//
+	// The counting query keys the marker JOIN on the stamp as well as on the record, for the index
+	// (see enrichmentFailureJoins), so this marker is NOT counted: the accepted trade, and the safe
+	// direction, since the record just reads as still in progress. What must never change is the
+	// other half — the stamped tenant sees nothing, because the boundary is the RECORD's tenant in
+	// the outer WHERE, not the stamp.
+	misstampedTenant := "wrong-stamp-" + uuid.NewString()
 	misstamped := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "marker stamped with the wrong tenant")
-	insertFailureMarker(t, db, misstamped.ID, "wrong-stamp-"+uuid.NewString(), "sentiment", false, "provider_error")
+	insertFailureMarker(t, db, misstamped.ID, misstampedTenant, "sentiment", false, "provider_error")
 
 	counts, err := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(3), counts.SentimentFailed,
-		"transient + the multi-enrichment record + the one whose marker is stamped elsewhere")
+	assert.Equal(t, int64(2), counts.SentimentFailed,
+		"transient + the multi-enrichment record; the marker stamped elsewhere does not attach")
 	assert.Equal(t, int64(1), counts.SentimentFailedTerminal, "the content-filtered one")
 	assert.Equal(t, int64(0), counts.EmotionsFailed)
 	assert.Equal(t, int64(1), counts.EmotionsFailedTerminal, "the multi-enrichment record's refusal")
@@ -205,10 +210,16 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 	// The recovered record is enriched, so its stale marker contributes to nothing.
 	assert.Equal(t, int64(1), counts.SentimentDone)
 
-	// Another tenant's markers must be invisible even though the markers table carries a tenant_id
-	// of its own — the boundary is feedback_records.tenant_id. The misstamped marker above is the
-	// other half of this: one proves a foreign tenant sees nothing, the other proves the owning
-	// tenant sees everything of its own regardless of what the stamp says.
+	// A tenant with no records of its own sees nothing, however many markers name it. This is the
+	// boundary assertion: the stamped tenant owns no feedback record, so the outer
+	// fr.tenant_id predicate is the only thing that can be keeping its count at zero.
+	stamped, err := statusRepo.CountEnrichmentStatus(ctx, misstampedTenant, "")
+	require.NoError(t, err)
+	assert.Zero(t, stamped.SentimentEligible, "a tenant with no records has nothing eligible")
+	assert.Zero(t, stamped.SentimentFailed, "and cannot see a marker merely because it names them")
+	assert.Zero(t, stamped.SentimentFailedTerminal)
+
+	// And a wholly unrelated tenant likewise.
 	otherTenant := "enrichment-failed-counts-other-" + uuid.NewString()
 	otherCounts, err := statusRepo.CountEnrichmentStatus(ctx, otherTenant, "")
 	require.NoError(t, err)

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +15,24 @@ import (
 	"github.com/formbricks/hub/internal/repository"
 	"github.com/formbricks/hub/pkg/database"
 )
+
+// insertFailureMarker writes a marker directly, so a test can stamp a tenant_id that DISAGREES
+// with the record's. Nothing in production can produce that — the worker reads the tenant off the
+// record — but the tests below need it to tell the two candidate tenant boundaries apart, and a
+// fixture no code path can produce is exactly what proves the boundary is not the stamp.
+func insertFailureMarker(
+	t *testing.T, db *pgxpool.Pool,
+	record *models.FeedbackRecord, stampedTenant, enrichment string, terminal bool, reason string,
+) {
+	t.Helper()
+
+	_, err := db.Exec(context.Background(), `
+		INSERT INTO feedback_record_enrichment_failures
+			(feedback_record_id, enrichment, tenant_id, terminal, reason)
+		VALUES ($1, $2, $3, $4, $5)`,
+		record.ID, enrichment, stampedTenant, terminal, reason)
+	require.NoError(t, err)
+}
 
 // TestEnrichmentFailuresPurgedWithTenant proves the failure markers do not outlive the tenant they
 // belong to.
@@ -43,23 +62,32 @@ func TestEnrichmentFailuresPurgedWithTenant(t *testing.T) {
 	doomed := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "record that failed enrichment")
 	survivor := seedEnrichmentRecord(t, frepo, other, models.FieldTypeText, "record in a different tenant")
 
-	insertFailure := func(record *models.FeedbackRecord, tenantID, enrichment string, terminal bool, reason string) {
+	// One of each kind, so a cascade that somehow only caught one shape would still fail. The
+	// third is stamped with a tenant that is not its record's: it must be purged all the same,
+	// because what removes it is the record it hangs off, not the stamp.
+	insertFailureMarker(t, db, doomed, tenant, "sentiment", true, "content_filter")
+	insertFailureMarker(t, db, doomed, tenant, "emotions", false, "provider_error")
+	insertFailureMarker(t, db, doomed, "not-this-tenant-"+uuid.NewString(), "translation", false, "provider_error")
+	insertFailureMarker(t, db, survivor, other, "sentiment", true, "refusal")
+
+	// Counted two ways, because a survivor can hide from either one alone. Joining to the record
+	// misses an ORPHAN — a marker left behind by a dropped foreign key has no record to join to —
+	// and counting the denormalized stamp misses a marker whose stamp is wrong. A row has to
+	// evade both to slip through.
+	markersOwnedBy := func(tenantID string) int64 {
 		t.Helper()
 
-		_, execErr := db.Exec(ctx, `
-			INSERT INTO feedback_record_enrichment_failures
-				(feedback_record_id, enrichment, tenant_id, terminal, reason)
-			VALUES ($1, $2, $3, $4, $5)`,
-			record.ID, enrichment, tenantID, terminal, reason)
-		require.NoError(t, execErr)
+		var count int64
+		require.NoError(t, db.QueryRow(ctx, `
+			SELECT count(*)
+			FROM feedback_record_enrichment_failures f
+			JOIN feedback_records fr ON fr.id = f.feedback_record_id
+			WHERE fr.tenant_id = $1`, tenantID).Scan(&count))
+
+		return count
 	}
 
-	// One of each kind, so a cascade that somehow only caught one shape would still fail.
-	insertFailure(doomed, tenant, "sentiment", true, "content_filter")
-	insertFailure(doomed, tenant, "emotions", false, "provider_error")
-	insertFailure(survivor, other, "sentiment", true, "refusal")
-
-	countFor := func(tenantID string) int64 {
+	markersStamped := func(tenantID string) int64 {
 		t.Helper()
 
 		var count int64
@@ -70,16 +98,36 @@ func TestEnrichmentFailuresPurgedWithTenant(t *testing.T) {
 		return count
 	}
 
-	require.Equal(t, int64(2), countFor(tenant), "markers staged")
-	require.Equal(t, int64(1), countFor(other), "other tenant's marker staged")
+	orphanedMarkers := func() int64 {
+		t.Helper()
+
+		var count int64
+		require.NoError(t, db.QueryRow(ctx, `
+			SELECT count(*)
+			FROM feedback_record_enrichment_failures f
+			LEFT JOIN feedback_records fr ON fr.id = f.feedback_record_id
+			WHERE fr.id IS NULL`).Scan(&count))
+
+		return count
+	}
+
+	require.Equal(t, int64(3), markersOwnedBy(tenant), "markers staged, counted by the record they belong to")
+	require.Equal(t, int64(2), markersStamped(tenant), "the third marker is deliberately stamped elsewhere")
+	require.Equal(t, int64(1), markersOwnedBy(other), "other tenant's marker staged")
+	require.Zero(t, orphanedMarkers(), "no orphans before the purge")
 
 	_, err = tenantDataRepo.DeleteByTenant(ctx, tenant)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(0), countFor(tenant), "no failure marker may survive its tenant's purge")
+	assert.Zero(t, markersOwnedBy(tenant), "no failure marker may survive its tenant's purge")
+	assert.Zero(t, markersStamped(tenant), "nor may one identified only by its own stamp")
+	// The join above cannot see a marker whose record is gone, so the cascade is checked directly:
+	// drop the foreign key and the markers survive as orphans while every other count reads zero.
+	assert.Zero(t, orphanedMarkers(), "the cascade must remove markers, not orphan them")
+
 	// The purge is tenant-scoped, so a neighbour's markers must be untouched — the same boundary
 	// the counting queries rely on.
-	assert.Equal(t, int64(1), countFor(other), "another tenant's markers must be left alone")
+	assert.Equal(t, int64(1), markersOwnedBy(other), "another tenant's markers must be left alone")
 
 	_, err = tenantDataRepo.DeleteByTenant(ctx, other)
 	require.NoError(t, err)
@@ -107,12 +155,7 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 
 	mark := func(record *models.FeedbackRecord, enrichment string, terminal bool, reason string) {
 		t.Helper()
-
-		_, execErr := db.Exec(ctx, `
-			INSERT INTO feedback_record_enrichment_failures
-				(feedback_record_id, enrichment, tenant_id, terminal, reason)
-			VALUES ($1, $2, $3, $4, $5)`, record.ID, enrichment, tenant, terminal, reason)
-		require.NoError(t, execErr)
+		insertFailureMarker(t, db, record, tenant, enrichment, terminal, reason)
 	}
 
 	transient := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "transient failure")
@@ -134,23 +177,34 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 	mark(both, "sentiment", false, "provider_error")
 	mark(both, "emotions", true, "refusal")
 
+	// A record of THIS tenant whose marker is stamped with someone else's tenant_id. Migration 022
+	// says that column is there for its index and must never be a tenant predicate; this fixture
+	// is what enforces it. Gate any failure count on the marker's own tenant_id — the "obvious"
+	// optimization the migration warns about — and this record silently disappears from the tenant
+	// that actually owns it, while every other assertion here still passes.
+	misstamped := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "marker stamped with the wrong tenant")
+	insertFailureMarker(t, db, misstamped, "wrong-stamp-"+uuid.NewString(), "sentiment", false, "provider_error")
+
 	counts, err := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), counts.SentimentFailed, "transient + the multi-enrichment record")
+	assert.Equal(t, int64(3), counts.SentimentFailed,
+		"transient + the multi-enrichment record + the one whose marker is stamped elsewhere")
 	assert.Equal(t, int64(1), counts.SentimentFailedTerminal, "the content-filtered one")
 	assert.Equal(t, int64(0), counts.EmotionsFailed)
 	assert.Equal(t, int64(1), counts.EmotionsFailedTerminal, "the multi-enrichment record's refusal")
 
-	// The joins must be lookups, not fan-out: four records in, four eligible out. If a record with
-	// markers for two enrichments were counted twice this would read 5.
-	assert.Equal(t, int64(4), counts.SentimentEligible, "marker joins must not multiply rows")
+	// The joins must be lookups, not fan-out: five records in, five eligible out. If a record with
+	// markers for two enrichments were counted twice this would read 6.
+	assert.Equal(t, int64(5), counts.SentimentEligible, "marker joins must not multiply rows")
 
 	// The recovered record is enriched, so its stale marker contributes to nothing.
 	assert.Equal(t, int64(1), counts.SentimentDone)
 
 	// Another tenant's markers must be invisible even though the markers table carries a tenant_id
-	// of its own — the boundary is feedback_records.tenant_id.
+	// of its own — the boundary is feedback_records.tenant_id. The misstamped marker above is the
+	// other half of this: one proves a foreign tenant sees nothing, the other proves the owning
+	// tenant sees everything of its own regardless of what the stamp says.
 	otherTenant := "enrichment-failed-counts-other-" + uuid.NewString()
 	otherCounts, err := statusRepo.CountEnrichmentStatus(ctx, otherTenant, "")
 	require.NoError(t, err)

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -304,3 +304,158 @@ func TestEnrichmentFailureMarkerConstraints(t *testing.T) {
 		})
 	}
 }
+
+// TestStaleMarkerStopsCountingWhenTheRecordMovesOn is the fail → succeed → INVALIDATE case.
+//
+// The advisory-marker design rested on "a stale row stops counting the moment the record is done",
+// which quietly assumes done is permanent. It is not: editing value_text nulls the translation
+// columns, and changing a tenant's target_language shifts the effective target so an
+// already-translated record stops matching it. Either would revive a marker from a failure that
+// was resolved long ago, and the endpoint would then report `failed` for work that is merely
+// re-queued — the wrong-progress symptom this feature exists to remove, reintroduced by its own
+// bookkeeping. The successful write now deletes the marker, which is what closes it.
+func TestStaleMarkerStopsCountingWhenTheRecordMovesOn(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	frepo := repository.NewFeedbackRecordsRepository(db)
+	statusRepo := repository.NewEnrichmentStatusRepository(db)
+	tenant := "stale-marker-" + uuid.NewString()
+
+	_, err = db.Exec(ctx, `INSERT INTO tenant_settings (tenant_id, settings)
+		VALUES ($1, '{"target_language":"de-DE"}'::jsonb)`, tenant)
+	require.NoError(t, err)
+
+	record := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "failed once, then translated")
+
+	// 1. It failed.
+	insertFailureMarker(t, db, record.ID, tenant, "translation", false, "provider_error")
+
+	counts, err := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), counts.TranslationFailed, "a fresh failure counts")
+
+	// 2. It later succeeded. No cleanup write — that is the design — so the marker is still there.
+	translated := "übersetzt"
+	require.NoError(t, frepo.SetTranslation(ctx, record.ID, &translated, "de-DE", "",
+		func(*string) bool { return true }))
+
+	counts, err = statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), counts.TranslationDone)
+	require.Zero(t, counts.TranslationFailed, "a resolved failure stops counting")
+
+	// The successful write REMOVED the marker. This is the load-bearing half: leaving it in place
+	// is what let a resolved failure come back when the record was later un-enriched.
+	markers := countRowsIn(ctx, t, db,
+		`SELECT count(*) FROM feedback_record_enrichment_failures WHERE feedback_record_id = $1`, record.ID)
+	require.Zero(t, markers, "success clears the marker it resolved")
+
+	// 3. The tenant changes its target language. The record is untouched, but it is no longer
+	//    translated INTO THE CURRENT TARGET, so it is pending again — and the marker must not come
+	//    back with it.
+	_, err = db.Exec(ctx, `UPDATE tenant_settings SET settings = '{"target_language":"fr-FR"}'::jsonb
+		WHERE tenant_id = $1`, tenant)
+	require.NoError(t, err)
+
+	counts, err = statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+	require.NoError(t, err)
+	assert.Zero(t, counts.TranslationDone, "a new target means the old translation no longer counts")
+	assert.Zero(t, counts.TranslationFailed,
+		"and the resolved failure must NOT resurrect: this work is queued, not failed")
+	assert.Zero(t, counts.TranslationFailedTerminal)
+
+	// 4. A failure recorded against the record as it now stands does count — the mechanism removes
+	//    resolved failures, not current ones.
+	insertFailureMarker(t, db, record.ID, tenant, "translation", true, "content_filter")
+
+	counts, err = statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), counts.TranslationFailedTerminal,
+		"a failure that has not been resolved describes the record as it stands")
+}
+
+// TestCountFailedRecordsAggregateIsGated covers the cross-tenant gauge, which had no test at all
+// and is the one query here with no tenant predicate.
+//
+// It must agree with what the endpoint reports for the same tenants, or an operator sees failures
+// on a dashboard that the API says are zero and cannot reconcile the two.
+func TestCountFailedRecordsAggregateIsGated(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	frepo := repository.NewFeedbackRecordsRepository(db)
+	statusRepo := repository.NewEnrichmentStatusRepository(db)
+
+	countFor := func(enrichment string, terminal bool, counts []repository.FailedRecordCount) int64 {
+		for _, c := range counts {
+			if c.Enrichment == enrichment && c.Terminal == terminal {
+				return c.Count
+			}
+		}
+
+		return 0
+	}
+
+	before, err := statusRepo.CountFailedRecordsAggregate(ctx)
+	require.NoError(t, err)
+
+	// A tenant that switched sentiment off. Its failures are history, not work.
+	off := "agg-off-" + uuid.NewString()
+	_, err = db.Exec(ctx, `INSERT INTO tenant_settings (tenant_id, settings)
+		VALUES ($1, '{"sentiment_enabled":false}'::jsonb)`, off)
+	require.NoError(t, err)
+
+	offRecord := seedEnrichmentRecord(t, frepo, off, models.FieldTypeText, "sentiment is switched off here")
+	insertFailureMarker(t, db, offRecord.ID, off, "sentiment", false, "provider_error")
+
+	// A record whose text was blanked: eligible for nothing, so owed nothing.
+	blanked := "agg-blank-" + uuid.NewString()
+	blankRecord := seedEnrichmentRecord(t, frepo, blanked, models.FieldTypeText, "text that will be removed")
+	insertFailureMarker(t, db, blankRecord.ID, blanked, "sentiment", false, "provider_error")
+	_, err = db.Exec(ctx, `UPDATE feedback_records SET value_text = '   ' WHERE id = $1`, blankRecord.ID)
+	require.NoError(t, err)
+
+	// And a real, current failure that must be counted.
+	live := "agg-live-" + uuid.NewString()
+	liveRecord := seedEnrichmentRecord(t, frepo, live, models.FieldTypeText, "genuinely failed sentiment")
+	insertFailureMarker(t, db, liveRecord.ID, live, "sentiment", false, "provider_error")
+
+	after, err := statusRepo.CountFailedRecordsAggregate(ctx)
+	require.NoError(t, err)
+
+	delta := countFor("sentiment", false, after) - countFor("sentiment", false, before)
+	assert.Equal(t, int64(1), delta,
+		"only the live failure counts: not the switched-off tenant's, not the blanked record's")
+
+	// The gauge and the endpoint must not disagree for the same tenant.
+	for _, tenant := range []string{off, blanked} {
+		counts, statusErr := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
+		require.NoError(t, statusErr)
+		assert.Zero(t, counts.SentimentFailed, "%s: the endpoint reports nothing failed", tenant)
+	}
+}
+
+func countRowsIn(ctx context.Context, t *testing.T, db *pgxpool.Pool, query string, args ...any) int64 {
+	t.Helper()
+
+	var count int64
+
+	require.NoError(t, db.QueryRow(ctx, query, args...).Scan(&count))
+
+	return count
+}

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -213,4 +214,82 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, otherCounts.SentimentFailed)
 	assert.Zero(t, otherCounts.SentimentFailedTerminal)
+}
+
+// TestEnrichmentFailureMarkerConstraints holds the database to the rule the Go types only assert
+// by convention: terminal and reason are ONE decision, and the enrichment name is closed.
+//
+// The CHECK is what stops a bug writing terminal = true with a retryable reason, which would make
+// anything that re-enqueues unfinished work skip that record permanently — a record silently
+// abandoned because of a typo. A constraint nothing tries to violate is a constraint nobody
+// notices the loss of.
+func TestEnrichmentFailureMarkerConstraints(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	frepo := repository.NewFeedbackRecordsRepository(db)
+	tenant := "enrichment-marker-checks-" + uuid.NewString()
+	record := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "constraint fixture")
+
+	insert := func(enrichment string, terminal bool, reason string) error {
+		_, execErr := db.Exec(ctx, `
+			INSERT INTO feedback_record_enrichment_failures
+				(feedback_record_id, enrichment, tenant_id, terminal, reason)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (feedback_record_id, enrichment) DO UPDATE SET
+				terminal = EXCLUDED.terminal, reason = EXCLUDED.reason`,
+			record.ID, enrichment, tenant, terminal, reason)
+		if execErr != nil {
+			return fmt.Errorf("insert marker: %w", execErr)
+		}
+
+		return nil
+	}
+
+	accepted := map[string]struct {
+		terminal bool
+		reason   string
+	}{
+		"content filter is permanent": {true, "content_filter"},
+		"refusal is permanent":        {true, "refusal"},
+		"length is permanent":         {true, "length"},
+		"recitation is permanent":     {true, "recitation"},
+		"a provider outage is not":    {false, "provider_error"},
+		"nor is a failed write":       {false, "write_failed"},
+	}
+
+	for name, want := range accepted {
+		t.Run("accepts "+name, func(t *testing.T) {
+			require.NoError(t, insert("sentiment", want.terminal, want.reason))
+		})
+	}
+
+	rejected := map[string]struct {
+		enrichment string
+		terminal   bool
+		reason     string
+	}{
+		// The dangerous direction: a permanent-looking marker for a failure a retry would fix,
+		// which has anything that re-enqueues unfinished work skip the record for good.
+		"a retryable reason marked permanent": {"sentiment", true, "provider_error"},
+		"a failed write marked permanent":     {"sentiment", true, "write_failed"},
+		// And the mirror, which has the reconciler retrying something that can never succeed.
+		"a permanent reason marked retryable": {"sentiment", false, "content_filter"},
+		"a reason nothing defines":            {"sentiment", false, "something_new"},
+		// Widening the enrichment set must take a migration, not just worker code.
+		"an enrichment this table does not hold": {"embeddings", false, "provider_error"},
+	}
+
+	for name, bad := range rejected {
+		t.Run("rejects "+name, func(t *testing.T) {
+			require.Error(t, insert(bad.enrichment, bad.terminal, bad.reason))
+		})
+	}
 }

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/config"
+	"github.com/formbricks/hub/internal/models"
+	"github.com/formbricks/hub/internal/repository"
+	"github.com/formbricks/hub/pkg/database"
+)
+
+// TestEnrichmentFailuresPurgedWithTenant proves the failure markers do not outlive the tenant they
+// belong to.
+//
+// The rows carry tenant_id, so surviving one is tenant-scoped data left behind by a purge — a
+// retention problem, not untidiness. They are removed by ON DELETE CASCADE rather than by an
+// explicit delete in the purge, which diverges from the convention in tenant_data_repository.go,
+// so the cascade is what needs proving: drop the foreign key or change the purge to delete by
+// tenant instead of by record and this test is what notices.
+func TestEnrichmentFailuresPurgedWithTenant(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+
+	db, err := database.NewPostgresPool(ctx, cfg.Database.URL, database.WithPoolConfig(cfg.Database.PoolConfig()))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	frepo := repository.NewFeedbackRecordsRepository(db)
+	tenantDataRepo := repository.NewTenantDataRepository(db, 5*time.Second)
+
+	tenant := "enrichment-failures-purge-" + uuid.NewString()
+	other := "enrichment-failures-keep-" + uuid.NewString()
+
+	doomed := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "record that failed enrichment")
+	survivor := seedEnrichmentRecord(t, frepo, other, models.FieldTypeText, "record in a different tenant")
+
+	insertFailure := func(record *models.FeedbackRecord, tenantID, enrichment string, terminal bool, reason string) {
+		t.Helper()
+
+		_, execErr := db.Exec(ctx, `
+			INSERT INTO feedback_record_enrichment_failures
+				(feedback_record_id, enrichment, tenant_id, terminal, reason)
+			VALUES ($1, $2, $3, $4, $5)`,
+			record.ID, enrichment, tenantID, terminal, reason)
+		require.NoError(t, execErr)
+	}
+
+	// One of each kind, so a cascade that somehow only caught one shape would still fail.
+	insertFailure(doomed, tenant, "sentiment", true, "content_filter")
+	insertFailure(doomed, tenant, "emotions", false, "provider_error")
+	insertFailure(survivor, other, "sentiment", true, "refusal")
+
+	countFor := func(tenantID string) int64 {
+		t.Helper()
+
+		var count int64
+		require.NoError(t, db.QueryRow(ctx,
+			`SELECT count(*) FROM feedback_record_enrichment_failures WHERE tenant_id = $1`,
+			tenantID).Scan(&count))
+
+		return count
+	}
+
+	require.Equal(t, int64(2), countFor(tenant), "markers staged")
+	require.Equal(t, int64(1), countFor(other), "other tenant's marker staged")
+
+	_, err = tenantDataRepo.DeleteByTenant(ctx, tenant)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), countFor(tenant), "no failure marker may survive its tenant's purge")
+	// The purge is tenant-scoped, so a neighbour's markers must be untouched — the same boundary
+	// the counting queries rely on.
+	assert.Equal(t, int64(1), countFor(other), "another tenant's markers must be left alone")
+
+	_, err = tenantDataRepo.DeleteByTenant(ctx, other)
+	require.NoError(t, err)
+}

--- a/tests/enrichment_failures_test.go
+++ b/tests/enrichment_failures_test.go
@@ -20,9 +20,12 @@ import (
 // with the record's. Nothing in production can produce that — the worker reads the tenant off the
 // record — but the tests below need it to tell the two candidate tenant boundaries apart, and a
 // fixture no code path can produce is exactly what proves the boundary is not the stamp.
+//
+// Takes the record id rather than the record so the purge tests, which seed through the taxonomy
+// helpers and hold only ids, use the same fixture as the counting tests.
 func insertFailureMarker(
 	t *testing.T, db *pgxpool.Pool,
-	record *models.FeedbackRecord, stampedTenant, enrichment string, terminal bool, reason string,
+	recordID uuid.UUID, stampedTenant, enrichment string, terminal bool, reason string,
 ) {
 	t.Helper()
 
@@ -30,7 +33,7 @@ func insertFailureMarker(
 		INSERT INTO feedback_record_enrichment_failures
 			(feedback_record_id, enrichment, tenant_id, terminal, reason)
 		VALUES ($1, $2, $3, $4, $5)`,
-		record.ID, enrichment, stampedTenant, terminal, reason)
+		recordID, enrichment, stampedTenant, terminal, reason)
 	require.NoError(t, err)
 }
 
@@ -65,10 +68,10 @@ func TestEnrichmentFailuresPurgedWithTenant(t *testing.T) {
 	// One of each kind, so a cascade that somehow only caught one shape would still fail. The
 	// third is stamped with a tenant that is not its record's: it must be purged all the same,
 	// because what removes it is the record it hangs off, not the stamp.
-	insertFailureMarker(t, db, doomed, tenant, "sentiment", true, "content_filter")
-	insertFailureMarker(t, db, doomed, tenant, "emotions", false, "provider_error")
-	insertFailureMarker(t, db, doomed, "not-this-tenant-"+uuid.NewString(), "translation", false, "provider_error")
-	insertFailureMarker(t, db, survivor, other, "sentiment", true, "refusal")
+	insertFailureMarker(t, db, doomed.ID, tenant, "sentiment", true, "content_filter")
+	insertFailureMarker(t, db, doomed.ID, tenant, "emotions", false, "provider_error")
+	insertFailureMarker(t, db, doomed.ID, "not-this-tenant-"+uuid.NewString(), "translation", false, "provider_error")
+	insertFailureMarker(t, db, survivor.ID, other, "sentiment", true, "refusal")
 
 	// Counted two ways, because a survivor can hide from either one alone. Joining to the record
 	// misses an ORPHAN — a marker left behind by a dropped foreign key has no record to join to —
@@ -155,7 +158,7 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 
 	mark := func(record *models.FeedbackRecord, enrichment string, terminal bool, reason string) {
 		t.Helper()
-		insertFailureMarker(t, db, record, tenant, enrichment, terminal, reason)
+		insertFailureMarker(t, db, record.ID, tenant, enrichment, terminal, reason)
 	}
 
 	transient := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "transient failure")
@@ -183,7 +186,7 @@ func TestCountEnrichmentStatusCountsFailures(t *testing.T) {
 	// optimization the migration warns about — and this record silently disappears from the tenant
 	// that actually owns it, while every other assertion here still passes.
 	misstamped := seedEnrichmentRecord(t, frepo, tenant, models.FieldTypeText, "marker stamped with the wrong tenant")
-	insertFailureMarker(t, db, misstamped, "wrong-stamp-"+uuid.NewString(), "sentiment", false, "provider_error")
+	insertFailureMarker(t, db, misstamped.ID, "wrong-stamp-"+uuid.NewString(), "sentiment", false, "provider_error")
 
 	counts, err := statusRepo.CountEnrichmentStatus(ctx, tenant, "")
 	require.NoError(t, err)

--- a/tests/feedback_emotions_test.go
+++ b/tests/feedback_emotions_test.go
@@ -130,7 +130,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{
 			Labels: []models.EmotionValue{models.EmotionJoy, models.EmotionFear},
 		}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -148,7 +148,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetEmotions(ctx, rec.ID, []models.EmotionValue{models.EmotionAnger}, nil))
 
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: nil}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -164,7 +164,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetEmotions(ctx, rec.ID, []models.EmotionValue{models.EmotionSadness}, nil))
 
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -176,7 +176,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 
 	t.Run("worker skips a record gone before classify", func(t *testing.T) {
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(uuid.Must(uuid.NewV7()))))
 		assert.Equal(t, 0, fake.calls, "a gone record is not classified")

--- a/tests/feedback_emotions_test.go
+++ b/tests/feedback_emotions_test.go
@@ -130,7 +130,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{
 			Labels: []models.EmotionValue{models.EmotionJoy, models.EmotionFear},
 		}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -148,7 +148,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetEmotions(ctx, rec.ID, []models.EmotionValue{models.EmotionAnger}, nil))
 
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: nil}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -164,7 +164,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetEmotions(ctx, rec.ID, []models.EmotionValue{models.EmotionSadness}, nil))
 
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(rec.ID)))
 
@@ -176,7 +176,7 @@ func TestFeedbackEmotions_WorkerPipeline(t *testing.T) {
 
 	t.Run("worker skips a record gone before classify", func(t *testing.T) {
 		fake := &fakeEmotionsClient{result: service.EmotionsResult{Labels: []models.EmotionValue{models.EmotionJoy}}}
-		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackEmotionsWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, emotionsWorkerJob(uuid.Must(uuid.NewV7()))))
 		assert.Equal(t, 0, fake.calls, "a gone record is not classified")

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -97,6 +97,14 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 	ids := seedTaxonomyGraph(ctx, t, db, scope)
 	seedPurgeEmbedding(ctx, t, db, ids.FeedbackRecordID)
 
+	// Enrichment failure markers (migration 022). Unlike embeddings and cluster memberships these
+	// are NOT deleted explicitly — they rely on ON DELETE CASCADE — so this purge is the one place
+	// that can prove the cascade fires. One of the two is stamped with a tenant that is not its
+	// record's, because what removes a marker is the record it hangs off, never the stamp.
+	insertFailureMarker(t, db, ids.FeedbackRecordID, tenantID, "sentiment", true, "content_filter")
+	insertFailureMarker(t, db, ids.FeedbackRecordID,
+		"not-this-tenant-"+uuid.NewString(), "emotions", false, "provider_error")
+
 	// A second tenant with its own graph, to prove the purge does not reach across the boundary.
 	otherScope := models.TaxonomyScope{
 		TenantID:   otherTenantID,
@@ -106,6 +114,7 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 	}
 	otherIDs := seedTaxonomyGraph(ctx, t, db, otherScope)
 	seedPurgeEmbedding(ctx, t, db, otherIDs.FeedbackRecordID)
+	insertFailureMarker(t, db, otherIDs.FeedbackRecordID, otherTenantID, "sentiment", true, "refusal")
 
 	// Tenant configuration that must outlive the purge.
 	_, err := db.Exec(ctx, `
@@ -139,6 +148,21 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 			`SELECT count(*) FROM embeddings WHERE feedback_record_id = $1`, ids.FeedbackRecordID))
 		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, tenantID))
+	})
+
+	// The failure markers carry a tenant_id, so one surviving its records is tenant-scoped data
+	// left behind — a retention problem rather than untidiness. They are the only derived table
+	// this purge leaves to ON DELETE CASCADE, and a cascade reports nothing, so it is invisible
+	// unless something looks. Counted by record and as orphans: drop the foreign key and the rows
+	// survive with no record to join to, which the by-record count alone would read as success.
+	t.Run("removes the enrichment failure markers by cascade", func(t *testing.T) {
+		assert.Zero(t, countRows(ctx, t, db,
+			`SELECT count(*) FROM feedback_record_enrichment_failures WHERE feedback_record_id = $1`,
+			ids.FeedbackRecordID))
+		assert.Zero(t, countRows(ctx, t, db, `
+			SELECT count(*) FROM feedback_record_enrichment_failures f
+			LEFT JOIN feedback_records fr ON fr.id = f.feedback_record_id
+			WHERE fr.id IS NULL`))
 	})
 
 	// The taxonomy goes with the records it describes. Keeping it would leave a tree the dashboard
@@ -179,6 +203,9 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 			`SELECT count(*) FROM taxonomy_runs WHERE id = $1`, otherIDs.RunID))
 		assert.Equal(t, 3, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_nodes WHERE run_id = $1`, otherIDs.RunID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM feedback_record_enrichment_failures WHERE feedback_record_id = $1`,
+			otherIDs.FeedbackRecordID))
 	})
 
 	t.Run("is idempotent", func(t *testing.T) {

--- a/tests/feedback_sentiment_test.go
+++ b/tests/feedback_sentiment_test.go
@@ -131,7 +131,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 	t.Run("classifies and persists", func(t *testing.T) {
 		rec := createText("Great product")
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 0.5}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, sentimentWorkerJob(rec.ID)))
 
@@ -153,7 +153,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetSentiment(ctx, rec.ID, &label, &score, nil))
 
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, sentimentWorkerJob(rec.ID)))
 
@@ -166,7 +166,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 
 	t.Run("worker skips a record gone before classify", func(t *testing.T) {
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
 
 		// A job for a nonexistent record: GetFeedbackRecord returns NotFound end to end
 		// (service -> repo -> DB), which the worker treats as a benign skip — no error, no

--- a/tests/feedback_sentiment_test.go
+++ b/tests/feedback_sentiment_test.go
@@ -131,7 +131,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 	t.Run("classifies and persists", func(t *testing.T) {
 		rec := createText("Great product")
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 0.5}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, sentimentWorkerJob(rec.ID)))
 
@@ -153,7 +153,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 		require.NoError(t, svc.SetSentiment(ctx, rec.ID, &label, &score, nil))
 
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, sentimentWorkerJob(rec.ID)))
 
@@ -166,7 +166,7 @@ func TestFeedbackSentiment_WorkerPipeline(t *testing.T) {
 
 	t.Run("worker skips a record gone before classify", func(t *testing.T) {
 		fake := &fakeSentimentClient{result: service.SentimentResult{Label: models.SentimentPositive, Score: 1}}
-		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil)
+		worker := workers.NewFeedbackSentimentWorker(svc, settingsSvc, fake, nil, nil, nil)
 
 		// A job for a nonexistent record: GetFeedbackRecord returns NotFound end to end
 		// (service -> repo -> DB), which the worker treats as a benign skip — no error, no

--- a/tests/feedback_translation_test.go
+++ b/tests/feedback_translation_test.go
@@ -409,7 +409,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("translates and persists", func(t *testing.T) {
 		rec := createText("Bonjour le monde", "fr", "en-US")
 		fake := &fakeTranslationClient{out: "Hello world"}
-		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-US")))
 
@@ -427,7 +427,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("copies when source matches target without calling the provider", func(t *testing.T) {
 		rec := createText("Hello world", "en-US", "en-GB")
 		fake := &fakeTranslationClient{out: "should-not-be-used"}
-		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-GB")))
 
@@ -443,7 +443,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 		stale := "stale translation"
 		require.NoError(t, repo.SetTranslation(ctx, rec.ID, &stale, "en-US", "", nil))
 
-		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "unused"}, nil, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "unused"}, nil, nil, nil)
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-US")))
 
 		got, getErr := repo.GetByID(ctx, rec.ID)
@@ -455,7 +455,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("stale-target write is superseded without persisting", func(t *testing.T) {
 		rec := createText("Hallo Welt", "de", "de-DE") // tenant's current target is de-DE
 
-		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "Bonjour le monde"}, nil, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "Bonjour le monde"}, nil, nil, nil)
 
 		// The job's target (fr-FR) no longer matches the tenant's current target (de-DE) — an
 		// older job or a stale-cache enqueue. The write must no-op and the job must complete

--- a/tests/feedback_translation_test.go
+++ b/tests/feedback_translation_test.go
@@ -409,7 +409,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("translates and persists", func(t *testing.T) {
 		rec := createText("Bonjour le monde", "fr", "en-US")
 		fake := &fakeTranslationClient{out: "Hello world"}
-		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-US")))
 
@@ -427,7 +427,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("copies when source matches target without calling the provider", func(t *testing.T) {
 		rec := createText("Hello world", "en-US", "en-GB")
 		fake := &fakeTranslationClient{out: "should-not-be-used"}
-		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, fake, nil, nil)
 
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-GB")))
 
@@ -443,7 +443,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 		stale := "stale translation"
 		require.NoError(t, repo.SetTranslation(ctx, rec.ID, &stale, "en-US", "", nil))
 
-		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "unused"}, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "unused"}, nil, nil)
 		require.NoError(t, worker.Work(ctx, translationWorkerJob(rec.ID, "en-US")))
 
 		got, getErr := repo.GetByID(ctx, rec.ID)
@@ -455,7 +455,7 @@ func TestFeedbackTranslation_WorkerPipeline(t *testing.T) {
 	t.Run("stale-target write is superseded without persisting", func(t *testing.T) {
 		rec := createText("Hallo Welt", "de", "de-DE") // tenant's current target is de-DE
 
-		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "Bonjour le monde"}, nil)
+		worker := workers.NewFeedbackTranslationWorker(svc, &fakeTranslationClient{out: "Bonjour le monde"}, nil, nil)
 
 		// The job's target (fr-FR) no longer matches the tenant's current target (de-DE) — an
 		// older job or a stale-cache enqueue. The write must no-op and the job must complete


### PR DESCRIPTION
## What does this PR do?

`GET /v1/enrichment-status` returned `{enabled, eligible, done}`, and the consumer derived "in progress" as `eligible - done`. That number quietly merges three unrelated populations: work that is genuinely queued, records that failed permanently, and records that were never enqueued at all. Dhru's repro on ENG-2375 is the third one — create a record with AI credentials unset, set them, create a second record, and the UI reports 1 of 2 with the first row spinning forever.

This PR makes the difference reportable. It does **not** yet make it self-correcting — the reconciler and the retry endpoint are ENG-2376, stacked on top of this.

**Phase 1 fields.** `as_of` (when the counts were taken, so a polling client can derive throughput and an ETA without us computing either) and `disabled_reason` — `not_configured` / `switched_off` / `no_target_language`. The service already evaluated those three gates separately and then collapsed them into one bool; `enabled: false` on its own is unactionable, since an operator who never configured a provider and a tenant who turned the enrichment off need completely different fixes.

**A terminal-vs-transient taxonomy.** `huberrors.TerminalProviderError` with a closed reason set (`content_filter`, `refusal`, `length`, `recitation`). Both provider clients already detected these and threw the distinction away. Two bugs fell out of building it:

- a `length` finish reason was being read *after* the content, so a truncated translation was stored as a finished one and a truncated JSON body read as a transient parse glitch. It is permanent for that text at that model, and it is now checked before the content is touched.
- `resp.Candidates[0]` in the Gemini path panics on `"candidates": [null]` — the SDK's own `Text()` has the same gap (it guards the slice length and a nil `Content`, but not a nil candidate).

**Durable failure state** — migration `022`, `feedback_record_enrichment_failures`, one row per (record, enrichment) with whether retrying could ever help. It has to be durable because River reaps discarded jobs (7d default; we override only `CompletedJobRetentionPeriod`), so a queue-derived failure count silently drains to zero. Rows are **advisory**: `failed` is reported as "a row exists AND the record is still un-enriched", so a later success needs no cleanup write and the enrichment hot path stays free of bookkeeping. `reason` is a bounded enum, never the provider's error string — refusal text is model-generated but routinely paraphrases the input, so storing it would put paraphrased customer feedback at rest and then into the API.

**The counts** — `failed` and `failed_terminal`, from the same scan the endpoint already did (three PK-lookup joins, no second query). The failure joins are deliberately kept off the cross-tenant aggregate, which is the one documented full-table scan and does not read those columns.

**Cost metrics**, per the OTel GenAI semantic conventions: `gen_ai.client.token.usage` and `gen_ai.client.operation.duration`. Both clients were decoding the `usage` block every provider returns and dropping it, so there was no way to answer what enrichment costs. Plus `hub_enrichment_terminal_total{enrichment,reason}` and `hub_enrichment_failed_records{enrichment,terminal}`. `tenant_id` is deliberately absent from all of them, and GenAI *content* attributes are prohibited in code and pinned by a test — `gen_ai.input.messages` carries the prompt, which is customer feedback text.

A terminal failure now returns `river.JobCancel` rather than burning the remaining attempts, which is worth real money: a re-sweep of a permanently-failing corpus costs one provider call per record instead of `MAX_ATTEMPTS` (measured below).

**Measured, because the failure columns are not free.** The three marker joins originally carried no tenant-side predicate — the tenant boundary must be `feedback_records.tenant_id`, never the denormalized stamp — which left the planner nothing to filter the marker table by, so it hash-joined the whole thing three times. On 1M records with 300k markers, a tenant holding 2,500 records and *no failures of its own* went from 3ms to 42ms, scaling with the **global** marker count rather than its own (7ms at 10k markers, 18ms at 100k, 32ms at 300k). One tenant's provider outage taxing everyone else's status endpoint, on something the UI polls every five seconds per open page.

Each join now also keys on the marker's `tenant_id`, which restores `idx_enrichment_failures_tenant_enrichment` and puts that query back to 3.9ms — the plan switches from three sequential scans to three index scans. **Additional, not instead of:** `fr.tenant_id` stays in the outer WHERE and stays the boundary, and a join predicate can only narrow which marker attaches to a record, so it cannot reach another tenant's row. The trade is that a marker whose stamp disagreed with its record would stop counting; nothing can produce one, and under-counting is the safe direction. The fixture that covered it now asserts the half that matters — the stamped tenant, owning no record, sees nothing.

The two leader-tick aggregates were measured too and are fine: the backlog scan 380–450ms and the new `CountFailedRecordsAggregate` 118–135ms, both every five minutes on one replica under a statement timeout.

Rebased onto `main` after #122 landed. The records-scoped purge it added removes these markers by `ON DELETE CASCADE` — that is the only derived table it leaves to a cascade, and a cascade reports no row count, so nothing would notice if it stopped firing. There is now a test for it.

Linear: https://linear.app/formbricks/issue/ENG-2375/extend-status-endpoint-with-more-info
Follow-up (stacked on this): https://linear.app/formbricks/issue/ENG-2376/auto-re-queue-failed-jobs

### API change

```
GET /v1/enrichment-status?tenant_id=t1
```
```json
{
  "tenant_id": "t1",
  "as_of": "2026-08-19T16:17:24Z",
  "translation": { "enabled": true,  "eligible": 2000, "done": 1852, "failed": 0, "failed_terminal": 148 },
  "sentiment":   { "enabled": true,  "eligible": 2000, "done": 1830, "failed": 3, "failed_terminal": 167 },
  "emotions":    { "enabled": false, "disabled_reason": "switched_off", "eligible": 0, "done": 0, "failed": 0, "failed_terminal": 0 }
}
```

`enabled` is unchanged and still means what it did. `disabled_reason` is present exactly when `enabled` is false — the two are derived from one decision, so they cannot contradict each other. A disabled enrichment reports zeroes for everything, failures included: the API must not show a backlog of failed work for a pipeline that will never run.

## How should this be tested?

⚠️ **If you ran `goose up` on this branch before `e2b2f83`, recreate your database.** Migration `022`'s CHECK gained a `write_failed` reason after the file had already been applied, and goose tracks by version, so `goose up` is a no-op and your constraint is the old one. `dropdb && createdb && goose up`, or re-apply the two `ALTER TABLE ... reason_valid` statements by hand.

**The suites** (`DATABASE_URL` pointing at a fresh database with pgvector, `goose up`, `river migrate-up`):

```
make build
make lint
go test ./internal/... ./cmd/...     # 16 packages
make tests                            # integration, real Postgres
make lint-openapi
make migrate-validate
```

**The interesting bits are the fault injections**, since a green suite proves very little on its own. Each of these should turn the suite red, and does:

- gate the failure counts on the markers' own `tenant_id` instead of the record's (the "optimization" migration 022 warns about) → `TestCountEnrichmentStatusCountsFailures`
- drop the marker table's foreign key → `TestEnrichmentFailuresPurgedWithTenant` and `TestPurgeFeedbackRecordsByTenant`
- drop either CHECK constraint → `TestEnrichmentFailureMarkerConstraints`
- add a `tenant_id` or `gen_ai.input.messages` attribute to any metric → `TestGenAIMetricsCarryOnlyAllowedAttributes`
- remove the marker write from the persist path → `TestFeedbackSentimentWorker_WriteFailureRecordsMarker`

**End to end.** I ran the whole thing against a synthetic OpenAI-compatible provider that injects a configurable mix of 429s, 500s, refusals, content-filter blocks and truncations — 3200 records across five tenants, ~14k provider calls, 916 assertions, 0 failures:

- the API's counts agree with an **independent** SQL computation (not the query under test) for every tenant and enrichment
- `eligible = done + failed + failed_terminal` closes exactly, with nothing stranded, and `done + failed + failed_terminal` never went backwards across ~90 live samples taken while work was in flight
- all three terminal reasons came through the real classification path — refusal 359, content_filter 239, length 235 — and 747 of 841 terminal give-ups happened on the first call
- re-sweeping 677 permanently-failing records cost **exactly 677 provider calls**, not 3×; for contrast a total outage over 200 records spent 1803 (200 × 3 enrichments × 3 attempts) and then recovered to zero failures with every marker still in the table, unread
- every stored translation was the provider's complete output — the truncation fix, asserted end to end
- 500,808 input / 143,088 output tokens recorded, and no tenant id, feedback text, or unbounded value on any exported metric label

**What is not covered**, so you know where to push back: the smoke run used `MAX_CONCURRENT=25` per pipeline — 75 concurrent jobs — in a single `hub-worker` against a single `hub-api`. Two live API replicas competing for leadership was never exercised end to end, which is exactly what the backlog/failed-records poller's leader election and its withdraw-on-handover behaviour exist for. Only the unit test covers withdrawal, in isolation.

**By hand**, if you want Dhru's original repro: create a record with `SENTIMENT_PROVIDER`/`SENTIMENT_MODEL` unset, set them, create a second record, and hit the endpoint. Before this PR the first record is invisible in `eligible - done`; now the tenant reads `not_configured` while it is off, and the stranded record shows up as neither done nor failed — which is honest, and is what ENG-2376 then drains.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate`

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary
- [ ] Ran `make tests-coverage` for meaningful logic changes
