### PR TITLE
fix(taxonomy): harden run persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,11 +56,9 @@ LOG_LEVEL=info
 # Stuck-run reaper (only runs when the taxonomy service is configured):
 # TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS: max seconds a pending/running run may go without its updated_at
 #   being bumped (via the internal heartbeat endpoint) before the reaper force-fails it (default
-#   1800 = 30 min). Once the taxonomy service heartbeats during generation, tune this down to a small
-#   multiple of its heartbeat interval. WARNING: until heartbeats flow, updated_at only advances on
-#   state changes, so this MUST exceed the longest legitimate run or healthy generations get reaped.
+#   300 = 5 min, ten times the taxonomy service's default 30-second heartbeat interval).
 # TAXONOMY_REAPER_INTERVAL_SECONDS: seconds between reaper sweeps for stuck runs (default 60).
-# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=1800
+# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=300
 # TAXONOMY_REAPER_INTERVAL_SECONDS=60
 
 # Message publisher: event channel buffer size (optional). Default: 1024

--- a/.env.example
+++ b/.env.example
@@ -56,9 +56,11 @@ LOG_LEVEL=info
 # Stuck-run reaper (only runs when the taxonomy service is configured):
 # TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS: max seconds a pending/running run may go without its updated_at
 #   being bumped (via the internal heartbeat endpoint) before the reaper force-fails it (default
-#   300 = 5 min, ten times the taxonomy service's default 30-second heartbeat interval).
+#   1800 = 30 min, safe for older taxonomy images that do not heartbeat through terminal callbacks).
+#   After deploying a heartbeat-capable image, this may be reduced while retaining several heartbeat
+#   intervals of headroom above the longest expected Hub callback.
 # TAXONOMY_REAPER_INTERVAL_SECONDS: seconds between reaper sweeps for stuck runs (default 60).
-# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=300
+# TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS=1800
 # TAXONOMY_REAPER_INTERVAL_SECONDS=60
 
 # Message publisher: event channel buffer size (optional). Default: 1024

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -867,8 +867,8 @@ func runRiverQueueDepthPoller(ctx context.Context, db *pgxpool.Pool, eventMetric
 	}
 }
 
-// stuckTaxonomyRunMessage is stored on runs the reaper force-fails. The Web maps the internal_error
-// code to a localized, user-facing message; this raw string is for operators (logs / API consumers).
+// stuckTaxonomyRunMessage is stored on runs the reaper force-fails. A stale run is retryable service
+// unavailability, not an internal persistence invariant failure; this raw string is for operators.
 const stuckTaxonomyRunMessage = "taxonomy run timed out without completing"
 
 // runTaxonomyRunReaper periodically fails taxonomy runs orphaned in a non-terminal state — the
@@ -893,13 +893,13 @@ func runTaxonomyRunReaper(
 
 	reap := func() {
 		reaped, err := repo.FailStuckRuns(ctx, timeout, stuckTaxonomyRunMessage,
-			models.TaxonomyRunFailureCodeInternalError)
+			models.TaxonomyRunFailureCodeServiceUnavailable)
 		for _, run := range reaped {
 			slog.ErrorContext(ctx, "taxonomy stuck-run reaper failed stalled run",
 				"event", "hub.taxonomy.run.reaped", "run_id", run.ID, "tenant_id", run.TenantID,
 				"scope_type", run.ScopeType, "source_type", run.SourceType,
 				"source_id", run.SourceID, "field_id", run.FieldID,
-				"failure_code", models.TaxonomyRunFailureCodeInternalError)
+				"failure_code", models.TaxonomyRunFailureCodeServiceUnavailable)
 		}
 
 		if len(reaped) > 0 && metrics != nil {
@@ -907,7 +907,7 @@ func runTaxonomyRunReaper(
 
 			for _, run := range reaped {
 				metrics.RecordRunOutcome(ctx, string(models.TaxonomyRunStatusFailed),
-					string(models.TaxonomyRunFailureCodeInternalError), string(run.ScopeType))
+					string(models.TaxonomyRunFailureCodeServiceUnavailable), string(run.ScopeType))
 
 				started := run.CreatedAt
 				if run.StartedAt != nil {

--- a/internal/api/handlers/taxonomy_internal_handler.go
+++ b/internal/api/handlers/taxonomy_internal_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -9,6 +10,12 @@ import (
 	"github.com/formbricks/hub/internal/api/response"
 	"github.com/formbricks/hub/internal/models"
 )
+
+// maxTaxonomyResultBodyBytes bounds the only internal taxonomy request whose size scales with
+// the selected input. A maximum run has 10,000 memberships plus at most 80 clusters and a bounded
+// hierarchy; 16 MiB leaves ample JSON overhead while preventing an authenticated caller from
+// making Hub decode an unbounded body into memory.
+const maxTaxonomyResultBodyBytes = 16 << 20
 
 // TaxonomyInternalService is the application service used by internal taxonomy endpoints.
 type TaxonomyInternalService interface {
@@ -81,8 +88,17 @@ func (h *TaxonomyInternalHandler) CompleteRun(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxTaxonomyResultBodyBytes)
+
 	var req models.TaxonomyRunResultRequest
 	if err := decodeAndValidateJSON(r, &req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			response.RespondProblem(w, r, http.StatusRequestEntityTooLarge, "request body too large")
+
+			return
+		}
+
 		response.RespondError(w, r, err)
 
 		return

--- a/internal/api/handlers/taxonomy_internal_handler_test.go
+++ b/internal/api/handlers/taxonomy_internal_handler_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/formbricks/hub/internal/models"
+)
+
+type taxonomyInternalHandlerTestService struct {
+	completeCalled bool
+}
+
+func (s *taxonomyInternalHandlerTestService) GetRunInput(
+	context.Context, uuid.UUID,
+) (*models.TaxonomyRunInputResponse, error) {
+	return nil, nil
+}
+
+func (s *taxonomyInternalHandlerTestService) CompleteRun(
+	context.Context, uuid.UUID, models.TaxonomyRunResultRequest,
+) (*models.TaxonomyRun, error) {
+	s.completeCalled = true
+
+	return nil, nil
+}
+
+func (s *taxonomyInternalHandlerTestService) FailRun(
+	context.Context, uuid.UUID, models.TaxonomyRunFailedRequest,
+) (*models.TaxonomyRun, error) {
+	return nil, nil
+}
+
+func (s *taxonomyInternalHandlerTestService) Heartbeat(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func TestTaxonomyInternalHandlerCompleteRunRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	service := &taxonomyInternalHandlerTestService{}
+	handler := NewTaxonomyInternalHandler(service)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/internal/v1/taxonomy/runs/ignored/result",
+		strings.NewReader(strings.Repeat(" ", maxTaxonomyResultBodyBytes+1)))
+	req.SetPathValue("run_id", uuid.NewString())
+
+	recorder := httptest.NewRecorder()
+
+	handler.CompleteRun(recorder, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	assert.False(t, service.completeCalled)
+}

--- a/internal/api/handlers/tenant_data_handler.go
+++ b/internal/api/handlers/tenant_data_handler.go
@@ -40,6 +40,7 @@ func (h *TenantDataHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		DeletedEmbeddings:                 result.DeletedEmbeddings,
 		DeletedWebhooks:                   result.DeletedWebhooks,
 		DeletedTaxonomyRuns:               result.DeletedTaxonomyRuns,
+		DeletedTaxonomyRunInputRecords:    result.DeletedTaxonomyRunInputRecords,
 		DeletedTaxonomyClusters:           result.DeletedTaxonomyClusters,
 		DeletedTaxonomyClusterMemberships: result.DeletedTaxonomyClusterMemberships,
 		DeletedTaxonomyNodes:              result.DeletedTaxonomyNodes,

--- a/internal/api/handlers/tenant_data_handler_test.go
+++ b/internal/api/handlers/tenant_data_handler_test.go
@@ -43,6 +43,7 @@ func TestTenantDataHandler_Delete(t *testing.T) {
 						DeletedEmbeddings:                 2,
 						DeletedWebhooks:                   1,
 						DeletedTaxonomyRuns:               4,
+						DeletedTaxonomyRunInputRecords:    10,
 						DeletedTaxonomyClusters:           5,
 						DeletedTaxonomyClusterMemberships: 6,
 						DeletedTaxonomyNodes:              7,
@@ -71,6 +72,7 @@ func TestTenantDataHandler_Delete(t *testing.T) {
 		assert.Equal(t, int64(2), resp.DeletedEmbeddings)
 		assert.Equal(t, int64(1), resp.DeletedWebhooks)
 		assert.Equal(t, int64(4), resp.DeletedTaxonomyRuns)
+		assert.Equal(t, int64(10), resp.DeletedTaxonomyRunInputRecords)
 		assert.Equal(t, int64(5), resp.DeletedTaxonomyClusters)
 		assert.Equal(t, int64(6), resp.DeletedTaxonomyClusterMemberships)
 		assert.Equal(t, int64(7), resp.DeletedTaxonomyNodes)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,11 +220,11 @@ type TaxonomyConfig struct {
 	EmbeddingModel         string `env:"TAXONOMY_EMBEDDING_MODEL"`
 	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
 	// StuckRunTimeout is the maximum time a pending/running run may go without its updated_at being
-	// bumped (via the internal heartbeat endpoint) before the reaper force-fails it. Once the taxonomy
-	// service heartbeats during generation, this should stay at a small multiple of the heartbeat
-	// interval. The taxonomy service defaults to a 30-second heartbeat, so five minutes tolerates
-	// transient callback/network failures without leaving orphaned runs indefinitely.
-	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"300"`
+	// bumped (via the internal heartbeat endpoint) before the reaper force-fails it. Keep the default
+	// compatible with taxonomy images that do not heartbeat through terminal callbacks; operators may
+	// lower it after deploying a heartbeat-capable image and retaining several heartbeat intervals of
+	// headroom.
+	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"1800"`
 	// ReaperInterval is how often the reaper sweeps for stuck runs.
 	ReaperInterval DurationSec `env:"TAXONOMY_REAPER_INTERVAL_SECONDS" env-default:"60"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,10 +221,10 @@ type TaxonomyConfig struct {
 	MinimumEmbeddedRecords int    `env:"TAXONOMY_MIN_EMBEDDED_RECORDS" env-default:"20"`
 	// StuckRunTimeout is the maximum time a pending/running run may go without its updated_at being
 	// bumped (via the internal heartbeat endpoint) before the reaper force-fails it. Once the taxonomy
-	// service heartbeats during generation this can be tuned down to a small multiple of the heartbeat
-	// interval; until then updated_at only advances on state changes, so keep it above the longest
-	// legitimate run so healthy long-running generations are not reaped.
-	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"1800"`
+	// service heartbeats during generation, this should stay at a small multiple of the heartbeat
+	// interval. The taxonomy service defaults to a 30-second heartbeat, so five minutes tolerates
+	// transient callback/network failures without leaving orphaned runs indefinitely.
+	StuckRunTimeout DurationSec `env:"TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS" env-default:"300"`
 	// ReaperInterval is how often the reaper sweeps for stuck runs.
 	ReaperInterval DurationSec `env:"TAXONOMY_REAPER_INTERVAL_SECONDS" env-default:"60"`
 }

--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -1,0 +1,46 @@
+// Package jsonutil contains small helpers for comparing and reading JSON payloads.
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+)
+
+// ObjectString returns a string property from a JSON object, or an empty string
+// when the payload is invalid, is not an object, or the property is not a string.
+func ObjectString(raw json.RawMessage, key string) string {
+	values := make(map[string]any)
+	if err := json.Unmarshal(normalizeEmptyObject(raw), &values); err != nil {
+		return ""
+	}
+
+	value, _ := values[key].(string)
+
+	return value
+}
+
+// CanonicalEqual compares JSON values independent of object-key ordering. Empty
+// and null payloads are normalized to an empty object because JSONB object
+// columns persist an omitted metrics payload as {}.
+func CanonicalEqual(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(normalizeEmptyObject(left), &leftValue) != nil ||
+		json.Unmarshal(normalizeEmptyObject(right), &rightValue) != nil {
+		return false
+	}
+
+	leftRaw, leftErr := json.Marshal(leftValue)
+	rightRaw, rightErr := json.Marshal(rightValue)
+
+	return leftErr == nil && rightErr == nil && slices.Equal(leftRaw, rightRaw)
+}
+
+func normalizeEmptyObject(raw json.RawMessage) json.RawMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return json.RawMessage(`{}`)
+	}
+
+	return raw
+}

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -1,0 +1,46 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCanonicalEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		left, right json.RawMessage
+		want        bool
+	}{
+		{name: "key order", left: json.RawMessage(`{"a":1,"b":2}`), right: json.RawMessage(`{"b":2,"a":1}`), want: true},
+		{name: "empty and object", left: nil, right: json.RawMessage(`{}`), want: true},
+		{name: "null and object", left: json.RawMessage(`null`), right: json.RawMessage(`{}`), want: true},
+		{name: "different values", left: json.RawMessage(`{"a":1}`), right: json.RawMessage(`{"a":2}`), want: false},
+		{name: "invalid value", left: json.RawMessage(`{`), right: json.RawMessage(`{}`), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := CanonicalEqual(test.left, test.right); got != test.want {
+				t.Fatalf("CanonicalEqual(%q, %q) = %v, want %v", test.left, test.right, got, test.want)
+			}
+		})
+	}
+}
+
+func TestObjectString(t *testing.T) {
+	t.Parallel()
+
+	if got := ObjectString(json.RawMessage(`{"result_digest":"sha256:abc"}`), "result_digest"); got != "sha256:abc" {
+		t.Fatalf("ObjectString() = %q, want %q", got, "sha256:abc")
+	}
+
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`), json.RawMessage(`{`), json.RawMessage(`{"result_digest":1}`)} {
+		if got := ObjectString(raw, "result_digest"); got != "" {
+			t.Fatalf("ObjectString(%q) = %q, want empty", raw, got)
+		}
+	}
+}

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -94,26 +94,31 @@ type TaxonomyFieldsResponse struct {
 
 // TaxonomyRun is a persisted taxonomy generation run.
 type TaxonomyRun struct {
-	ID             uuid.UUID               `json:"id"`
-	ScopeType      TaxonomyScopeType       `json:"scope_type"`
-	TenantID       string                  `json:"tenant_id"`
-	SourceType     string                  `json:"source_type"`
-	SourceID       string                  `json:"source_id"`
-	FieldID        string                  `json:"field_id"`
-	FieldLabel     *string                 `json:"field_label,omitempty"`
-	Status         TaxonomyRunStatus       `json:"status"`
-	Params         json.RawMessage         `json:"params,omitempty"`
-	Metrics        json.RawMessage         `json:"metrics,omitempty"`
-	RecordCount    int                     `json:"record_count"`
-	EmbeddingCount int                     `json:"embedding_count"`
-	ClusterCount   int                     `json:"cluster_count"`
-	NodeCount      int                     `json:"node_count"`
-	Error          *string                 `json:"error,omitempty"`
-	ErrorCode      *TaxonomyRunFailureCode `json:"error_code,omitempty"`
-	StartedAt      *time.Time              `json:"started_at,omitempty"`
-	FinishedAt     *time.Time              `json:"finished_at,omitempty"`
-	CreatedAt      time.Time               `json:"created_at"`
-	UpdatedAt      time.Time               `json:"updated_at"`
+	ID                 uuid.UUID               `json:"id"`
+	ScopeType          TaxonomyScopeType       `json:"scope_type"`
+	TenantID           string                  `json:"tenant_id"`
+	SourceType         string                  `json:"source_type"`
+	SourceID           string                  `json:"source_id"`
+	FieldID            string                  `json:"field_id"`
+	FieldLabel         *string                 `json:"field_label,omitempty"`
+	Status             TaxonomyRunStatus       `json:"status"`
+	Params             json.RawMessage         `json:"params,omitempty"`
+	Metrics            json.RawMessage         `json:"metrics,omitempty"`
+	RecordCount        int                     `json:"record_count"`
+	EmbeddingCount     int                     `json:"embedding_count"`
+	EligibleCount      int                     `json:"eligible_count,omitempty"`
+	SelectedCount      int                     `json:"selected_count,omitempty"`
+	SelectionCap       int                     `json:"selection_cap,omitempty"`
+	SelectionTruncated bool                    `json:"selection_truncated,omitempty"`
+	SelectionStrategy  string                  `json:"selection_strategy,omitempty"`
+	ClusterCount       int                     `json:"cluster_count"`
+	NodeCount          int                     `json:"node_count"`
+	Error              *string                 `json:"error,omitempty"`
+	ErrorCode          *TaxonomyRunFailureCode `json:"error_code,omitempty"`
+	StartedAt          *time.Time              `json:"started_at,omitempty"`
+	FinishedAt         *time.Time              `json:"finished_at,omitempty"`
+	CreatedAt          time.Time               `json:"created_at"`
+	UpdatedAt          time.Time               `json:"updated_at"`
 }
 
 // CreateTaxonomyRunRequest starts a manual taxonomy generation run.
@@ -259,18 +264,39 @@ type TaxonomyRunFailedRequest struct {
 // TaxonomyRunFailureDiagnostics contains bounded, non-sensitive compute diagnostics. It is stored
 // inside the existing metrics JSON column, keeping the database and public API schema unchanged.
 type TaxonomyRunFailureDiagnostics struct {
-	Phase              string             `json:"phase,omitempty"                   validate:"omitempty,oneof=input_fetch input_validation clustering evidence_selection cluster_labeling taxonomy_generation payload_validation persistence unknown"`                                                        //nolint:lll
-	FailureReason      string             `json:"failure_reason,omitempty"          validate:"omitempty,oneof=provider_authentication provider_rate_limit provider_timeout provider_unavailable provider_response invalid_output validation_failed insufficient_data hub_unavailable internal_error unknown"` //nolint:lll
-	Provider           string             `json:"provider,omitempty"                validate:"omitempty,oneof=openai bedrock vertex unknown"`
-	Model              string             `json:"model,omitempty"                   validate:"omitempty,no_null_bytes,max=255"`
-	ProviderAdapter    string             `json:"provider_adapter,omitempty"        validate:"omitempty,no_null_bytes,max=100"`
-	AdapterVersion     string             `json:"adapter_version,omitempty"         validate:"omitempty,no_null_bytes,max=100"`
-	ProviderSDKVersion string             `json:"provider_sdk_version,omitempty"    validate:"omitempty,no_null_bytes,max=100"`
-	LLMAttempts        *int               `json:"llm_attempts,omitempty"            validate:"omitempty,min=0,max=1000"`
-	InputTokens        *int64             `json:"input_tokens,omitempty"            validate:"omitempty,min=0"`
-	OutputTokens       *int64             `json:"output_tokens,omitempty"           validate:"omitempty,min=0"`
-	TotalTokens        *int64             `json:"total_tokens,omitempty"            validate:"omitempty,min=0"`
-	PhaseDurations     map[string]float64 `json:"phase_durations_seconds,omitempty" validate:"omitempty,max=8,dive,keys,oneof=input_fetch input_validation clustering evidence_selection cluster_labeling taxonomy_generation payload_validation persistence,endkeys,gte=0"` //nolint:lll
+	Phase              string                     `json:"phase,omitempty"                   validate:"omitempty,oneof=input_fetch input_validation clustering evidence_selection cluster_labeling taxonomy_generation payload_validation persistence unknown"`                                                                                                                                                                                                                                       //nolint:lll
+	FailureReason      string                     `json:"failure_reason,omitempty"          validate:"omitempty,oneof=provider_authentication provider_permission provider_rate_limit provider_timeout provider_unavailable provider_invalid_request provider_response unsupported_schema context_exhaustion truncation refusal safety_block malformed_response invalid_output validation_failed run_deadline_exceeded internal_invariant insufficient_data hub_unavailable internal_error unknown"` //nolint:lll
+	GenerationStep     string                     `json:"generation_step,omitempty"         validate:"omitempty,oneof=labeling branch_plan cluster_assignment hierarchy_plan assembly payload persistence none"`                                                                                                                                                                                                                                                                                     //nolint:lll
+	ValidationReason   string                     `json:"validation_reason,omitempty"       validate:"omitempty,oneof=invalid_json_or_shape missing_key duplicate_key unknown_key invalid_depth coverage_mismatch duplicate_label non_english_label truncation context_exhaustion refusal internal_invariant invalid_semantics none"`                                                                                                                                                                //nolint:lll
+	RecoveryAction     string                     `json:"recovery_action,omitempty"         validate:"omitempty,oneof=none provider_retry semantic_retry clustering_fallback label_fallback post_processing_rollback"`                                                                                                                                                                                                                                                                               //nolint:lll
+	Provider           string                     `json:"provider,omitempty"                validate:"omitempty,oneof=openai bedrock vertex unknown"`                                                                                                                                                                                                                                                                                                                                                //nolint:lll
+	Model              string                     `json:"model,omitempty"                   validate:"omitempty,no_null_bytes,max=255"`
+	ProviderAdapter    string                     `json:"provider_adapter,omitempty"        validate:"omitempty,no_null_bytes,max=100"`
+	AdapterVersion     string                     `json:"adapter_version,omitempty"         validate:"omitempty,no_null_bytes,max=100"`
+	ProviderSDKVersion string                     `json:"provider_sdk_version,omitempty"    validate:"omitempty,no_null_bytes,max=100"`
+	LLMAttempts        *int                       `json:"llm_attempts,omitempty"            validate:"omitempty,min=0,max=1000"`
+	InputTokens        *int64                     `json:"input_tokens,omitempty"            validate:"omitempty,min=0"`
+	OutputTokens       *int64                     `json:"output_tokens,omitempty"           validate:"omitempty,min=0"`
+	TotalTokens        *int64                     `json:"total_tokens,omitempty"            validate:"omitempty,min=0"`
+	PhaseDurations     map[string]float64         `json:"phase_durations_seconds,omitempty" validate:"omitempty,max=8,dive,keys,oneof=input_fetch input_validation clustering evidence_selection cluster_labeling taxonomy_generation payload_validation persistence,endkeys,gte=0"` //nolint:lll
+	PartialMetrics     *TaxonomyRunPartialMetrics `json:"partial_metrics,omitempty"         validate:"omitempty"`
+}
+
+// TaxonomyRunPartialMetrics preserves bounded progress when generation fails before a complete
+// result can be persisted. It contains counts and booleans only; no labels, feedback, or identifiers.
+type TaxonomyRunPartialMetrics struct {
+	SelectedRecordCount    int   `json:"selected_record_count,omitempty"    validate:"omitempty,min=0,max=10000"`
+	ClusterCount           int   `json:"cluster_count,omitempty"            validate:"omitempty,min=0,max=1000"`
+	MembershipCount        int   `json:"membership_count,omitempty"         validate:"omitempty,min=0,max=10000"`
+	ClusteringFallbackUsed *bool `json:"clustering_fallback_used,omitempty" validate:"omitempty"`
+	ClusterCapActivated    *bool `json:"cluster_cap_activated,omitempty"    validate:"omitempty"`
+	ClusterCapMergeCount   int   `json:"cluster_cap_merge_count,omitempty"  validate:"omitempty,min=0,max=1000"`
+	PostProcessingFailed   *bool `json:"post_processing_failed,omitempty"   validate:"omitempty"`
+	LabelFallbackCount     int   `json:"label_fallback_count,omitempty"     validate:"omitempty,min=0,max=1000"`
+	NodeCount              int   `json:"node_count,omitempty"               validate:"omitempty,min=0,max=100000"`
+	BranchCount            int   `json:"branch_count,omitempty"             validate:"omitempty,min=0,max=100000"`
+	LeafCount              int   `json:"leaf_count,omitempty"               validate:"omitempty,min=0,max=1000"`
+	DepthValid             *bool `json:"depth_valid,omitempty"              validate:"omitempty"`
 }
 
 // RenameTaxonomyNodeRequest renames a generated taxonomy node.

--- a/internal/models/taxonomy.go
+++ b/internal/models/taxonomy.go
@@ -94,31 +94,35 @@ type TaxonomyFieldsResponse struct {
 
 // TaxonomyRun is a persisted taxonomy generation run.
 type TaxonomyRun struct {
-	ID                 uuid.UUID               `json:"id"`
-	ScopeType          TaxonomyScopeType       `json:"scope_type"`
-	TenantID           string                  `json:"tenant_id"`
-	SourceType         string                  `json:"source_type"`
-	SourceID           string                  `json:"source_id"`
-	FieldID            string                  `json:"field_id"`
-	FieldLabel         *string                 `json:"field_label,omitempty"`
-	Status             TaxonomyRunStatus       `json:"status"`
-	Params             json.RawMessage         `json:"params,omitempty"`
-	Metrics            json.RawMessage         `json:"metrics,omitempty"`
-	RecordCount        int                     `json:"record_count"`
-	EmbeddingCount     int                     `json:"embedding_count"`
-	EligibleCount      int                     `json:"eligible_count,omitempty"`
-	SelectedCount      int                     `json:"selected_count,omitempty"`
-	SelectionCap       int                     `json:"selection_cap,omitempty"`
-	SelectionTruncated bool                    `json:"selection_truncated,omitempty"`
-	SelectionStrategy  string                  `json:"selection_strategy,omitempty"`
-	ClusterCount       int                     `json:"cluster_count"`
-	NodeCount          int                     `json:"node_count"`
-	Error              *string                 `json:"error,omitempty"`
-	ErrorCode          *TaxonomyRunFailureCode `json:"error_code,omitempty"`
-	StartedAt          *time.Time              `json:"started_at,omitempty"`
-	FinishedAt         *time.Time              `json:"finished_at,omitempty"`
-	CreatedAt          time.Time               `json:"created_at"`
-	UpdatedAt          time.Time               `json:"updated_at"`
+	ID             uuid.UUID         `json:"id"`
+	ScopeType      TaxonomyScopeType `json:"scope_type"`
+	TenantID       string            `json:"tenant_id"`
+	SourceType     string            `json:"source_type"`
+	SourceID       string            `json:"source_id"`
+	FieldID        string            `json:"field_id"`
+	FieldLabel     *string           `json:"field_label,omitempty"`
+	Status         TaxonomyRunStatus `json:"status"`
+	Params         json.RawMessage   `json:"params,omitempty"`
+	Metrics        json.RawMessage   `json:"metrics,omitempty"`
+	RecordCount    int               `json:"record_count"`
+	EmbeddingCount int               `json:"embedding_count"`
+	// InputSnapshotMaterialized distinguishes runs whose exact input was frozen by a
+	// snapshot-aware Hub replica from legacy or mixed-rollout runs served by older code.
+	// It is persistence metadata, not part of the public taxonomy run contract.
+	InputSnapshotMaterialized bool                    `json:"-"`
+	EligibleCount             int                     `json:"eligible_count,omitempty"`
+	SelectedCount             int                     `json:"selected_count,omitempty"`
+	SelectionCap              int                     `json:"selection_cap,omitempty"`
+	SelectionTruncated        bool                    `json:"selection_truncated,omitempty"`
+	SelectionStrategy         string                  `json:"selection_strategy,omitempty"`
+	ClusterCount              int                     `json:"cluster_count"`
+	NodeCount                 int                     `json:"node_count"`
+	Error                     *string                 `json:"error,omitempty"`
+	ErrorCode                 *TaxonomyRunFailureCode `json:"error_code,omitempty"`
+	StartedAt                 *time.Time              `json:"started_at,omitempty"`
+	FinishedAt                *time.Time              `json:"finished_at,omitempty"`
+	CreatedAt                 time.Time               `json:"created_at"`
+	UpdatedAt                 time.Time               `json:"updated_at"`
 }
 
 // CreateTaxonomyRunRequest starts a manual taxonomy generation run.

--- a/internal/models/tenant_data.go
+++ b/internal/models/tenant_data.go
@@ -5,6 +5,7 @@ package models
 // the whole taxonomy, so they report the same numbers.
 type TenantTaxonomyDeleteCounts struct {
 	Runs               int64
+	InputRecords       int64
 	Clusters           int64
 	ClusterMemberships int64
 	Nodes              int64
@@ -22,6 +23,7 @@ type TenantDataDeleteCounts struct {
 	// purge (not via feedback-record cascades). Each field is the exact row
 	// count deleted from its taxonomy table for the tenant.
 	DeletedTaxonomyRuns               int64
+	DeletedTaxonomyRunInputRecords    int64
 	DeletedTaxonomyClusters           int64
 	DeletedTaxonomyClusterMemberships int64
 	DeletedTaxonomyNodes              int64
@@ -43,6 +45,7 @@ type TenantDataDeleteResponse struct {
 	DeletedEmbeddings                 int64  `json:"deleted_embeddings"`
 	DeletedWebhooks                   int64  `json:"deleted_webhooks"`
 	DeletedTaxonomyRuns               int64  `json:"deleted_taxonomy_runs"`
+	DeletedTaxonomyRunInputRecords    int64  `json:"deleted_taxonomy_run_input_records"`
 	DeletedTaxonomyClusters           int64  `json:"deleted_taxonomy_clusters"`
 	DeletedTaxonomyClusterMemberships int64  `json:"deleted_taxonomy_cluster_memberships"`
 	DeletedTaxonomyNodes              int64  `json:"deleted_taxonomy_nodes"`

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgvector/pgvector-go"
 
@@ -26,10 +27,11 @@ const (
 )
 
 var (
-	defaultJSONObj                        = json.RawMessage(`{}`)
-	defaultJSONArr                        = json.RawMessage(`[]`)
-	errTaxonomyRunInputSnapshotUnreadable = errors.New("materialized taxonomy run input is no longer readable")
+	defaultJSONObj = json.RawMessage(`{}`)
+	defaultJSONArr = json.RawMessage(`[]`)
 )
+
+const taxonomyRunInputChangedMessage = "a selected feedback record was deleted after taxonomy dispatch"
 
 // TaxonomyRepository stores taxonomy runs, artifacts, and edit events.
 type TaxonomyRepository struct {
@@ -740,10 +742,7 @@ func (r *TaxonomyRepository) GetRunInput(
 		}
 
 		if len(records) != selectedCount {
-			return fmt.Errorf(
-				"%w: selected %d records, loaded %d",
-				errTaxonomyRunInputSnapshotUnreadable, selectedCount, len(records),
-			)
+			return huberrors.NewConflictError(taxonomyRunInputChangedMessage)
 		}
 
 		run.EligibleCount = run.RecordCount
@@ -771,10 +770,12 @@ func (r *TaxonomyRepository) GetRunInputRecordIDs(
 	tenantID string,
 ) ([]uuid.UUID, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT feedback_record_id
-		FROM taxonomy_run_input_records
-		WHERE run_id = $1 AND tenant_id = $2
-		ORDER BY sort_order`, runID, tenantID)
+		SELECT input.feedback_record_id, fr.id IS NOT NULL
+		FROM taxonomy_run_input_records input
+		LEFT JOIN feedback_records fr
+			ON fr.id = input.feedback_record_id AND fr.tenant_id = input.tenant_id
+		WHERE input.run_id = $1 AND input.tenant_id = $2
+		ORDER BY input.sort_order`, runID, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run input record IDs: %w", err)
 	}
@@ -783,9 +784,17 @@ func (r *TaxonomyRepository) GetRunInputRecordIDs(
 	recordIDs := make([]uuid.UUID, 0)
 
 	for rows.Next() {
-		var recordID uuid.UUID
-		if err := rows.Scan(&recordID); err != nil {
+		var (
+			recordID uuid.UUID
+			readable bool
+		)
+
+		if err := rows.Scan(&recordID, &readable); err != nil {
 			return nil, fmt.Errorf("scan taxonomy run input record ID: %w", err)
+		}
+
+		if !readable {
+			return nil, huberrors.NewConflictError(taxonomyRunInputChangedMessage)
 		}
 
 		recordIDs = append(recordIDs, recordID)
@@ -848,6 +857,16 @@ func storeResultAndActivateInTx(
 
 	if run.Status != models.TaxonomyRunStatusRunning {
 		return nil, taxonomyTransitionConflict(run, models.TaxonomyRunStatusSucceeded)
+	}
+
+	// Lock every still-live selected record before inserting memberships. The service's earlier
+	// readability check is intentionally duplicated inside this write transaction: without these
+	// key-share locks a record could be deleted between validation and the membership FK insert,
+	// turning a permanent input change into a retryable 500.
+	if run.InputSnapshotMaterialized {
+		if err := lockReadableTaxonomyRunInput(ctx, transaction, run.ID, run.TenantID); err != nil {
+			return nil, err
+		}
 	}
 
 	clusterIDs, err := insertTaxonomyClustersBulk(ctx, transaction, run.ID, req.Clusters)
@@ -1014,6 +1033,12 @@ func insertTaxonomyMembershipsBulk(
 			run_id uuid, tenant_id text, cluster_id uuid, feedback_record_id uuid,
 			confidence double precision, distance double precision, metadata jsonb
 		)`, string(payload)); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == foreignKeyViolationSQLState &&
+			strings.Contains(pgErr.ConstraintName, "feedback_record_id") {
+			return huberrors.NewConflictError(taxonomyRunInputChangedMessage)
+		}
+
 		return fmt.Errorf("bulk insert taxonomy cluster memberships: %w", err)
 	}
 
@@ -1404,7 +1429,7 @@ func materializeRunInputSnapshot(
 	}
 
 	if alreadyMaterialized {
-		return nil
+		return markRunInputSnapshotMaterialized(ctx, dbTx, run)
 	}
 
 	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
@@ -1432,7 +1457,7 @@ func materializeRunInputSnapshot(
 			return fmt.Errorf("materialize directory taxonomy run input: %w", err)
 		}
 
-		return nil
+		return markRunInputSnapshotMaterialized(ctx, dbTx, run)
 	}
 
 	_, err := dbTx.Exec(ctx, `
@@ -1460,6 +1485,64 @@ func materializeRunInputSnapshot(
 		run.ID, run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel)
 	if err != nil {
 		return fmt.Errorf("materialize field taxonomy run input: %w", err)
+	}
+
+	return markRunInputSnapshotMaterialized(ctx, dbTx, run)
+}
+
+func markRunInputSnapshotMaterialized(ctx context.Context, dbTx tenantWriteTx, run *models.TaxonomyRun) error {
+	if _, err := dbTx.Exec(ctx, `
+		UPDATE taxonomy_runs
+		SET input_snapshot_materialized = true
+		WHERE id = $1 AND tenant_id = $2`, run.ID, run.TenantID); err != nil {
+		return fmt.Errorf("mark taxonomy run input snapshot materialized: %w", err)
+	}
+
+	run.InputSnapshotMaterialized = true
+
+	return nil
+}
+
+func lockReadableTaxonomyRunInput(
+	ctx context.Context,
+	transaction tenantWriteTx,
+	runID uuid.UUID,
+	tenantID string,
+) error {
+	rows, err := transaction.Query(ctx, `
+		SELECT fr.id
+		FROM taxonomy_run_input_records input
+		INNER JOIN feedback_records fr
+			ON fr.id = input.feedback_record_id AND fr.tenant_id = input.tenant_id
+		WHERE input.run_id = $1 AND input.tenant_id = $2
+		FOR KEY SHARE OF fr`, runID, tenantID)
+	if err != nil {
+		return fmt.Errorf("lock taxonomy run input records: %w", err)
+	}
+
+	liveCount := 0
+	for rows.Next() {
+		liveCount++
+	}
+
+	if err := rows.Err(); err != nil {
+		rows.Close()
+
+		return fmt.Errorf("iterate locked taxonomy run input records: %w", err)
+	}
+
+	rows.Close()
+
+	var selectedCount int
+	if err := transaction.QueryRow(ctx, `
+		SELECT COUNT(*)::int
+		FROM taxonomy_run_input_records
+		WHERE run_id = $1 AND tenant_id = $2`, runID, tenantID).Scan(&selectedCount); err != nil {
+		return fmt.Errorf("count locked taxonomy run input records: %w", err)
+	}
+
+	if liveCount != selectedCount {
+		return huberrors.NewConflictError(taxonomyRunInputChangedMessage)
 	}
 
 	return nil
@@ -1581,6 +1664,7 @@ const taxonomyRunSelect = `
 				taxonomy_runs.source_id, taxonomy_runs.field_id, taxonomy_runs.field_label,
 				taxonomy_runs.status, taxonomy_runs.params, taxonomy_runs.metrics,
 				taxonomy_runs.record_count, taxonomy_runs.embedding_count,
+				taxonomy_runs.input_snapshot_materialized,
 			taxonomy_runs.cluster_count, taxonomy_runs.node_count, taxonomy_runs.error, taxonomy_runs.error_code,
 			taxonomy_runs.started_at, taxonomy_runs.finished_at,
 			taxonomy_runs.created_at, taxonomy_runs.updated_at`
@@ -1608,6 +1692,7 @@ func scanTaxonomyRun(row scanner) (*models.TaxonomyRun, error) {
 		&run.Metrics,
 		&run.RecordCount,
 		&run.EmbeddingCount,
+		&run.InputSnapshotMaterialized,
 		&run.ClusterCount,
 		&run.NodeCount,
 		&run.Error,

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -26,8 +26,9 @@ const (
 )
 
 var (
-	defaultJSONObj = json.RawMessage(`{}`)
-	defaultJSONArr = json.RawMessage(`[]`)
+	defaultJSONObj                        = json.RawMessage(`{}`)
+	defaultJSONArr                        = json.RawMessage(`[]`)
+	errTaxonomyRunInputSnapshotUnreadable = errors.New("materialized taxonomy run input is no longer readable")
 )
 
 // TaxonomyRepository stores taxonomy runs, artifacts, and edit events.
@@ -671,60 +672,94 @@ func (r *TaxonomyRepository) GetRunInput(
 	tenantID string,
 	embeddingModel string,
 ) (*models.TaxonomyRunInputResponse, error) {
-	run, err := r.GetRunForTenant(ctx, runID, tenantID)
-	if err != nil {
-		return nil, err
-	}
+	var response *models.TaxonomyRunInputResponse
 
-	limit := run.RecordCount
-	if limit > MaxTaxonomyRunInputRows {
-		slog.Warn("taxonomy run input truncated to the row cap",
-			"run_id", runID, "eligible_count", run.RecordCount,
-			"embedding_count", run.EmbeddingCount, "cap", MaxTaxonomyRunInputRows)
+	err := withTenantWritePoolTx(ctx, r.db, []string{tenantID}, func(dbTx tenantWriteTx) error {
+		run, err := queryTaxonomyRun(ctx, dbTx, taxonomyRunSelect+`
+			FROM taxonomy_runs
+			WHERE id = $1 AND tenant_id = $2
+			FOR UPDATE`, runID, tenantID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+		}
 
-		limit = MaxTaxonomyRunInputRows
-	}
+		if err != nil {
+			return fmt.Errorf("lock taxonomy run for input materialization: %w", err)
+		}
 
-	rows, err := r.queryRunInputRows(ctx, run, limit, embeddingModel)
+		limit := min(run.RecordCount, MaxTaxonomyRunInputRows)
+		if run.RecordCount > MaxTaxonomyRunInputRows {
+			slog.Warn("taxonomy run input truncated to the row cap",
+				"run_id", runID, "eligible_count", run.RecordCount,
+				"embedding_count", run.EmbeddingCount, "cap", MaxTaxonomyRunInputRows)
+		}
+
+		if err := materializeRunInputSnapshot(ctx, dbTx, run, limit, embeddingModel); err != nil {
+			return err
+		}
+
+		var selectedCount int
+		if err := dbTx.QueryRow(ctx, `
+			SELECT COUNT(*)::int
+			FROM taxonomy_run_input_records
+			WHERE run_id = $1 AND tenant_id = $2`, runID, tenantID).Scan(&selectedCount); err != nil {
+			return fmt.Errorf("count materialized taxonomy run input: %w", err)
+		}
+
+		rows, err := queryMaterializedRunInputRows(ctx, dbTx, runID, tenantID, embeddingModel)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		records := make([]models.TaxonomyRunInputRecord, 0, selectedCount)
+
+		for rows.Next() {
+			var (
+				record models.TaxonomyRunInputRecord
+				vec    pgvector.HalfVector
+			)
+			if err := rows.Scan(
+				&record.FeedbackRecordID,
+				&record.SourceType,
+				&record.SourceID,
+				&record.FieldID,
+				&record.FieldLabel,
+				&record.ValueText,
+				&vec,
+			); err != nil {
+				return fmt.Errorf("scan materialized taxonomy run input record: %w", err)
+			}
+
+			record.Embedding = vec.Slice()
+			records = append(records, record)
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate materialized taxonomy run input records: %w", err)
+		}
+
+		if len(records) != selectedCount {
+			return fmt.Errorf(
+				"%w: selected %d records, loaded %d",
+				errTaxonomyRunInputSnapshotUnreadable, selectedCount, len(records),
+			)
+		}
+
+		run.EligibleCount = run.RecordCount
+		run.SelectedCount = selectedCount
+		run.SelectionCap = MaxTaxonomyRunInputRows
+		run.SelectionTruncated = run.RecordCount > selectedCount
+		run.SelectionStrategy = "most_recent"
+		response = &models.TaxonomyRunInputResponse{Run: *run, Records: records}
+
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run input: %w", err)
 	}
-	defer rows.Close()
 
-	records := make([]models.TaxonomyRunInputRecord, 0, limit)
-
-	for rows.Next() {
-		var (
-			record models.TaxonomyRunInputRecord
-			vec    pgvector.HalfVector
-		)
-		if err := rows.Scan(
-			&record.FeedbackRecordID,
-			&record.SourceType,
-			&record.SourceID,
-			&record.FieldID,
-			&record.FieldLabel,
-			&record.ValueText,
-			&vec,
-		); err != nil {
-			return nil, fmt.Errorf("scan taxonomy run input record: %w", err)
-		}
-
-		record.Embedding = vec.Slice()
-		records = append(records, record)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate taxonomy run input records: %w", err)
-	}
-
-	run.EligibleCount = run.RecordCount
-	run.SelectedCount = len(records)
-	run.SelectionCap = MaxTaxonomyRunInputRows
-	run.SelectionTruncated = run.RecordCount > len(records)
-	run.SelectionStrategy = "most_recent"
-
-	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
+	return response, nil
 }
 
 // GetRunInputRecordIDs returns the exact bounded record selection a taxonomy result
@@ -734,22 +769,18 @@ func (r *TaxonomyRepository) GetRunInputRecordIDs(
 	ctx context.Context,
 	runID uuid.UUID,
 	tenantID string,
-	embeddingModel string,
 ) ([]uuid.UUID, error) {
-	run, err := r.GetRunForTenant(ctx, runID, tenantID)
-	if err != nil {
-		return nil, err
-	}
-
-	limit := min(run.RecordCount, MaxTaxonomyRunInputRows)
-
-	rows, err := r.queryRunInputRecordIDs(ctx, run, limit, embeddingModel)
+	rows, err := r.db.Query(ctx, `
+		SELECT feedback_record_id
+		FROM taxonomy_run_input_records
+		WHERE run_id = $1 AND tenant_id = $2
+		ORDER BY sort_order`, runID, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run input record IDs: %w", err)
 	}
 	defer rows.Close()
 
-	recordIDs := make([]uuid.UUID, 0, limit)
+	recordIDs := make([]uuid.UUID, 0)
 
 	for rows.Next() {
 		var recordID uuid.UUID
@@ -1357,38 +1388,91 @@ func (r *TaxonomyRepository) ListNodeRecords(
 	return records, limit, nil
 }
 
-func (r *TaxonomyRepository) queryRunInputRows(
+func materializeRunInputSnapshot(
 	ctx context.Context,
+	dbTx tenantWriteTx,
 	run *models.TaxonomyRun,
 	limit int,
 	embeddingModel string,
-) (pgx.Rows, error) {
-	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
-		rows, err := r.db.Query(ctx, `
-			SELECT
-				fr.id,
-				fr.source_type,
-				COALESCE(NULLIF(btrim(fr.source_id), ''), ''),
-				fr.field_id,
-				COALESCE(fr.field_label, ''),
-				COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')),
-				e.embedding
-			FROM feedback_records fr
-			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
-			WHERE fr.tenant_id = $1
-			  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
-			ORDER BY fr.collected_at DESC, fr.id ASC
-			LIMIT $2`,
-			run.TenantID, limit, embeddingModel,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("query directory taxonomy run input rows: %w", err)
-		}
-
-		return rows, nil
+) error {
+	var alreadyMaterialized bool
+	if err := dbTx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM taxonomy_run_input_records WHERE run_id = $1
+		)`, run.ID).Scan(&alreadyMaterialized); err != nil {
+		return fmt.Errorf("check taxonomy run input snapshot: %w", err)
 	}
 
-	rows, err := r.db.Query(ctx, `
+	if alreadyMaterialized {
+		return nil
+	}
+
+	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
+		_, err := dbTx.Exec(ctx, `
+			INSERT INTO taxonomy_run_input_records (
+				run_id, tenant_id, feedback_record_id, sort_order
+			)
+			SELECT $1, $2, selected.id, selected.sort_order
+			FROM (
+				SELECT
+					fr.id,
+					(ROW_NUMBER() OVER (ORDER BY fr.collected_at DESC, fr.id ASC) - 1)::int AS sort_order
+				FROM feedback_records fr
+				INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $4
+				WHERE fr.tenant_id = $2
+				  AND COALESCE(
+					NULLIF(btrim(fr.value_text_translated), ''),
+					NULLIF(btrim(fr.value_text), '')
+				  ) IS NOT NULL
+				ORDER BY fr.collected_at DESC, fr.id ASC
+				LIMIT $3
+			) selected`,
+			run.ID, run.TenantID, limit, embeddingModel)
+		if err != nil {
+			return fmt.Errorf("materialize directory taxonomy run input: %w", err)
+		}
+
+		return nil
+	}
+
+	_, err := dbTx.Exec(ctx, `
+		INSERT INTO taxonomy_run_input_records (
+			run_id, tenant_id, feedback_record_id, sort_order
+		)
+		SELECT $1, $2, selected.id, selected.sort_order
+		FROM (
+			SELECT
+				fr.id,
+				(ROW_NUMBER() OVER (ORDER BY fr.collected_at DESC, fr.id ASC) - 1)::int AS sort_order
+			FROM feedback_records fr
+			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $7
+			WHERE fr.tenant_id = $2
+			  AND fr.source_type = $3
+			  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($4), '')
+			  AND fr.field_id = $5
+			  AND COALESCE(
+				NULLIF(btrim(fr.value_text_translated), ''),
+				NULLIF(btrim(fr.value_text), '')
+			  ) IS NOT NULL
+			ORDER BY fr.collected_at DESC, fr.id ASC
+			LIMIT $6
+		) selected`,
+		run.ID, run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel)
+	if err != nil {
+		return fmt.Errorf("materialize field taxonomy run input: %w", err)
+	}
+
+	return nil
+}
+
+func queryMaterializedRunInputRows(
+	ctx context.Context,
+	dbTx tenantWriteTx,
+	runID uuid.UUID,
+	tenantID string,
+	embeddingModel string,
+) (pgx.Rows, error) {
+	rows, err := dbTx.Query(ctx, `
 		SELECT
 			fr.id,
 			fr.source_type,
@@ -1397,63 +1481,15 @@ func (r *TaxonomyRepository) queryRunInputRows(
 			COALESCE(fr.field_label, ''),
 			COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')),
 			e.embedding
-		FROM feedback_records fr
-		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
-		WHERE fr.tenant_id = $1
-		  AND fr.source_type = $2
-		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
-		  AND fr.field_id = $4
-		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
-		ORDER BY fr.collected_at DESC, fr.id ASC
-		LIMIT $5`,
-		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
-	)
+		FROM taxonomy_run_input_records input
+		INNER JOIN feedback_records fr
+			ON fr.id = input.feedback_record_id AND fr.tenant_id = input.tenant_id
+		INNER JOIN embeddings e
+			ON e.feedback_record_id = input.feedback_record_id AND e.model = $3
+		WHERE input.run_id = $1 AND input.tenant_id = $2
+		ORDER BY input.sort_order`, runID, tenantID, embeddingModel)
 	if err != nil {
-		return nil, fmt.Errorf("query field taxonomy run input rows: %w", err)
-	}
-
-	return rows, nil
-}
-
-func (r *TaxonomyRepository) queryRunInputRecordIDs(
-	ctx context.Context,
-	run *models.TaxonomyRun,
-	limit int,
-	embeddingModel string,
-) (pgx.Rows, error) {
-	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
-		rows, err := r.db.Query(ctx, `
-			SELECT fr.id
-			FROM feedback_records fr
-			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
-			WHERE fr.tenant_id = $1
-			  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
-			ORDER BY fr.collected_at DESC, fr.id ASC
-			LIMIT $2`,
-			run.TenantID, limit, embeddingModel,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("query directory taxonomy run input record IDs: %w", err)
-		}
-
-		return rows, nil
-	}
-
-	rows, err := r.db.Query(ctx, `
-		SELECT fr.id
-		FROM feedback_records fr
-		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
-		WHERE fr.tenant_id = $1
-		  AND fr.source_type = $2
-		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
-		  AND fr.field_id = $4
-		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
-		ORDER BY fr.collected_at DESC, fr.id ASC
-		LIMIT $5`,
-		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query field taxonomy run input record IDs: %w", err)
+		return nil, fmt.Errorf("query materialized taxonomy run input rows: %w", err)
 	}
 
 	return rows, nil

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -302,21 +302,43 @@ func (r *TaxonomyRepository) MarkRunFailed(
 	var run *models.TaxonomyRun
 
 	err := withTenantWritePoolTx(ctx, r.db, []string{tenantID}, func(dbTx tenantWriteTx) error {
+		normalizedMetrics := rawOrDefault(metrics, defaultJSONObj)
+
+		existing, err := queryTaxonomyRun(ctx, dbTx, taxonomyRunSelect+`
+			FROM taxonomy_runs
+			WHERE id = $1 AND tenant_id = $2
+			FOR UPDATE`, runID, tenantID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return huberrors.NewNotFoundError("taxonomy_run", "taxonomy run not found")
+			}
+
+			return fmt.Errorf("lock taxonomy run for failure: %w", err)
+		}
+
+		if existing.Status == models.TaxonomyRunStatusFailed && taxonomyFailureCallbackMatches(
+			existing, message, errorCode, normalizedMetrics,
+		) {
+			run = existing
+
+			return nil
+		}
+
+		if existing.Status != models.TaxonomyRunStatusPending && existing.Status != models.TaxonomyRunStatusRunning {
+			return taxonomyTransitionConflict(existing, models.TaxonomyRunStatusFailed)
+		}
+
 		updated, err := queryTaxonomyRun(ctx, dbTx, `
 			WITH taxonomy_runs AS (
 				UPDATE taxonomy_runs
 				SET status = 'failed', error = $2, error_code = $3, metrics = $4,
 					finished_at = NOW(), updated_at = NOW()
-				WHERE id = $1 AND tenant_id = $5 AND status IN ('pending', 'running')
+				WHERE id = $1 AND tenant_id = $5
 				RETURNING *
 			)`+taxonomyRunSelect+` FROM taxonomy_runs`,
-			runID, message, nullableFailureCode(errorCode), rawOrDefault(metrics, defaultJSONObj), tenantID,
+			runID, message, nullableFailureCode(errorCode), normalizedMetrics, tenantID,
 		)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return r.transitionError(ctx, dbTx, runID, tenantID, models.TaxonomyRunStatusFailed)
-			}
-
 			return fmt.Errorf("mark taxonomy run failed: %w", err)
 		}
 
@@ -633,8 +655,8 @@ func (r *TaxonomyRepository) ListRuns(
 }
 
 // maxTaxonomyRunInputRows caps how many (record, embedding) rows one run-input fetch may
-// materialize. run.EmbeddingCount is simply "all embedded records in scope" with no upper
-// bound, and each row carries a 768-dim vector (~3 KB binary, ~8-10 KB as JSON) — a 200k-record
+// materialize. run.RecordCount is simply "all eligible records in scope" with no upper
+// bound, and each selected embedded row carries a 768-dim vector (~3 KB binary, ~8-10 KB as JSON) — a 200k-record
 // tenant would otherwise allocate multiple GB in the API process for a single internal request.
 // 10k rows ≈ 100 MB JSON keeps the endpoint safe while staying far above typical run sizes;
 // larger scopes are truncated to the most recent rows (the ORDER BY) and logged.
@@ -653,10 +675,11 @@ func (r *TaxonomyRepository) GetRunInput(
 		return nil, err
 	}
 
-	limit := run.EmbeddingCount
+	limit := run.RecordCount
 	if limit > maxTaxonomyRunInputRows {
 		slog.Warn("taxonomy run input truncated to the row cap",
-			"run_id", runID, "embedding_count", run.EmbeddingCount, "cap", maxTaxonomyRunInputRows)
+			"run_id", runID, "eligible_count", run.RecordCount,
+			"embedding_count", run.EmbeddingCount, "cap", maxTaxonomyRunInputRows)
 
 		limit = maxTaxonomyRunInputRows
 	}
@@ -693,6 +716,12 @@ func (r *TaxonomyRepository) GetRunInput(
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate taxonomy run input records: %w", err)
 	}
+
+	run.EligibleCount = run.RecordCount
+	run.SelectedCount = limit
+	run.SelectionCap = maxTaxonomyRunInputRows
+	run.SelectionTruncated = run.RecordCount > limit
+	run.SelectionStrategy = "most_recent"
 
 	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
 }
@@ -741,134 +770,25 @@ func storeResultAndActivateInTx(
 		return nil, fmt.Errorf("lock taxonomy run: %w", err)
 	}
 
+	if run.Status == models.TaxonomyRunStatusSucceeded && taxonomyResultDigestsMatch(run.Metrics, req.Metrics) {
+		return run, nil
+	}
+
 	if run.Status != models.TaxonomyRunStatusRunning {
 		return nil, taxonomyTransitionConflict(run, models.TaxonomyRunStatusSucceeded)
 	}
 
-	clusterIDs := make(map[int]uuid.UUID, len(req.Clusters))
-	for _, cluster := range req.Clusters {
-		var clusterID uuid.UUID
-		if err := transaction.QueryRow(ctx, `
-			INSERT INTO taxonomy_clusters (
-				run_id, cluster_key, label, llm_label, keywords, size, is_outlier, metrics
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-			RETURNING id`,
-			run.ID,
-			cluster.ClusterKey,
-			cluster.Label,
-			cluster.LLMLabel,
-			rawOrDefault(cluster.Keywords, defaultJSONArr),
-			cluster.Size,
-			cluster.IsOutlier,
-			rawOrDefault(cluster.Metrics, defaultJSONObj),
-		).Scan(&clusterID); err != nil {
-			return nil, fmt.Errorf("insert taxonomy cluster: %w", err)
-		}
-
-		clusterIDs[cluster.ClusterKey] = clusterID
+	clusterIDs, err := insertTaxonomyClustersBulk(ctx, transaction, run.ID, req.Clusters)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, membership := range req.Memberships {
-		clusterID, ok := clusterIDs[membership.ClusterKey]
-		if !ok {
-			return nil, huberrors.NewValidationError("memberships.cluster_key", "references an unknown cluster")
-		}
-
-		if _, err := transaction.Exec(ctx, `
-			INSERT INTO taxonomy_cluster_memberships (
-				run_id, tenant_id, cluster_id, feedback_record_id, confidence, distance, metadata
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			run.ID,
-			run.TenantID,
-			clusterID,
-			membership.FeedbackRecordID,
-			membership.Confidence,
-			membership.Distance,
-			rawOrDefault(membership.Metadata, defaultJSONObj),
-		); err != nil {
-			return nil, fmt.Errorf("insert taxonomy cluster membership: %w", err)
-		}
+	if err := insertTaxonomyMembershipsBulk(ctx, transaction, run, req.Memberships, clusterIDs); err != nil {
+		return nil, err
 	}
 
-	nodes := append([]models.TaxonomyResultNode(nil), req.Nodes...)
-	sort.SliceStable(nodes, func(i, j int) bool {
-		if nodes[i].Level == nodes[j].Level {
-			return nodes[i].SortOrder < nodes[j].SortOrder
-		}
-
-		return nodes[i].Level < nodes[j].Level
-	})
-
-	nodeIDs := make(map[string]uuid.UUID, len(nodes))
-	for _, node := range nodes {
-		var parentID *uuid.UUID
-
-		if node.ParentKey != nil {
-			resolved, ok := nodeIDs[*node.ParentKey]
-			if !ok {
-				return nil, huberrors.NewValidationError("nodes.parent_key", "references an unknown parent")
-			}
-
-			parentID = &resolved
-		}
-
-		var clusterID *uuid.UUID
-
-		if node.ClusterKey != nil {
-			resolved, ok := clusterIDs[*node.ClusterKey]
-			if !ok {
-				return nil, huberrors.NewValidationError("nodes.cluster_key", "references an unknown cluster")
-			}
-
-			clusterID = &resolved
-		}
-
-		var nodeID uuid.UUID
-		if err := transaction.QueryRow(ctx, `
-			INSERT INTO taxonomy_nodes (
-				run_id, parent_id, cluster_id, node_type, label, original_label,
-				description, level, sort_order, metadata
-			)
-			VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9)
-			RETURNING id`,
-			run.ID,
-			parentID,
-			clusterID,
-			node.NodeType,
-			node.Label,
-			node.Description,
-			node.Level,
-			node.SortOrder,
-			rawOrDefault(node.Metadata, defaultJSONObj),
-		).Scan(&nodeID); err != nil {
-			return nil, fmt.Errorf("insert taxonomy node: %w", err)
-		}
-
-		nodeIDs[node.NodeKey] = nodeID
-	}
-
-	activatedBy := taxonomyRunRequestedBy(run.Params)
-	if _, err := transaction.Exec(ctx, `
-			INSERT INTO taxonomy_active_runs (
-				tenant_id, scope_type, source_type, source_id, field_id, run_id, activated_by
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
-			ON CONFLICT (tenant_id, scope_type, source_type, source_id, field_id)
-			DO UPDATE SET
-				run_id = EXCLUDED.run_id,
-				activated_by = EXCLUDED.activated_by,
-				activated_at = NOW()`,
-		run.TenantID,
-		run.ScopeType,
-		run.SourceType,
-		run.SourceID,
-		run.FieldID,
-		run.ID,
-		activatedBy,
-	); err != nil {
-		return nil, fmt.Errorf("activate taxonomy run: %w", err)
+	if err := insertTaxonomyNodesBulk(ctx, transaction, run.ID, req.Nodes, clusterIDs); err != nil {
+		return nil, err
 	}
 
 	updated, err := queryTaxonomyRun(ctx, transaction, `
@@ -894,7 +814,278 @@ func storeResultAndActivateInTx(
 		return nil, fmt.Errorf("mark taxonomy run succeeded: %w", err)
 	}
 
+	activatedBy := taxonomyRunRequestedBy(run.Params)
+	if _, err := transaction.Exec(ctx, `
+			INSERT INTO taxonomy_active_runs (
+				tenant_id, scope_type, source_type, source_id, field_id, run_id, activated_by
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (tenant_id, scope_type, source_type, source_id, field_id)
+			DO UPDATE SET
+				run_id = EXCLUDED.run_id,
+				activated_by = EXCLUDED.activated_by,
+				activated_at = NOW()`,
+		run.TenantID,
+		run.ScopeType,
+		run.SourceType,
+		run.SourceID,
+		run.FieldID,
+		run.ID,
+		activatedBy,
+	); err != nil {
+		return nil, fmt.Errorf("activate taxonomy run: %w", err)
+	}
+
 	return updated, nil
+}
+
+type taxonomyClusterInsert struct {
+	ID         uuid.UUID       `json:"id"`
+	RunID      uuid.UUID       `json:"run_id"`
+	ClusterKey int             `json:"cluster_key"`
+	Label      *string         `json:"label"`
+	LLMLabel   *string         `json:"llm_label"`
+	Keywords   json.RawMessage `json:"keywords"`
+	Size       int             `json:"size"`
+	IsOutlier  bool            `json:"is_outlier"`
+	Metrics    json.RawMessage `json:"metrics"`
+}
+
+func insertTaxonomyClustersBulk(
+	ctx context.Context,
+	transaction tenantWriteTx,
+	runID uuid.UUID,
+	clusters []models.TaxonomyResultCluster,
+) (map[int]uuid.UUID, error) {
+	clusterIDs := make(map[int]uuid.UUID, len(clusters))
+
+	rows := make([]taxonomyClusterInsert, 0, len(clusters))
+	for _, cluster := range clusters {
+		if _, exists := clusterIDs[cluster.ClusterKey]; exists {
+			return nil, huberrors.NewValidationError("clusters.cluster_key", "contains a duplicate cluster")
+		}
+
+		clusterID := uuid.New()
+		clusterIDs[cluster.ClusterKey] = clusterID
+		rows = append(rows, taxonomyClusterInsert{
+			ID: clusterID, RunID: runID, ClusterKey: cluster.ClusterKey,
+			Label: cluster.Label, LLMLabel: cluster.LLMLabel,
+			Keywords: rawOrDefault(cluster.Keywords, defaultJSONArr),
+			Size:     cluster.Size, IsOutlier: cluster.IsOutlier,
+			Metrics: rawOrDefault(cluster.Metrics, defaultJSONObj),
+		})
+	}
+
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return nil, fmt.Errorf("marshal taxonomy clusters: %w", err)
+	}
+
+	if _, err := transaction.Exec(ctx, `
+		INSERT INTO taxonomy_clusters (
+			id, run_id, cluster_key, label, llm_label, keywords, size, is_outlier, metrics
+		)
+		SELECT id, run_id, cluster_key, label, llm_label, keywords, size, is_outlier, metrics
+		FROM jsonb_to_recordset($1::jsonb) AS input(
+			id uuid, run_id uuid, cluster_key integer, label text, llm_label text,
+			keywords jsonb, size integer, is_outlier boolean, metrics jsonb
+		)`, string(payload)); err != nil {
+		return nil, fmt.Errorf("bulk insert taxonomy clusters: %w", err)
+	}
+
+	return clusterIDs, nil
+}
+
+type taxonomyMembershipInsert struct {
+	RunID            uuid.UUID       `json:"run_id"`
+	TenantID         string          `json:"tenant_id"`
+	ClusterID        uuid.UUID       `json:"cluster_id"`
+	FeedbackRecordID uuid.UUID       `json:"feedback_record_id"`
+	Confidence       *float64        `json:"confidence"`
+	Distance         *float64        `json:"distance"`
+	Metadata         json.RawMessage `json:"metadata"`
+}
+
+func insertTaxonomyMembershipsBulk(
+	ctx context.Context,
+	transaction tenantWriteTx,
+	run *models.TaxonomyRun,
+	memberships []models.TaxonomyResultMembership,
+	clusterIDs map[int]uuid.UUID,
+) error {
+	rows := make([]taxonomyMembershipInsert, 0, len(memberships))
+	for _, membership := range memberships {
+		clusterID, ok := clusterIDs[membership.ClusterKey]
+		if !ok {
+			return huberrors.NewValidationError("memberships.cluster_key", "references an unknown cluster")
+		}
+
+		rows = append(rows, taxonomyMembershipInsert{
+			RunID: run.ID, TenantID: run.TenantID, ClusterID: clusterID,
+			FeedbackRecordID: membership.FeedbackRecordID,
+			Confidence:       membership.Confidence, Distance: membership.Distance,
+			Metadata: rawOrDefault(membership.Metadata, defaultJSONObj),
+		})
+	}
+
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal taxonomy memberships: %w", err)
+	}
+
+	if _, err := transaction.Exec(ctx, `
+		INSERT INTO taxonomy_cluster_memberships (
+			run_id, tenant_id, cluster_id, feedback_record_id, confidence, distance, metadata
+		)
+		SELECT run_id, tenant_id, cluster_id, feedback_record_id, confidence, distance, metadata
+		FROM jsonb_to_recordset($1::jsonb) AS input(
+			run_id uuid, tenant_id text, cluster_id uuid, feedback_record_id uuid,
+			confidence double precision, distance double precision, metadata jsonb
+		)`, string(payload)); err != nil {
+		return fmt.Errorf("bulk insert taxonomy cluster memberships: %w", err)
+	}
+
+	return nil
+}
+
+type taxonomyNodeInsert struct {
+	ID            uuid.UUID       `json:"id"`
+	RunID         uuid.UUID       `json:"run_id"`
+	ParentID      *uuid.UUID      `json:"parent_id"`
+	ClusterID     *uuid.UUID      `json:"cluster_id"`
+	NodeType      string          `json:"node_type"`
+	Label         string          `json:"label"`
+	OriginalLabel string          `json:"original_label"`
+	Description   *string         `json:"description"`
+	Level         int             `json:"level"`
+	SortOrder     int             `json:"sort_order"`
+	Metadata      json.RawMessage `json:"metadata"`
+}
+
+func insertTaxonomyNodesBulk(
+	ctx context.Context,
+	transaction tenantWriteTx,
+	runID uuid.UUID,
+	nodes []models.TaxonomyResultNode,
+	clusterIDs map[int]uuid.UUID,
+) error {
+	ordered := append([]models.TaxonomyResultNode(nil), nodes...)
+	sort.SliceStable(ordered, func(leftIndex, rightIndex int) bool {
+		if ordered[leftIndex].Level == ordered[rightIndex].Level {
+			if ordered[leftIndex].SortOrder == ordered[rightIndex].SortOrder {
+				return ordered[leftIndex].NodeKey < ordered[rightIndex].NodeKey
+			}
+
+			return ordered[leftIndex].SortOrder < ordered[rightIndex].SortOrder
+		}
+
+		return ordered[leftIndex].Level < ordered[rightIndex].Level
+	})
+
+	nodeIDs := make(map[string]uuid.UUID, len(ordered))
+
+	rows := make([]taxonomyNodeInsert, 0, len(ordered))
+	for _, node := range ordered {
+		if _, exists := nodeIDs[node.NodeKey]; exists {
+			return huberrors.NewValidationError("nodes.node_key", "contains a duplicate node")
+		}
+
+		var parentID *uuid.UUID
+
+		if node.ParentKey != nil {
+			resolved, ok := nodeIDs[*node.ParentKey]
+			if !ok {
+				return huberrors.NewValidationError("nodes.parent_key", "references an unknown parent")
+			}
+
+			parentID = &resolved
+		}
+
+		var clusterID *uuid.UUID
+
+		if node.ClusterKey != nil {
+			resolved, ok := clusterIDs[*node.ClusterKey]
+			if !ok {
+				return huberrors.NewValidationError("nodes.cluster_key", "references an unknown cluster")
+			}
+
+			clusterID = &resolved
+		}
+
+		nodeID := uuid.New()
+		nodeIDs[node.NodeKey] = nodeID
+		rows = append(rows, taxonomyNodeInsert{
+			ID: nodeID, RunID: runID, ParentID: parentID, ClusterID: clusterID,
+			NodeType: string(node.NodeType), Label: node.Label, OriginalLabel: node.Label,
+			Description: node.Description, Level: node.Level, SortOrder: node.SortOrder,
+			Metadata: rawOrDefault(node.Metadata, defaultJSONObj),
+		})
+	}
+
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal taxonomy nodes: %w", err)
+	}
+
+	if _, err := transaction.Exec(ctx, `
+		INSERT INTO taxonomy_nodes (
+			id, run_id, parent_id, cluster_id, node_type, label, original_label,
+			description, level, sort_order, metadata
+		)
+		SELECT id, run_id, parent_id, cluster_id, node_type, label, original_label,
+			description, level, sort_order, metadata
+		FROM jsonb_to_recordset($1::jsonb) AS input(
+			id uuid, run_id uuid, parent_id uuid, cluster_id uuid, node_type taxonomy_node_type_enum,
+			label text, original_label text, description text, level integer,
+			sort_order integer, metadata jsonb
+		)`, string(payload)); err != nil {
+		return fmt.Errorf("bulk insert taxonomy nodes: %w", err)
+	}
+
+	return nil
+}
+
+func taxonomyResultDigestsMatch(existing, incoming json.RawMessage) bool {
+	existingDigest := taxonomyMetricString(existing, "result_digest")
+
+	return existingDigest != "" && existingDigest == taxonomyMetricString(incoming, "result_digest")
+}
+
+func taxonomyMetricString(metrics json.RawMessage, key string) string {
+	values := make(map[string]any)
+	if err := json.Unmarshal(metrics, &values); err != nil {
+		return ""
+	}
+
+	value, _ := values[key].(string)
+
+	return value
+}
+
+func taxonomyFailureCallbackMatches(
+	run *models.TaxonomyRun,
+	message string,
+	errorCode models.TaxonomyRunFailureCode,
+	metrics json.RawMessage,
+) bool {
+	if run.Error == nil || *run.Error != message || run.ErrorCode == nil || *run.ErrorCode != errorCode {
+		return false
+	}
+
+	return taxonomyCanonicalJSONEqual(run.Metrics, metrics)
+}
+
+func taxonomyCanonicalJSONEqual(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(rawOrDefault(left, defaultJSONObj), &leftValue) != nil ||
+		json.Unmarshal(rawOrDefault(right, defaultJSONObj), &rightValue) != nil {
+		return false
+	}
+
+	leftCanonical, leftErr := json.Marshal(leftValue)
+	rightCanonical, rightErr := json.Marshal(rightValue)
+
+	return leftErr == nil && rightErr == nil && string(leftCanonical) == string(rightCanonical)
 }
 
 // GetTree returns the visible taxonomy tree for a run.

--- a/internal/repository/taxonomy_repository.go
+++ b/internal/repository/taxonomy_repository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pgvector/pgvector-go"
 
 	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/jsonutil"
 	"github.com/formbricks/hub/internal/models"
 )
 
@@ -654,16 +655,16 @@ func (r *TaxonomyRepository) ListRuns(
 	return scanTaxonomyRuns(rows)
 }
 
-// maxTaxonomyRunInputRows caps how many (record, embedding) rows one run-input fetch may
+// MaxTaxonomyRunInputRows caps how many (record, embedding) rows one run-input fetch may
 // materialize. run.RecordCount is simply "all eligible records in scope" with no upper
 // bound, and each selected embedded row carries a 768-dim vector (~3 KB binary, ~8-10 KB as JSON) — a 200k-record
 // tenant would otherwise allocate multiple GB in the API process for a single internal request.
 // 10k rows ≈ 100 MB JSON keeps the endpoint safe while staying far above typical run sizes;
 // larger scopes are truncated to the most recent rows (the ORDER BY) and logged.
-const maxTaxonomyRunInputRows = 10_000
+const MaxTaxonomyRunInputRows = 10_000
 
 // GetRunInput returns feedback records and embeddings for a taxonomy run, capped at
-// maxTaxonomyRunInputRows (most recent first).
+// MaxTaxonomyRunInputRows (most recent first).
 func (r *TaxonomyRepository) GetRunInput(
 	ctx context.Context,
 	runID uuid.UUID,
@@ -676,12 +677,12 @@ func (r *TaxonomyRepository) GetRunInput(
 	}
 
 	limit := run.RecordCount
-	if limit > maxTaxonomyRunInputRows {
+	if limit > MaxTaxonomyRunInputRows {
 		slog.Warn("taxonomy run input truncated to the row cap",
 			"run_id", runID, "eligible_count", run.RecordCount,
-			"embedding_count", run.EmbeddingCount, "cap", maxTaxonomyRunInputRows)
+			"embedding_count", run.EmbeddingCount, "cap", MaxTaxonomyRunInputRows)
 
-		limit = maxTaxonomyRunInputRows
+		limit = MaxTaxonomyRunInputRows
 	}
 
 	rows, err := r.queryRunInputRows(ctx, run, limit, embeddingModel)
@@ -718,12 +719,52 @@ func (r *TaxonomyRepository) GetRunInput(
 	}
 
 	run.EligibleCount = run.RecordCount
-	run.SelectedCount = limit
-	run.SelectionCap = maxTaxonomyRunInputRows
-	run.SelectionTruncated = run.RecordCount > limit
+	run.SelectedCount = len(records)
+	run.SelectionCap = MaxTaxonomyRunInputRows
+	run.SelectionTruncated = run.RecordCount > len(records)
 	run.SelectionStrategy = "most_recent"
 
 	return &models.TaxonomyRunInputResponse{Run: *run, Records: records}, nil
+}
+
+// GetRunInputRecordIDs returns the exact bounded record selection a taxonomy result
+// must cover. It intentionally omits feedback text and embeddings so completion does
+// not materialize the full run input a second time.
+func (r *TaxonomyRepository) GetRunInputRecordIDs(
+	ctx context.Context,
+	runID uuid.UUID,
+	tenantID string,
+	embeddingModel string,
+) ([]uuid.UUID, error) {
+	run, err := r.GetRunForTenant(ctx, runID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := min(run.RecordCount, MaxTaxonomyRunInputRows)
+
+	rows, err := r.queryRunInputRecordIDs(ctx, run, limit, embeddingModel)
+	if err != nil {
+		return nil, fmt.Errorf("get taxonomy run input record IDs: %w", err)
+	}
+	defer rows.Close()
+
+	recordIDs := make([]uuid.UUID, 0, limit)
+
+	for rows.Next() {
+		var recordID uuid.UUID
+		if err := rows.Scan(&recordID); err != nil {
+			return nil, fmt.Errorf("scan taxonomy run input record ID: %w", err)
+		}
+
+		recordIDs = append(recordIDs, recordID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate taxonomy run input record IDs: %w", err)
+	}
+
+	return recordIDs, nil
 }
 
 // StoreResultAndActivate stores generated taxonomy artifacts and activates the run.
@@ -1046,20 +1087,9 @@ func insertTaxonomyNodesBulk(
 }
 
 func taxonomyResultDigestsMatch(existing, incoming json.RawMessage) bool {
-	existingDigest := taxonomyMetricString(existing, "result_digest")
+	existingDigest := jsonutil.ObjectString(existing, "result_digest")
 
-	return existingDigest != "" && existingDigest == taxonomyMetricString(incoming, "result_digest")
-}
-
-func taxonomyMetricString(metrics json.RawMessage, key string) string {
-	values := make(map[string]any)
-	if err := json.Unmarshal(metrics, &values); err != nil {
-		return ""
-	}
-
-	value, _ := values[key].(string)
-
-	return value
+	return existingDigest != "" && existingDigest == jsonutil.ObjectString(incoming, "result_digest")
 }
 
 func taxonomyFailureCallbackMatches(
@@ -1072,20 +1102,7 @@ func taxonomyFailureCallbackMatches(
 		return false
 	}
 
-	return taxonomyCanonicalJSONEqual(run.Metrics, metrics)
-}
-
-func taxonomyCanonicalJSONEqual(left, right json.RawMessage) bool {
-	var leftValue, rightValue any
-	if json.Unmarshal(rawOrDefault(left, defaultJSONObj), &leftValue) != nil ||
-		json.Unmarshal(rawOrDefault(right, defaultJSONObj), &rightValue) != nil {
-		return false
-	}
-
-	leftCanonical, leftErr := json.Marshal(leftValue)
-	rightCanonical, rightErr := json.Marshal(rightValue)
-
-	return leftErr == nil && rightErr == nil && string(leftCanonical) == string(rightCanonical)
+	return jsonutil.CanonicalEqual(run.Metrics, metrics)
 }
 
 // GetTree returns the visible taxonomy tree for a run.
@@ -1393,6 +1410,50 @@ func (r *TaxonomyRepository) queryRunInputRows(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query field taxonomy run input rows: %w", err)
+	}
+
+	return rows, nil
+}
+
+func (r *TaxonomyRepository) queryRunInputRecordIDs(
+	ctx context.Context,
+	run *models.TaxonomyRun,
+	limit int,
+	embeddingModel string,
+) (pgx.Rows, error) {
+	if run.ScopeType == models.TaxonomyScopeTypeDirectory {
+		rows, err := r.db.Query(ctx, `
+			SELECT fr.id
+			FROM feedback_records fr
+			INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $3
+			WHERE fr.tenant_id = $1
+			  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
+			ORDER BY fr.collected_at DESC, fr.id ASC
+			LIMIT $2`,
+			run.TenantID, limit, embeddingModel,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("query directory taxonomy run input record IDs: %w", err)
+		}
+
+		return rows, nil
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT fr.id
+		FROM feedback_records fr
+		INNER JOIN embeddings e ON e.feedback_record_id = fr.id AND e.model = $6
+		WHERE fr.tenant_id = $1
+		  AND fr.source_type = $2
+		  AND NULLIF(btrim(fr.source_id), '') IS NOT DISTINCT FROM NULLIF(btrim($3), '')
+		  AND fr.field_id = $4
+		  AND COALESCE(NULLIF(btrim(fr.value_text_translated), ''), NULLIF(btrim(fr.value_text), '')) IS NOT NULL
+		ORDER BY fr.collected_at DESC, fr.id ASC
+		LIMIT $5`,
+		run.TenantID, run.SourceType, run.SourceID, run.FieldID, limit, embeddingModel,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query field taxonomy run input record IDs: %w", err)
 	}
 
 	return rows, nil

--- a/internal/repository/tenant_data_repository.go
+++ b/internal/repository/tenant_data_repository.go
@@ -136,6 +136,7 @@ func (r *TenantDataRepository) PurgeFeedbackRecordsByTenant(
 	}
 
 	total.Runs = taxonomy.Runs
+	total.InputRecords = taxonomy.InputRecords
 	total.Clusters = taxonomy.Clusters
 	total.Nodes = taxonomy.Nodes
 	total.ActiveRuns = taxonomy.ActiveRuns
@@ -393,6 +394,7 @@ func deleteTenantDataInTx(
 		DeletedEmbeddings:                 embeddingTag.RowsAffected(),
 		DeletedWebhooks:                   webhooksTag.RowsAffected(),
 		DeletedTaxonomyRuns:               taxonomy.Runs,
+		DeletedTaxonomyRunInputRecords:    taxonomy.InputRecords,
 		DeletedTaxonomyClusters:           taxonomy.Clusters,
 		DeletedTaxonomyClusterMemberships: taxonomy.ClusterMemberships,
 		DeletedTaxonomyNodes:              taxonomy.Nodes,
@@ -409,7 +411,7 @@ func deleteTenantDataInTx(
 // cluster memberships (via the membership -> feedback_records FK), leaving runs, clusters, nodes,
 // active-run rows and node events orphaned. Every table is removed explicitly, children before
 // parents, so each count is exact and the purge never relies on cascades. Ordering rules:
-//   - node_events and cluster_memberships reference runs/nodes/clusters, so they go first.
+//   - node_events, cluster_memberships, and input records reference runs, so they go first.
 //   - taxonomy_clusters and taxonomy_nodes have no tenant_id column; they are scoped through their
 //     run via a taxonomy_runs subquery, which means taxonomy_runs MUST be deleted last (after nodes
 //     and clusters) or the subquery would match nothing and orphan them.
@@ -428,6 +430,13 @@ func deleteTenantTaxonomyInTx(
 		WHERE tenant_id = $1`, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("delete tenant taxonomy cluster memberships: %w", err)
+	}
+
+	inputRecordsTag, err := exec.Exec(ctx, `
+		DELETE FROM taxonomy_run_input_records
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("delete tenant taxonomy run input records: %w", err)
 	}
 
 	nodesTag, err := exec.Exec(ctx, `
@@ -460,6 +469,7 @@ func deleteTenantTaxonomyInTx(
 
 	return &models.TenantTaxonomyDeleteCounts{
 		Runs:               runsTag.RowsAffected(),
+		InputRecords:       inputRecordsTag.RowsAffected(),
 		Clusters:           clustersTag.RowsAffected(),
 		ClusterMemberships: clusterMembershipsTag.RowsAffected(),
 		Nodes:              nodesTag.RowsAffected(),

--- a/internal/repository/tenant_data_repository_test.go
+++ b/internal/repository/tenant_data_repository_test.go
@@ -61,7 +61,7 @@ func purgeLockTags() []pgconn.CommandTag {
 	}
 }
 
-// tenantDeleteTags returns command tags for the ten DELETE statements
+// tenantDeleteTags returns command tags for the eleven DELETE statements
 // deleteTenantDataInTx issues, in execution order, each with a distinct row
 // count so tests can assert the per-table count mapping (see
 // assertTenantDeleteCounts).
@@ -70,6 +70,7 @@ func tenantDeleteTags() []pgconn.CommandTag {
 		pgconn.NewCommandTag("DELETE 2"),  // embeddings
 		pgconn.NewCommandTag("DELETE 11"), // taxonomy_node_events
 		pgconn.NewCommandTag("DELETE 12"), // taxonomy_cluster_memberships
+		pgconn.NewCommandTag("DELETE 17"), // taxonomy_run_input_records
 		pgconn.NewCommandTag("DELETE 13"), // taxonomy_nodes
 		pgconn.NewCommandTag("DELETE 14"), // taxonomy_clusters
 		pgconn.NewCommandTag("DELETE 15"), // taxonomy_active_runs
@@ -90,6 +91,7 @@ func assertTenantDeleteCounts(t *testing.T, counts *models.TenantDataDeleteCount
 		DeletedEmbeddings:                 2,
 		DeletedWebhooks:                   1,
 		DeletedTaxonomyRuns:               16,
+		DeletedTaxonomyRunInputRecords:    17,
 		DeletedTaxonomyClusters:           14,
 		DeletedTaxonomyClusterMemberships: 12,
 		DeletedTaxonomyNodes:              13,
@@ -131,15 +133,15 @@ func TestTenantDataRepository_DeleteByTenant(t *testing.T) {
 			t.Fatal("deferred rollback was not called")
 		}
 
-		if len(transaction.queries) != 13 {
-			t.Fatalf("queries = %d, want 13 (3 lock statements + 10 deletes)", len(transaction.queries))
+		if len(transaction.queries) != 14 {
+			t.Fatalf("queries = %d, want 14 (3 lock statements + 11 deletes)", len(transaction.queries))
 		}
 
 		assertQueryContains(t, transaction.queries[0], "set_config('lock_timeout', $1, true)")
 		assertQueryContains(t, transaction.queries[1], "pg_advisory_xact_lock(hashtextextended($1, 0))")
 		assertQueryContains(t, transaction.queries[2], "set_config('lock_timeout', '0', true)")
 		assertQueryContains(t, transaction.queries[3], "DELETE FROM embeddings")
-		assertQueryContains(t, transaction.queries[12], "DELETE FROM tenant_settings")
+		assertQueryContains(t, transaction.queries[13], "DELETE FROM tenant_settings")
 
 		if len(transaction.args[1]) != 1 || transaction.args[1][0] != TenantWriteLockKey("org-123") {
 			t.Fatalf("lock args = %#v, want tenant write lock key", transaction.args[1])
@@ -255,8 +257,8 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 
 		assertTenantDeleteCounts(t, counts)
 
-		if len(exec.queries) != 10 {
-			t.Fatalf("queries = %d, want 10", len(exec.queries))
+		if len(exec.queries) != 11 {
+			t.Fatalf("queries = %d, want 11", len(exec.queries))
 		}
 
 		// Children before parents, with taxonomy_runs deleted after the
@@ -265,18 +267,19 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 		assertQueryContains(t, exec.queries[0], "USING feedback_records")
 		assertQueryContains(t, exec.queries[1], "DELETE FROM taxonomy_node_events")
 		assertQueryContains(t, exec.queries[2], "DELETE FROM taxonomy_cluster_memberships")
-		assertQueryContains(t, exec.queries[3], "DELETE FROM taxonomy_nodes")
-		assertQueryContains(t, exec.queries[4], "DELETE FROM taxonomy_clusters")
-		assertQueryContains(t, exec.queries[5], "DELETE FROM taxonomy_active_runs")
-		assertQueryContains(t, exec.queries[6], "DELETE FROM taxonomy_runs")
-		assertQueryContains(t, exec.queries[7], "DELETE FROM feedback_records")
-		assertQueryContains(t, exec.queries[8], "DELETE FROM webhooks")
-		assertQueryContains(t, exec.queries[9], "DELETE FROM tenant_settings")
+		assertQueryContains(t, exec.queries[3], "DELETE FROM taxonomy_run_input_records")
+		assertQueryContains(t, exec.queries[4], "DELETE FROM taxonomy_nodes")
+		assertQueryContains(t, exec.queries[5], "DELETE FROM taxonomy_clusters")
+		assertQueryContains(t, exec.queries[6], "DELETE FROM taxonomy_active_runs")
+		assertQueryContains(t, exec.queries[7], "DELETE FROM taxonomy_runs")
+		assertQueryContains(t, exec.queries[8], "DELETE FROM feedback_records")
+		assertQueryContains(t, exec.queries[9], "DELETE FROM webhooks")
+		assertQueryContains(t, exec.queries[10], "DELETE FROM tenant_settings")
 
 		// taxonomy_nodes and taxonomy_clusters have no tenant_id column, so they
 		// must be scoped through their run via a taxonomy_runs subquery.
-		assertQueryContains(t, exec.queries[3], "SELECT id FROM taxonomy_runs WHERE tenant_id = $1")
 		assertQueryContains(t, exec.queries[4], "SELECT id FROM taxonomy_runs WHERE tenant_id = $1")
+		assertQueryContains(t, exec.queries[5], "SELECT id FROM taxonomy_runs WHERE tenant_id = $1")
 
 		for queryIndex, args := range exec.args {
 			if len(args) != 1 || args[0] != "org-123" {
@@ -322,33 +325,7 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 	})
 
 	t.Run("stops before feedback records after taxonomy runs delete error", func(t *testing.T) {
-		// taxonomy_runs is the seventh delete (errAtQuery is 1-based).
-		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 7}
-
-		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
-		if err == nil {
-			t.Fatal("deleteTenantDataInTx() error = nil, want error")
-		}
-
-		if counts != nil {
-			t.Fatalf("counts = %+v, want nil", counts)
-		}
-
-		if len(exec.queries) != 7 {
-			t.Fatalf("queries = %d, want 7", len(exec.queries))
-		}
-
-		assertQueryContains(t, exec.queries[6], "DELETE FROM taxonomy_runs")
-
-		for _, query := range exec.queries {
-			if strings.Contains(query, "DELETE FROM feedback_records") {
-				t.Fatalf("feedback_records deleted before taxonomy runs error: %q", query)
-			}
-		}
-	})
-
-	t.Run("stops before webhooks after feedback delete error", func(t *testing.T) {
-		// feedback_records is the eighth delete.
+		// taxonomy_runs is the eighth delete (errAtQuery is 1-based).
 		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 8}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
@@ -364,12 +341,18 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 			t.Fatalf("queries = %d, want 8", len(exec.queries))
 		}
 
-		assertQueryContains(t, exec.queries[7], "DELETE FROM feedback_records")
+		assertQueryContains(t, exec.queries[7], "DELETE FROM taxonomy_runs")
+
+		for _, query := range exec.queries {
+			if strings.Contains(query, "DELETE FROM feedback_records") {
+				t.Fatalf("feedback_records deleted before taxonomy runs error: %q", query)
+			}
+		}
 	})
 
-	t.Run("stops after tenant settings delete error", func(t *testing.T) {
-		// tenant_settings is the tenth (final) delete.
-		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 10}
+	t.Run("stops before webhooks after feedback delete error", func(t *testing.T) {
+		// feedback_records is the ninth delete.
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 9}
 
 		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
 		if err == nil {
@@ -380,11 +363,31 @@ func TestDeleteTenantDataInTx(t *testing.T) {
 			t.Fatalf("counts = %+v, want nil", counts)
 		}
 
-		if len(exec.queries) != 10 {
-			t.Fatalf("queries = %d, want 10", len(exec.queries))
+		if len(exec.queries) != 9 {
+			t.Fatalf("queries = %d, want 9", len(exec.queries))
 		}
 
-		assertQueryContains(t, exec.queries[9], "DELETE FROM tenant_settings")
+		assertQueryContains(t, exec.queries[8], "DELETE FROM feedback_records")
+	})
+
+	t.Run("stops after tenant settings delete error", func(t *testing.T) {
+		// tenant_settings is the eleventh (final) delete.
+		exec := &fakeTenantDataExecutor{tags: tenantDeleteTags(), errAtQuery: 11}
+
+		counts, err := deleteTenantDataInTx(context.Background(), exec, "org-123")
+		if err == nil {
+			t.Fatal("deleteTenantDataInTx() error = nil, want error")
+		}
+
+		if counts != nil {
+			t.Fatalf("counts = %+v, want nil", counts)
+		}
+
+		if len(exec.queries) != 11 {
+			t.Fatalf("queries = %d, want 11", len(exec.queries))
+		}
+
+		assertQueryContains(t, exec.queries[10], "DELETE FROM tenant_settings")
 	})
 }
 

--- a/internal/service/feedback_records_purge_service.go
+++ b/internal/service/feedback_records_purge_service.go
@@ -114,6 +114,7 @@ func (s *FeedbackRecordsPurgeService) Purge(
 		"deleted_feedback_records", counts.DeletedFeedbackRecords,
 		"deleted_embeddings", counts.DeletedEmbeddings,
 		"deleted_taxonomy_cluster_memberships", counts.ClusterMemberships,
+		"deleted_taxonomy_run_input_records", counts.InputRecords,
 		"deleted_taxonomy_runs", counts.Runs,
 		"deleted_taxonomy_nodes", counts.Nodes,
 	)

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/formbricks/hub/internal/huberrors"
+	"github.com/formbricks/hub/internal/jsonutil"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/observability"
 	"github.com/formbricks/hub/internal/repository"
@@ -33,7 +34,6 @@ var (
 const defaultMinimumTaxonomyEmbeddingCount = 20
 
 const (
-	taxonomySelectionCap             = 10_000
 	minimumTaxonomyEmbeddingCoverage = 0.90
 	percentageScale                  = 100.0
 )
@@ -65,6 +65,12 @@ type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service 
 		tenantID string,
 		embeddingModel string,
 	) (*models.TaxonomyRunInputResponse, error)
+	GetRunInputRecordIDs(
+		ctx context.Context,
+		runID uuid.UUID,
+		tenantID string,
+		embeddingModel string,
+	) ([]uuid.UUID, error)
 	StoreResultAndActivate(
 		ctx context.Context,
 		runID uuid.UUID,
@@ -173,7 +179,7 @@ func (s *TaxonomyService) StartManualRun(
 		)
 	}
 
-	selectedCount := min(recordCount, taxonomySelectionCap)
+	selectedCount := min(recordCount, repository.MaxTaxonomyRunInputRows)
 
 	selectedEmbeddingCount := min(embeddingCount, selectedCount)
 	if selectedCount > 0 && float64(selectedEmbeddingCount)/float64(selectedCount) < minimumTaxonomyEmbeddingCoverage {
@@ -405,11 +411,20 @@ func (s *TaxonomyService) CompleteRun(
 	}
 
 	if existingRun.Status == models.TaxonomyRunStatusSucceeded {
-		if taxonomyMetricString(existingRun.Metrics, "result_digest") == resultDigest {
+		if jsonutil.ObjectString(existingRun.Metrics, "result_digest") == resultDigest {
 			return existingRun, nil
 		}
 
 		return nil, huberrors.NewConflictError("taxonomy run already succeeded with a different result")
+	}
+
+	selectedRecordIDs, err := s.repo.GetRunInputRecordIDs(ctx, runID, existingRun.TenantID, s.embeddingModel)
+	if err != nil {
+		return nil, fmt.Errorf("get selected taxonomy input records: %w", err)
+	}
+
+	if err := validateTaxonomyMembershipCoverage(req.Memberships, selectedRecordIDs); err != nil {
+		return nil, err
 	}
 
 	run, err := s.repo.StoreResultAndActivate(ctx, runID, existingRun.TenantID, req)
@@ -497,6 +512,34 @@ func validateTaxonomyResultMemberships(
 	for clusterKey, size := range clusterSizes {
 		if membershipCounts[clusterKey] != size {
 			return huberrors.NewValidationError("result.memberships", "cluster size must match membership count")
+		}
+	}
+
+	return nil
+}
+
+func validateTaxonomyMembershipCoverage(
+	memberships []models.TaxonomyResultMembership,
+	selectedRecordIDs []uuid.UUID,
+) error {
+	if len(memberships) != len(selectedRecordIDs) {
+		return huberrors.NewValidationError(
+			"result.memberships",
+			"memberships must exactly cover the selected run input",
+		)
+	}
+
+	selectedRecords := make(map[uuid.UUID]struct{}, len(selectedRecordIDs))
+	for _, recordID := range selectedRecordIDs {
+		selectedRecords[recordID] = struct{}{}
+	}
+
+	for _, membership := range memberships {
+		if _, exists := selectedRecords[membership.FeedbackRecordID]; !exists {
+			return huberrors.NewValidationError(
+				"result.memberships",
+				"memberships must exactly cover the selected run input",
+			)
 		}
 	}
 
@@ -867,7 +910,7 @@ func scopeValidationField(scope models.TaxonomyScope) string {
 }
 
 func taxonomyRunParams(actorID *string, embeddingModel string, eligibleCount, embeddingCount int) json.RawMessage {
-	selectedCount := min(eligibleCount, taxonomySelectionCap)
+	selectedCount := min(embeddingCount, repository.MaxTaxonomyRunInputRows)
 	params := map[string]any{
 		"trigger":         "manual",
 		"embedding_model": embeddingModel,
@@ -875,7 +918,7 @@ func taxonomyRunParams(actorID *string, embeddingModel string, eligibleCount, em
 			"eligible_count":           eligibleCount,
 			"embedding_eligible_count": embeddingCount,
 			"selected_count":           selectedCount,
-			"selection_cap":            taxonomySelectionCap,
+			"selection_cap":            repository.MaxTaxonomyRunInputRows,
 			"truncation_flag":          eligibleCount > selectedCount,
 			"selection_strategy":       "most_recent",
 		},
@@ -954,17 +997,6 @@ func mergeTaxonomyMetric(metrics json.RawMessage, key, value string) (json.RawMe
 	return raw, nil
 }
 
-func taxonomyMetricString(metrics json.RawMessage, key string) string {
-	values := make(map[string]any)
-	if err := json.Unmarshal(metrics, &values); err != nil {
-		return ""
-	}
-
-	value, _ := values[key].(string)
-
-	return value
-}
-
 func taxonomyFailureMatches(
 	run *models.TaxonomyRun,
 	message string,
@@ -975,25 +1007,5 @@ func taxonomyFailureMatches(
 		return false
 	}
 
-	return canonicalJSONEqual(run.Metrics, rawOrEmptyObject(metrics))
-}
-
-func canonicalJSONEqual(left, right json.RawMessage) bool {
-	var leftValue, rightValue any
-	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
-		return false
-	}
-
-	leftRaw, leftErr := json.Marshal(leftValue)
-	rightRaw, rightErr := json.Marshal(rightValue)
-
-	return leftErr == nil && rightErr == nil && slices.Equal(leftRaw, rightRaw)
-}
-
-func rawOrEmptyObject(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return json.RawMessage(`{}`)
-	}
-
-	return raw
+	return jsonutil.CanonicalEqual(run.Metrics, metrics)
 }

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -1,11 +1,15 @@
 package service
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,6 +31,12 @@ var (
 )
 
 const defaultMinimumTaxonomyEmbeddingCount = 20
+
+const (
+	taxonomySelectionCap             = 10_000
+	minimumTaxonomyEmbeddingCoverage = 0.90
+	percentageScale                  = 100.0
+)
 
 const directoryTaxonomyFieldLabel = "All feedback"
 
@@ -163,6 +173,21 @@ func (s *TaxonomyService) StartManualRun(
 		)
 	}
 
+	selectedCount := min(recordCount, taxonomySelectionCap)
+
+	selectedEmbeddingCount := min(embeddingCount, selectedCount)
+	if selectedCount > 0 && float64(selectedEmbeddingCount)/float64(selectedCount) < minimumTaxonomyEmbeddingCoverage {
+		return nil, huberrors.NewValidationError(
+			scopeValidationField(scope),
+			fmt.Sprintf(
+				"at least %.0f%% embedding coverage is required; found %d of %d selected records",
+				minimumTaxonomyEmbeddingCoverage*percentageScale,
+				selectedEmbeddingCount,
+				selectedCount,
+			),
+		)
+	}
+
 	fieldLabel := req.FieldLabel
 	if fieldLabel != nil {
 		trimmed := strings.TrimSpace(*fieldLabel)
@@ -178,7 +203,7 @@ func (s *TaxonomyService) StartManualRun(
 		fieldLabel = discoveredFieldLabel
 	}
 
-	params := taxonomyRunParams(req.ActorID, s.embeddingModel)
+	params := taxonomyRunParams(req.ActorID, s.embeddingModel, recordCount, embeddingCount)
 
 	run, created, err := s.repo.CreateRunIfAvailable(ctx, repository.CreateTaxonomyRunParams{
 		TaxonomyScope:  scope,
@@ -360,9 +385,31 @@ func (s *TaxonomyService) CompleteRun(
 	runID uuid.UUID,
 	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
+	if err := validateTaxonomyResultRequest(req); err != nil {
+		return nil, err
+	}
+
 	existingRun, err := s.repo.GetRunForInternalService(ctx, runID)
 	if err != nil {
 		return nil, fmt.Errorf("get taxonomy run: %w", err)
+	}
+
+	resultDigest, err := canonicalTaxonomyResultDigest(req)
+	if err != nil {
+		return nil, huberrors.NewValidationError("result", "taxonomy result cannot be canonicalized")
+	}
+
+	req.Metrics, err = mergeTaxonomyMetric(req.Metrics, "result_digest", resultDigest)
+	if err != nil {
+		return nil, huberrors.NewValidationError("metrics", "taxonomy metrics must be a JSON object")
+	}
+
+	if existingRun.Status == models.TaxonomyRunStatusSucceeded {
+		if taxonomyMetricString(existingRun.Metrics, "result_digest") == resultDigest {
+			return existingRun, nil
+		}
+
+		return nil, huberrors.NewConflictError("taxonomy run already succeeded with a different result")
 	}
 
 	run, err := s.repo.StoreResultAndActivate(ctx, runID, existingRun.TenantID, req)
@@ -373,6 +420,164 @@ func (s *TaxonomyService) CompleteRun(
 	s.recordTerminal(ctx, run, "")
 
 	return run, nil
+}
+
+func validateTaxonomyResultRequest(req models.TaxonomyRunResultRequest) error {
+	clusterSizes, err := validateTaxonomyResultClusters(req.Clusters)
+	if err != nil {
+		return err
+	}
+
+	if err := validateTaxonomyResultMemberships(req.Memberships, clusterSizes); err != nil {
+		return err
+	}
+
+	return validateTaxonomyResultNodes(req.Nodes, clusterSizes)
+}
+
+//nolint:wsl_v5 // Adjacent guards document independent result invariants.
+func validateTaxonomyResultClusters(clusters []models.TaxonomyResultCluster) (map[int]int, error) {
+	clusterSizes := make(map[int]int, len(clusters))
+	for _, cluster := range clusters {
+		if _, exists := clusterSizes[cluster.ClusterKey]; exists {
+			return nil, huberrors.NewValidationError("result.clusters", "cluster_key values must be unique")
+		}
+		if cluster.Size <= 0 {
+			return nil, huberrors.NewValidationError("result.clusters", "cluster sizes must be positive")
+		}
+		if cluster.IsOutlier != (cluster.ClusterKey == -1) {
+			return nil, huberrors.NewValidationError("result.clusters", "outlier cluster invariant failed")
+		}
+		if cluster.ClusterKey == -1 {
+			label := cluster.Label
+			if cluster.LLMLabel != nil {
+				label = cluster.LLMLabel
+			}
+			if label == nil || strings.TrimSpace(*label) != "Uncategorized Feedback" {
+				return nil, huberrors.NewValidationError("result.clusters", "outlier cluster label must be canonical")
+			}
+		}
+
+		clusterSizes[cluster.ClusterKey] = cluster.Size
+	}
+	if len(clusterSizes) == 0 {
+		return nil, huberrors.NewValidationError("result.clusters", "at least one cluster is required")
+	}
+
+	return clusterSizes, nil
+}
+
+//nolint:wsl_v5 // Adjacent guards document independent result invariants.
+func validateTaxonomyResultMemberships(
+	memberships []models.TaxonomyResultMembership,
+	clusterSizes map[int]int,
+) error {
+	membershipCounts := make(map[int]int, len(clusterSizes))
+	seenRecords := make(map[uuid.UUID]struct{}, len(memberships))
+	for _, membership := range memberships {
+		if _, exists := clusterSizes[membership.ClusterKey]; !exists {
+			return huberrors.NewValidationError("result.memberships", "membership references an unknown cluster")
+		}
+		if membership.FeedbackRecordID == uuid.Nil {
+			return huberrors.NewValidationError("result.memberships", "feedback_record_id is required")
+		}
+		if _, exists := seenRecords[membership.FeedbackRecordID]; exists {
+			return huberrors.NewValidationError("result.memberships", "feedback records must appear exactly once")
+		}
+		if membership.Confidence != nil && (math.IsNaN(*membership.Confidence) || math.IsInf(*membership.Confidence, 0)) {
+			return huberrors.NewValidationError("result.memberships", "confidence must be finite")
+		}
+		if membership.Distance != nil && (math.IsNaN(*membership.Distance) || math.IsInf(*membership.Distance, 0)) {
+			return huberrors.NewValidationError("result.memberships", "distance must be finite")
+		}
+
+		seenRecords[membership.FeedbackRecordID] = struct{}{}
+		membershipCounts[membership.ClusterKey]++
+	}
+	for clusterKey, size := range clusterSizes {
+		if membershipCounts[clusterKey] != size {
+			return huberrors.NewValidationError("result.memberships", "cluster size must match membership count")
+		}
+	}
+
+	return nil
+}
+
+//nolint:cyclop,wsl_v5 // Adjacent guards keep the five-level tree contract explicit and auditable.
+func validateTaxonomyResultNodes(nodes []models.TaxonomyResultNode, clusterSizes map[int]int) error {
+	nodesByKey := make(map[string]models.TaxonomyResultNode, len(nodes))
+	childrenByParent := make(map[string]int, len(nodes))
+	siblingLabels := make(map[string]map[string]struct{}, len(nodes))
+	rootCount := 0
+	leafClusters := make(map[int]struct{}, len(clusterSizes))
+	for _, node := range nodes {
+		if _, exists := nodesByKey[node.NodeKey]; exists {
+			return huberrors.NewValidationError("result.nodes", "node_key values must be unique")
+		}
+		if node.SortOrder < 0 {
+			return huberrors.NewValidationError("result.nodes", "sort_order must be non-negative")
+		}
+
+		nodesByKey[node.NodeKey] = node
+		if node.ParentKey != nil {
+			childrenByParent[*node.ParentKey]++
+			normalizedLabel := strings.ToLower(strings.Join(strings.Fields(node.Label), " "))
+			if siblingLabels[*node.ParentKey] == nil {
+				siblingLabels[*node.ParentKey] = make(map[string]struct{})
+			}
+			if _, exists := siblingLabels[*node.ParentKey][normalizedLabel]; exists {
+				return huberrors.NewValidationError("result.nodes", "sibling labels must be unique")
+			}
+			siblingLabels[*node.ParentKey][normalizedLabel] = struct{}{}
+		}
+
+		switch node.NodeType {
+		case models.TaxonomyNodeTypeRoot:
+			rootCount++
+			if node.Level != 0 || node.ParentKey != nil || node.ClusterKey != nil {
+				return huberrors.NewValidationError("result.nodes", "root node must be level 0 without parent or cluster")
+			}
+		case models.TaxonomyNodeTypeBranch:
+			if node.Level < 1 || node.Level > 3 || node.ParentKey == nil || node.ClusterKey != nil {
+				return huberrors.NewValidationError("result.nodes", "branch nodes must occupy levels 1 through 3")
+			}
+		case models.TaxonomyNodeTypeLeaf:
+			if node.Level != 4 || node.ParentKey == nil || node.ClusterKey == nil {
+				return huberrors.NewValidationError("result.nodes", "leaf nodes must occupy level 4 and reference a cluster")
+			}
+			if _, exists := clusterSizes[*node.ClusterKey]; !exists {
+				return huberrors.NewValidationError("result.nodes", "leaf references an unknown cluster")
+			}
+			if _, exists := leafClusters[*node.ClusterKey]; exists {
+				return huberrors.NewValidationError("result.nodes", "clusters must appear in exactly one leaf")
+			}
+			if *node.ClusterKey == -1 && strings.TrimSpace(node.Label) != "Uncategorized Feedback" {
+				return huberrors.NewValidationError("result.nodes", "outlier leaf label must be canonical")
+			}
+			leafClusters[*node.ClusterKey] = struct{}{}
+		default:
+			return huberrors.NewValidationError("result.nodes", "node_type is invalid")
+		}
+	}
+	if rootCount != 1 {
+		return huberrors.NewValidationError("result.nodes", "exactly one root node is required")
+	}
+	if len(leafClusters) != len(clusterSizes) {
+		return huberrors.NewValidationError("result.nodes", "leaves must cover every cluster exactly once")
+	}
+	for nodeKey, node := range nodesByKey {
+		if node.ParentKey != nil {
+			parent, exists := nodesByKey[*node.ParentKey]
+			if !exists || parent.Level != node.Level-1 || parent.NodeType == models.TaxonomyNodeTypeLeaf {
+				return huberrors.NewValidationError("result.nodes", "parent references must form an exact five-level tree")
+			}
+		}
+		if node.NodeType != models.TaxonomyNodeTypeLeaf && childrenByParent[nodeKey] == 0 {
+			return huberrors.NewValidationError("result.nodes", "root and branch nodes must have children")
+		}
+	}
+
+	return nil
 }
 
 // FailRun records a taxonomy run failure.
@@ -391,6 +596,14 @@ func (s *TaxonomyService) FailRun(
 	metrics, err := marshalFailureDiagnostics(req.Diagnostics)
 	if err != nil {
 		return nil, fmt.Errorf("marshal taxonomy failure diagnostics: %w", err)
+	}
+
+	if existingRun.Status == models.TaxonomyRunStatusFailed {
+		if taxonomyFailureMatches(existingRun, sanitized, normalizedCode, metrics) {
+			return existingRun, nil
+		}
+
+		return nil, huberrors.NewConflictError("taxonomy run already failed with a different result")
 	}
 
 	run, err := s.repo.MarkRunFailed(ctx, runID, existingRun.TenantID, sanitized, normalizedCode, metrics)
@@ -653,10 +866,19 @@ func scopeValidationField(scope models.TaxonomyScope) string {
 	return "field_id"
 }
 
-func taxonomyRunParams(actorID *string, embeddingModel string) json.RawMessage {
-	params := map[string]string{
+func taxonomyRunParams(actorID *string, embeddingModel string, eligibleCount, embeddingCount int) json.RawMessage {
+	selectedCount := min(eligibleCount, taxonomySelectionCap)
+	params := map[string]any{
 		"trigger":         "manual",
 		"embedding_model": embeddingModel,
+		"input_selection": map[string]any{
+			"eligible_count":           eligibleCount,
+			"embedding_eligible_count": embeddingCount,
+			"selected_count":           selectedCount,
+			"selection_cap":            taxonomySelectionCap,
+			"truncation_flag":          eligibleCount > selectedCount,
+			"selection_strategy":       "most_recent",
+		},
 	}
 
 	if actorID != nil && strings.TrimSpace(*actorID) != "" {
@@ -666,6 +888,111 @@ func taxonomyRunParams(actorID *string, embeddingModel string) json.RawMessage {
 	raw, err := json.Marshal(params)
 	if err != nil {
 		return json.RawMessage(`{"trigger":"manual"}`)
+	}
+
+	return raw
+}
+
+func canonicalTaxonomyResultDigest(req models.TaxonomyRunResultRequest) (string, error) {
+	clusters := slices.Clone(req.Clusters)
+	memberships := slices.Clone(req.Memberships)
+	nodes := slices.Clone(req.Nodes)
+
+	slices.SortFunc(clusters, func(left, right models.TaxonomyResultCluster) int {
+		return cmp.Compare(left.ClusterKey, right.ClusterKey)
+	})
+	slices.SortFunc(memberships, func(left, right models.TaxonomyResultMembership) int {
+		if byRecord := strings.Compare(left.FeedbackRecordID.String(), right.FeedbackRecordID.String()); byRecord != 0 {
+			return byRecord
+		}
+
+		return cmp.Compare(left.ClusterKey, right.ClusterKey)
+	})
+	slices.SortFunc(nodes, func(left, right models.TaxonomyResultNode) int {
+		return strings.Compare(left.NodeKey, right.NodeKey)
+	})
+
+	raw, err := json.Marshal(struct {
+		Clusters    []models.TaxonomyResultCluster    `json:"clusters"`
+		Memberships []models.TaxonomyResultMembership `json:"memberships"`
+		Nodes       []models.TaxonomyResultNode       `json:"nodes"`
+	}{Clusters: clusters, Memberships: memberships, Nodes: nodes})
+	if err != nil {
+		return "", fmt.Errorf("marshal taxonomy result: %w", err)
+	}
+
+	var canonical any
+	if err := json.Unmarshal(raw, &canonical); err != nil {
+		return "", fmt.Errorf("parse taxonomy result: %w", err)
+	}
+
+	raw, err = json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize taxonomy result: %w", err)
+	}
+
+	digest := sha256.Sum256(raw)
+
+	return fmt.Sprintf("sha256:%x", digest), nil
+}
+
+func mergeTaxonomyMetric(metrics json.RawMessage, key, value string) (json.RawMessage, error) {
+	values := make(map[string]any)
+	if len(metrics) > 0 && string(metrics) != "null" {
+		if err := json.Unmarshal(metrics, &values); err != nil {
+			return nil, fmt.Errorf("unmarshal taxonomy metrics: %w", err)
+		}
+	}
+
+	values[key] = value
+
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("marshal taxonomy metrics: %w", err)
+	}
+
+	return raw, nil
+}
+
+func taxonomyMetricString(metrics json.RawMessage, key string) string {
+	values := make(map[string]any)
+	if err := json.Unmarshal(metrics, &values); err != nil {
+		return ""
+	}
+
+	value, _ := values[key].(string)
+
+	return value
+}
+
+func taxonomyFailureMatches(
+	run *models.TaxonomyRun,
+	message string,
+	code models.TaxonomyRunFailureCode,
+	metrics json.RawMessage,
+) bool {
+	if run.Error == nil || *run.Error != message || run.ErrorCode == nil || *run.ErrorCode != code {
+		return false
+	}
+
+	return canonicalJSONEqual(run.Metrics, rawOrEmptyObject(metrics))
+}
+
+func canonicalJSONEqual(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+
+	leftRaw, leftErr := json.Marshal(leftValue)
+	rightRaw, rightErr := json.Marshal(rightValue)
+
+	return leftErr == nil && rightErr == nil && slices.Equal(leftRaw, rightRaw)
+}
+
+func rawOrEmptyObject(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
 	}
 
 	return raw

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -425,8 +425,13 @@ func (s *TaxonomyService) CompleteRun(
 		return nil, fmt.Errorf("get selected taxonomy input records: %w", err)
 	}
 
-	if err := validateTaxonomyMembershipCoverage(req.Memberships, selectedRecordIDs); err != nil {
-		return nil, err
+	// Inputs served by pre-snapshot Hub replicas are explicitly grandfathered by migration 023.
+	// They have no immutable selection to compare with, so they retain the old completion contract.
+	// Once a new replica materializes a snapshot, coverage is mandatory even if it is unexpectedly empty.
+	if existingRun.InputSnapshotMaterialized || len(selectedRecordIDs) > 0 {
+		if err := validateTaxonomyMembershipCoverage(req.Memberships, selectedRecordIDs); err != nil {
+			return nil, err
+		}
 	}
 
 	run, err := s.repo.StoreResultAndActivate(ctx, runID, existingRun.TenantID, req)

--- a/internal/service/taxonomy_service.go
+++ b/internal/service/taxonomy_service.go
@@ -69,7 +69,6 @@ type TaxonomyRepository interface { //nolint:interfacebloat // taxonomy service 
 		ctx context.Context,
 		runID uuid.UUID,
 		tenantID string,
-		embeddingModel string,
 	) ([]uuid.UUID, error)
 	StoreResultAndActivate(
 		ctx context.Context,
@@ -411,6 +410,9 @@ func (s *TaxonomyService) CompleteRun(
 	}
 
 	if existingRun.Status == models.TaxonomyRunStatusSucceeded {
+		// Runs completed before result digests were introduced cannot prove that a retry is identical.
+		// Keep the fail-safe conflict for a missing legacy digest instead of accepting a potentially
+		// different tree as idempotent.
 		if jsonutil.ObjectString(existingRun.Metrics, "result_digest") == resultDigest {
 			return existingRun, nil
 		}
@@ -418,7 +420,7 @@ func (s *TaxonomyService) CompleteRun(
 		return nil, huberrors.NewConflictError("taxonomy run already succeeded with a different result")
 	}
 
-	selectedRecordIDs, err := s.repo.GetRunInputRecordIDs(ctx, runID, existingRun.TenantID, s.embeddingModel)
+	selectedRecordIDs, err := s.repo.GetRunInputRecordIDs(ctx, runID, existingRun.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("get selected taxonomy input records: %w", err)
 	}

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/formbricks/hub/internal/jsonutil"
 	"github.com/formbricks/hub/internal/models"
 	"github.com/formbricks/hub/internal/repository"
 )
@@ -30,6 +31,8 @@ type mockTaxonomyRepo struct {
 	storeResultRequest   models.TaxonomyRunResultRequest
 	storeResultRun       *models.TaxonomyRun
 	storeResultCalls     int
+	selectedRecordIDs    []uuid.UUID
+	selectedRecordIDsErr error
 
 	countNodeRecords       []models.TaxonomyNodeRecordCount
 	countNodeRecordsErr    error
@@ -137,6 +140,15 @@ func (m *mockTaxonomyRepo) GetRunInput(
 	_ string,
 ) (*models.TaxonomyRunInputResponse, error) {
 	return nil, nil
+}
+
+func (m *mockTaxonomyRepo) GetRunInputRecordIDs(
+	_ context.Context,
+	_ uuid.UUID,
+	_ string,
+	_ string,
+) ([]uuid.UUID, error) {
+	return m.selectedRecordIDs, m.selectedRecordIDsErr
 }
 
 func (m *mockTaxonomyRepo) StoreResultAndActivate(
@@ -518,6 +530,32 @@ func TestTaxonomyService_FailRunIsIdempotentForIdenticalTerminalCallback(t *test
 	}
 }
 
+func TestTaxonomyService_FailRunNormalizesEmptyTerminalMetrics(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222226")
+	message := "provider request failed"
+	code := models.TaxonomyRunFailureCodeServiceUnavailable
+	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{
+		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusFailed,
+		Error: &message, ErrorCode: &code, Metrics: json.RawMessage(`{}`),
+	}}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	run, err := svc.FailRun(context.Background(), runID, models.TaxonomyRunFailedRequest{
+		Error: message, ErrorCode: code,
+	})
+	if err != nil {
+		t.Fatalf("FailRun() error = %v", err)
+	}
+
+	if run != repo.internalRun {
+		t.Fatal("FailRun() did not return the existing terminal run")
+	}
+
+	if repo.markRunFailedCalls != 0 {
+		t.Fatalf("MarkRunFailed() calls = %d, want 0", repo.markRunFailedCalls)
+	}
+}
+
 func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *testing.T) {
 	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222225")
 	firstID := uuid.MustParse("018e1234-5678-9abc-def0-100000000001")
@@ -567,9 +605,12 @@ func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *
 		t.Fatalf("digest changed with ordering: %q != %q", firstDigest, secondDigest)
 	}
 
-	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{
-		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusRunning,
-	}}
+	repo := &mockTaxonomyRepo{
+		internalRun: &models.TaxonomyRun{
+			ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusRunning,
+		},
+		selectedRecordIDs: []uuid.UUID{firstID, secondID},
+	}
 	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
 
 	run, err := svc.CompleteRun(context.Background(), runID, req)
@@ -585,7 +626,7 @@ func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *
 		t.Fatalf("StoreResultAndActivate() calls=%d tenant=%q", repo.storeResultCalls, repo.storeResultTenant)
 	}
 
-	if got := taxonomyMetricString(repo.storeResultRequest.Metrics, "result_digest"); got != firstDigest {
+	if got := jsonutil.ObjectString(repo.storeResultRequest.Metrics, "result_digest"); got != firstDigest {
 		t.Fatalf("persisted result digest = %q, want %q", got, firstDigest)
 	}
 
@@ -599,6 +640,28 @@ func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *
 
 	if repo.storeResultCalls != 1 {
 		t.Fatalf("StoreResultAndActivate() calls after retry = %d, want 1", repo.storeResultCalls)
+	}
+}
+
+func TestTaxonomyService_CompleteRunRejectsIncompleteSelectedInputCoverage(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222227")
+	selectedID := uuid.MustParse("018e1234-5678-9abc-def0-100000000003")
+	missingID := uuid.MustParse("018e1234-5678-9abc-def0-100000000004")
+	repo := &mockTaxonomyRepo{
+		internalRun: &models.TaxonomyRun{
+			ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusRunning,
+		},
+		selectedRecordIDs: []uuid.UUID{selectedID, missingID},
+	}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	_, err := svc.CompleteRun(context.Background(), runID, validTaxonomyServiceResult(selectedID))
+	if err == nil {
+		t.Fatal("CompleteRun() error = nil, want selected-input coverage validation error")
+	}
+
+	if repo.storeResultCalls != 0 {
+		t.Fatalf("StoreResultAndActivate() calls = %d, want 0", repo.storeResultCalls)
 	}
 }
 
@@ -651,4 +714,34 @@ func TestTaxonomyService_GetNodeRecordCounts(t *testing.T) {
 			t.Fatal("GetNodeRecordCounts() = nil error, want propagated repo error")
 		}
 	})
+}
+
+func validTaxonomyServiceResult(feedbackRecordID uuid.UUID) models.TaxonomyRunResultRequest {
+	label := "Login"
+
+	return models.TaxonomyRunResultRequest{
+		Clusters: []models.TaxonomyResultCluster{{ClusterKey: 1, Label: &label, Size: 1}},
+		Memberships: []models.TaxonomyResultMembership{
+			{ClusterKey: 1, FeedbackRecordID: feedbackRecordID},
+		},
+		Nodes: []models.TaxonomyResultNode{
+			{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
+			{
+				NodeKey: "level-2", ParentKey: new("root"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Experience", Level: 1,
+			},
+			{
+				NodeKey: "level-3", ParentKey: new("level-2"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Account Access", Level: 2,
+			},
+			{
+				NodeKey: "level-4", ParentKey: new("level-3"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Authentication", Level: 3,
+			},
+			{
+				NodeKey: "leaf", ParentKey: new("level-4"), ClusterKey: new(1),
+				NodeType: models.TaxonomyNodeTypeLeaf, Label: label, Level: 4,
+			},
+		},
+	}
 }

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -24,7 +24,12 @@ type mockTaxonomyRepo struct {
 	markRunFailedCode    models.TaxonomyRunFailureCode
 	markRunFailedTenant  string
 	markRunFailedMetrics json.RawMessage
+	markRunFailedCalls   int
 	heartbeatTenant      string
+	storeResultTenant    string
+	storeResultRequest   models.TaxonomyRunResultRequest
+	storeResultRun       *models.TaxonomyRun
+	storeResultCalls     int
 
 	countNodeRecords       []models.TaxonomyNodeRecordCount
 	countNodeRecordsErr    error
@@ -75,6 +80,7 @@ func (m *mockTaxonomyRepo) MarkRunFailed(
 	errorCode models.TaxonomyRunFailureCode,
 	metrics json.RawMessage,
 ) (*models.TaxonomyRun, error) {
+	m.markRunFailedCalls++
 	m.markRunFailedTenant = tenantID
 	m.markRunFailedMessage = message
 	m.markRunFailedCode = errorCode
@@ -135,11 +141,19 @@ func (m *mockTaxonomyRepo) GetRunInput(
 
 func (m *mockTaxonomyRepo) StoreResultAndActivate(
 	_ context.Context,
-	_ uuid.UUID,
-	_ string,
-	_ models.TaxonomyRunResultRequest,
+	runID uuid.UUID,
+	tenantID string,
+	req models.TaxonomyRunResultRequest,
 ) (*models.TaxonomyRun, error) {
-	return nil, nil
+	m.storeResultCalls++
+	m.storeResultTenant = tenantID
+	m.storeResultRequest = req
+
+	if m.storeResultRun != nil {
+		return m.storeResultRun, nil
+	}
+
+	return &models.TaxonomyRun{ID: runID, TenantID: tenantID, Status: models.TaxonomyRunStatusSucceeded}, nil
 }
 
 func (m *mockTaxonomyRepo) GetTree(
@@ -283,6 +297,107 @@ func TestTaxonomyService_StartManualRunMarksServiceUnavailableFailure(t *testing
 	}
 }
 
+func TestTaxonomyService_StartManualRunRequiresNinetyPercentEmbeddingCoverage(t *testing.T) {
+	repo := &mockTaxonomyRepo{countRecordCount: 100, countEmbeddingCount: 89}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{
+		Repo:           repo,
+		Starter:        successfulTaxonomyStarter{},
+		EmbeddingModel: "text-embedding-004",
+	})
+
+	result, err := svc.StartManualRun(context.Background(), models.CreateTaxonomyRunRequest{
+		TaxonomyScope: models.TaxonomyScope{
+			TenantID:   "tenant-1",
+			SourceType: "survey",
+			FieldID:    "question-1",
+		},
+	})
+	if err == nil {
+		t.Fatal("StartManualRun() error = nil, want embedding coverage validation error")
+	}
+
+	if result != nil {
+		t.Fatalf("StartManualRun() result = %+v, want nil", result)
+	}
+
+	if repo.createRun != nil || len(repo.createRunParams.Params) != 0 {
+		t.Fatal("CreateRunIfAvailable() was called for insufficient embedding coverage")
+	}
+}
+
+func TestTaxonomyService_StartManualRunMeasuresCoverageAgainstTheSelectedCap(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-111111111113")
+	repo := &mockTaxonomyRepo{
+		countRecordCount:    20_000,
+		countEmbeddingCount: 10_000,
+		createRun:           &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusPending},
+		createRunCreated:    true,
+	}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{
+		Repo:           repo,
+		Starter:        successfulTaxonomyStarter{},
+		EmbeddingModel: "text-embedding-004",
+	})
+
+	_, err := svc.StartManualRun(context.Background(), models.CreateTaxonomyRunRequest{
+		TaxonomyScope: models.TaxonomyScope{
+			TenantID:   "tenant-1",
+			SourceType: "survey",
+			FieldID:    "question-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartManualRun() error = %v", err)
+	}
+}
+
+func TestTaxonomyService_StartManualRunStoresBoundedSelectionContract(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-111111111112")
+	repo := &mockTaxonomyRepo{
+		countRecordCount:    12_000,
+		countEmbeddingCount: 11_000,
+		createRun:           &models.TaxonomyRun{ID: runID, Status: models.TaxonomyRunStatusPending},
+		createRunCreated:    true,
+	}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{
+		Repo:           repo,
+		Starter:        successfulTaxonomyStarter{},
+		EmbeddingModel: "text-embedding-004",
+	})
+
+	_, err := svc.StartManualRun(context.Background(), models.CreateTaxonomyRunRequest{
+		TaxonomyScope: models.TaxonomyScope{
+			TenantID:   "tenant-1",
+			SourceType: "survey",
+			FieldID:    "question-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartManualRun() error = %v", err)
+	}
+
+	var params struct {
+		InputSelection struct {
+			EligibleCount          int    `json:"eligible_count"`
+			EmbeddingEligibleCount int    `json:"embedding_eligible_count"`
+			SelectedCount          int    `json:"selected_count"`
+			SelectionCap           int    `json:"selection_cap"`
+			TruncationFlag         bool   `json:"truncation_flag"`
+			SelectionStrategy      string `json:"selection_strategy"`
+		} `json:"input_selection"`
+	}
+	if err := json.Unmarshal(repo.createRunParams.Params, &params); err != nil {
+		t.Fatalf("unmarshal run params: %v", err)
+	}
+
+	selection := params.InputSelection
+	if selection.EligibleCount != 12_000 || selection.EmbeddingEligibleCount != 11_000 ||
+		selection.SelectedCount != 10_000 || selection.SelectionCap != 10_000 ||
+		!selection.TruncationFlag || selection.SelectionStrategy != "most_recent" {
+		t.Fatalf("input selection = %+v", selection)
+	}
+}
+
 func TestTaxonomyService_HeartbeatResolvesTenant(t *testing.T) {
 	runID := uuid.MustParse("018e1234-5678-9abc-def0-333333333333")
 	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{ID: runID, TenantID: "tenant-7"}}
@@ -361,6 +476,129 @@ func TestTaxonomyService_FailRunPersistsSafeDiagnosticsInMetrics(t *testing.T) {
 
 	if diagnostics.TotalTokens == nil || *diagnostics.TotalTokens != 42 {
 		t.Fatalf("persisted total tokens = %v", diagnostics.TotalTokens)
+	}
+}
+
+func TestTaxonomyService_FailRunIsIdempotentForIdenticalTerminalCallback(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222224")
+	message := "provider request failed"
+	code := models.TaxonomyRunFailureCodeServiceUnavailable
+	diagnostics := &models.TaxonomyRunFailureDiagnostics{
+		Phase:            "taxonomy_generation",
+		FailureReason:    "provider_timeout",
+		GenerationStep:   "hierarchy_plan",
+		ValidationReason: "none",
+		RecoveryAction:   "provider_retry",
+	}
+
+	metrics, err := marshalFailureDiagnostics(diagnostics)
+	if err != nil {
+		t.Fatalf("marshal diagnostics: %v", err)
+	}
+
+	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{
+		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusFailed,
+		Error: &message, ErrorCode: &code, Metrics: metrics,
+	}}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	run, err := svc.FailRun(context.Background(), runID, models.TaxonomyRunFailedRequest{
+		Error: message, ErrorCode: code, Diagnostics: diagnostics,
+	})
+	if err != nil {
+		t.Fatalf("FailRun() error = %v", err)
+	}
+
+	if run != repo.internalRun {
+		t.Fatal("FailRun() did not return the existing terminal run")
+	}
+
+	if repo.markRunFailedCalls != 0 {
+		t.Fatalf("MarkRunFailed() calls = %d, want 0", repo.markRunFailedCalls)
+	}
+}
+
+func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222225")
+	firstID := uuid.MustParse("018e1234-5678-9abc-def0-100000000001")
+	secondID := uuid.MustParse("018e1234-5678-9abc-def0-100000000002")
+	firstLabel, secondLabel := "First", "Second"
+	req := models.TaxonomyRunResultRequest{
+		Metrics: json.RawMessage(`{"duration_seconds":12}`),
+		Clusters: []models.TaxonomyResultCluster{
+			{ClusterKey: 2, Label: &secondLabel, Size: 1},
+			{ClusterKey: 1, Label: &firstLabel, Size: 1},
+		},
+		Memberships: []models.TaxonomyResultMembership{
+			{ClusterKey: 2, FeedbackRecordID: secondID},
+			{ClusterKey: 1, FeedbackRecordID: firstID},
+		},
+		Nodes: []models.TaxonomyResultNode{
+			{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
+			{NodeKey: "level-2", ParentKey: new("root"), NodeType: models.TaxonomyNodeTypeBranch, Label: "Experience", Level: 1},
+			{NodeKey: "level-3", ParentKey: new("level-2"), NodeType: models.TaxonomyNodeTypeBranch, Label: "Product", Level: 2},
+			{NodeKey: "level-4", ParentKey: new("level-3"), NodeType: models.TaxonomyNodeTypeBranch, Label: "Specific Topics", Level: 3},
+			{NodeKey: "leaf-2", ParentKey: new("level-4"), ClusterKey: new(2), NodeType: models.TaxonomyNodeTypeLeaf, Label: secondLabel, Level: 4},
+			{
+				NodeKey: "leaf-1", ParentKey: new("level-4"), ClusterKey: new(1),
+				NodeType: models.TaxonomyNodeTypeLeaf, Label: firstLabel, Level: 4, SortOrder: 1,
+			},
+		},
+	}
+
+	reordered := req
+	reordered.Clusters = []models.TaxonomyResultCluster{req.Clusters[1], req.Clusters[0]}
+	reordered.Memberships = []models.TaxonomyResultMembership{req.Memberships[1], req.Memberships[0]}
+	reordered.Nodes = []models.TaxonomyResultNode{
+		req.Nodes[5], req.Nodes[4], req.Nodes[3], req.Nodes[2], req.Nodes[1], req.Nodes[0],
+	}
+
+	firstDigest, err := canonicalTaxonomyResultDigest(req)
+	if err != nil {
+		t.Fatalf("canonicalTaxonomyResultDigest() error = %v", err)
+	}
+
+	secondDigest, err := canonicalTaxonomyResultDigest(reordered)
+	if err != nil {
+		t.Fatalf("canonicalTaxonomyResultDigest(reordered) error = %v", err)
+	}
+
+	if firstDigest != secondDigest {
+		t.Fatalf("digest changed with ordering: %q != %q", firstDigest, secondDigest)
+	}
+
+	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{
+		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusRunning,
+	}}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	run, err := svc.CompleteRun(context.Background(), runID, req)
+	if err != nil {
+		t.Fatalf("CompleteRun() error = %v", err)
+	}
+
+	if run.Status != models.TaxonomyRunStatusSucceeded {
+		t.Fatalf("CompleteRun() status = %q", run.Status)
+	}
+
+	if repo.storeResultCalls != 1 || repo.storeResultTenant != "tenant-1" {
+		t.Fatalf("StoreResultAndActivate() calls=%d tenant=%q", repo.storeResultCalls, repo.storeResultTenant)
+	}
+
+	if got := taxonomyMetricString(repo.storeResultRequest.Metrics, "result_digest"); got != firstDigest {
+		t.Fatalf("persisted result digest = %q, want %q", got, firstDigest)
+	}
+
+	repo.internalRun = &models.TaxonomyRun{
+		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusSucceeded,
+		Metrics: repo.storeResultRequest.Metrics,
+	}
+	if _, err := svc.CompleteRun(context.Background(), runID, reordered); err != nil {
+		t.Fatalf("idempotent CompleteRun() error = %v", err)
+	}
+
+	if repo.storeResultCalls != 1 {
+		t.Fatalf("StoreResultAndActivate() calls after retry = %d, want 1", repo.storeResultCalls)
 	}
 }
 

--- a/internal/service/taxonomy_service_test.go
+++ b/internal/service/taxonomy_service_test.go
@@ -146,7 +146,6 @@ func (m *mockTaxonomyRepo) GetRunInputRecordIDs(
 	_ context.Context,
 	_ uuid.UUID,
 	_ string,
-	_ string,
 ) ([]uuid.UUID, error) {
 	return m.selectedRecordIDs, m.selectedRecordIDsErr
 }
@@ -640,6 +639,25 @@ func TestTaxonomyService_CompleteRunAddsCanonicalDigestAndIsOrderIndependent(t *
 
 	if repo.storeResultCalls != 1 {
 		t.Fatalf("StoreResultAndActivate() calls after retry = %d, want 1", repo.storeResultCalls)
+	}
+}
+
+func TestTaxonomyService_CompleteRunKeepsLegacySucceededRunFailSafe(t *testing.T) {
+	runID := uuid.MustParse("018e1234-5678-9abc-def0-222222222226")
+	recordID := uuid.MustParse("018e1234-5678-9abc-def0-100000000005")
+	repo := &mockTaxonomyRepo{internalRun: &models.TaxonomyRun{
+		ID: runID, TenantID: "tenant-1", Status: models.TaxonomyRunStatusSucceeded,
+		Metrics: json.RawMessage(`{}`),
+	}}
+	svc := NewTaxonomyService(NewTaxonomyServiceParams{Repo: repo})
+
+	_, err := svc.CompleteRun(context.Background(), runID, validTaxonomyServiceResult(recordID))
+	if err == nil {
+		t.Fatal("CompleteRun() error = nil for legacy succeeded run without a digest")
+	}
+
+	if repo.storeResultCalls != 0 {
+		t.Fatalf("StoreResultAndActivate() calls = %d, want 0", repo.storeResultCalls)
 	}
 }
 

--- a/internal/workers/feedback_records_purge.go
+++ b/internal/workers/feedback_records_purge.go
@@ -91,6 +91,7 @@ func logPurgeFailure(
 			"deleted_feedback_records", counts.DeletedFeedbackRecords,
 			"deleted_embeddings", counts.DeletedEmbeddings,
 			"deleted_taxonomy_cluster_memberships", counts.ClusterMemberships,
+			"deleted_taxonomy_run_input_records", counts.InputRecords,
 			"deleted_taxonomy_runs", counts.Runs,
 			"deleted_taxonomy_nodes", counts.Nodes,
 		)

--- a/migrations/023_taxonomy_run_input_snapshot.sql
+++ b/migrations/023_taxonomy_run_input_snapshot.sql
@@ -1,0 +1,20 @@
+-- +goose up
+-- Freeze the exact bounded feedback-record selection handed to the taxonomy
+-- service. Completion validates memberships against this snapshot rather than
+-- re-running the live "most recent" query, whose window can move while a long
+-- generation is in flight.
+CREATE TABLE taxonomy_run_input_records (
+  run_id UUID NOT NULL,
+  tenant_id VARCHAR(255) NOT NULL,
+  feedback_record_id UUID NOT NULL,
+  sort_order INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (run_id, feedback_record_id),
+  UNIQUE (run_id, sort_order),
+  FOREIGN KEY (run_id, tenant_id) REFERENCES taxonomy_runs(id, tenant_id) ON DELETE CASCADE,
+  CONSTRAINT taxonomy_run_input_records_tenant_id_required CHECK (btrim(tenant_id) <> ''),
+  CONSTRAINT taxonomy_run_input_records_sort_order_nonnegative CHECK (sort_order >= 0)
+);
+
+-- +goose down
+DROP TABLE IF EXISTS taxonomy_run_input_records;

--- a/migrations/023_taxonomy_run_input_snapshot.sql
+++ b/migrations/023_taxonomy_run_input_snapshot.sql
@@ -3,6 +3,15 @@
 -- service. Completion validates memberships against this snapshot rather than
 -- re-running the live "most recent" query, whose window can move while a long
 -- generation is in flight.
+--
+-- The compatibility bit deliberately records materialization, not which Hub
+-- version created the run. During a rolling deploy a new replica may create a
+-- run whose /input request lands on an old replica that cannot snapshot it.
+-- Such a run must retain the old completion contract. A new /input handler
+-- flips the bit in the same transaction that creates or reuses the snapshot.
+ALTER TABLE taxonomy_runs
+  ADD COLUMN input_snapshot_materialized BOOLEAN NOT NULL DEFAULT false;
+
 CREATE TABLE taxonomy_run_input_records (
   run_id UUID NOT NULL,
   tenant_id VARCHAR(255) NOT NULL,
@@ -18,3 +27,4 @@ CREATE TABLE taxonomy_run_input_records (
 
 -- +goose down
 DROP TABLE IF EXISTS taxonomy_run_input_records;
+ALTER TABLE taxonomy_runs DROP COLUMN IF EXISTS input_snapshot_materialized;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1259,6 +1259,7 @@ paths:
                                         deleted_embeddings: 17
                                         deleted_webhooks: 3
                                         deleted_taxonomy_runs: 4
+                                        deleted_taxonomy_run_input_records: 1200
                                         deleted_taxonomy_clusters: 28
                                         deleted_taxonomy_cluster_memberships: 1200
                                         deleted_taxonomy_nodes: 36
@@ -2789,6 +2790,10 @@ components:
                     type: integer
                     description: Number of taxonomy runs deleted
                     format: int64
+                deleted_taxonomy_run_input_records:
+                    type: integer
+                    description: Number of immutable taxonomy run-input snapshot rows deleted
+                    format: int64
                 deleted_taxonomy_clusters:
                     type: integer
                     description: Number of taxonomy clusters deleted
@@ -2818,6 +2823,7 @@ components:
                 - deleted_embeddings
                 - deleted_webhooks
                 - deleted_taxonomy_runs
+                - deleted_taxonomy_run_input_records
                 - deleted_taxonomy_clusters
                 - deleted_taxonomy_cluster_memberships
                 - deleted_taxonomy_nodes

--- a/tests/feedback_records_purge_test.go
+++ b/tests/feedback_records_purge_test.go
@@ -135,6 +135,7 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 		assert.Equal(t, int64(1), counts.DeletedEmbeddings)
 		assert.Equal(t, int64(1), counts.ClusterMemberships)
 		assert.Equal(t, int64(1), counts.Runs)
+		assert.Equal(t, int64(1), counts.InputRecords)
 		assert.Equal(t, int64(1), counts.Clusters)
 		assert.Equal(t, int64(3), counts.Nodes)
 		assert.Equal(t, int64(1), counts.ActiveRuns)
@@ -148,6 +149,8 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 			`SELECT count(*) FROM embeddings WHERE feedback_record_id = $1`, ids.FeedbackRecordID))
 		assert.Zero(t, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, tenantID))
+		assert.Zero(t, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_run_input_records WHERE tenant_id = $1`, tenantID))
 	})
 
 	// The failure markers carry a tenant_id, so one surviving its records is tenant-scoped data
@@ -200,6 +203,8 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 		assert.Equal(t, 1, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_cluster_memberships WHERE tenant_id = $1`, otherTenantID))
 		assert.Equal(t, 1, countRows(ctx, t, db,
+			`SELECT count(*) FROM taxonomy_run_input_records WHERE tenant_id = $1`, otherTenantID))
+		assert.Equal(t, 1, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_runs WHERE id = $1`, otherIDs.RunID))
 		assert.Equal(t, 3, countRows(ctx, t, db,
 			`SELECT count(*) FROM taxonomy_nodes WHERE run_id = $1`, otherIDs.RunID))
@@ -215,6 +220,7 @@ func TestPurgeFeedbackRecordsByTenant(t *testing.T) {
 		assert.Zero(t, repeat.DeletedFeedbackRecords)
 		assert.Zero(t, repeat.DeletedEmbeddings)
 		assert.Zero(t, repeat.ClusterMemberships)
+		assert.Zero(t, repeat.InputRecords)
 		assert.Zero(t, repeat.Runs)
 		assert.Zero(t, repeat.Nodes)
 	})

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1100,6 +1100,7 @@ func TestDeleteTenantData(t *testing.T) {
 	// createTenantDataTaxonomyGraph builds one run with one cluster, one
 	// membership, three nodes (root/branch/leaf), one active run, and one event.
 	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyRuns)
+	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyRunInputRecords)
 	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyClusters)
 	assert.Equal(t, int64(1), deleteResp.DeletedTaxonomyClusterMemberships)
 	assert.Equal(t, int64(3), deleteResp.DeletedTaxonomyNodes)
@@ -1133,6 +1134,7 @@ func TestDeleteTenantData(t *testing.T) {
 	assert.Equal(t, int64(0), repeatedResp.DeletedEmbeddings)
 	assert.Equal(t, int64(0), repeatedResp.DeletedWebhooks)
 	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyRuns)
+	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyRunInputRecords)
 	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyClusters)
 	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyClusterMemberships)
 	assert.Equal(t, int64(0), repeatedResp.DeletedTaxonomyNodes)
@@ -1277,6 +1279,11 @@ func createTenantDataTaxonomyGraph(
 		RETURNING id`,
 		tenantID, sourceID, fieldID,
 	).Scan(&runID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO taxonomy_run_input_records (run_id, tenant_id, feedback_record_id, sort_order)
+		VALUES ($1, $2, $3, 0)`, runID, tenantID, feedbackRecordID)
 	require.NoError(t, err)
 
 	var clusterID uuid.UUID

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -1016,6 +1016,95 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		assertTaxonomyRunUnchanged(ctx, t, harness, runID, scope.TenantID)
 	})
 
+	t.Run("deleted snapshotted input fails fast as a conflict", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-deleted-snapshot-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordID := seedEmbeddedFeedback(ctx, t, harness, scope, 1)[0]
+		runID := startRunForScope(ctx, t, harness, scope)
+		materializeTaxonomyRunInput(ctx, t, harness, runID)
+
+		_, err := harness.db.Exec(ctx, `DELETE FROM feedback_records WHERE id = $1`, feedbackRecordID)
+		require.NoError(t, err)
+
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+		requestTaxonomyProblem(
+			ctx, t, http.MethodGet, inputURL, harness.internalToken, nil,
+			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict,
+		)
+
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+		requestTaxonomyProblem(
+			ctx, t, http.MethodPut, resultURL, harness.internalToken, validTaxonomyResult(feedbackRecordID),
+			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict,
+		)
+		assertTaxonomyRunUnchanged(ctx, t, harness, runID, scope.TenantID)
+	})
+
+	t.Run("legacy in-flight run without a snapshot keeps its original completion contract", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-legacy-no-snapshot")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+
+		var runID uuid.UUID
+
+		err := harness.db.QueryRow(ctx, `
+			INSERT INTO taxonomy_runs (
+				tenant_id, scope_type, source_type, source_id, field_id, status,
+				record_count, embedding_count, started_at
+			)
+			VALUES ($1, 'field', $2, $3, $4, 'running', 1, 1, NOW())
+			RETURNING id`, scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID,
+		).Scan(&runID)
+		require.NoError(t, err)
+
+		var completed models.TaxonomyRun
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPut,
+			harness.server.URL+"/internal/v1/taxonomy/runs/"+runID.String()+"/result",
+			harness.internalToken,
+			validTaxonomyResult(feedbackRecordID),
+			http.StatusOK,
+			&completed,
+		)
+		assert.Equal(t, models.TaxonomyRunStatusSucceeded, completed.Status)
+	})
+
+	t.Run("legacy result referencing a deleted record fails fast as a conflict", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-legacy-deleted-input")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+
+		var runID uuid.UUID
+
+		err := harness.db.QueryRow(ctx, `
+			INSERT INTO taxonomy_runs (
+				tenant_id, scope_type, source_type, source_id, field_id, status,
+				record_count, embedding_count, started_at
+			)
+			VALUES ($1, 'field', $2, $3, $4, 'running', 1, 1, NOW())
+			RETURNING id`, scope.TenantID, scope.SourceType, scope.SourceID, scope.FieldID,
+		).Scan(&runID)
+		require.NoError(t, err)
+
+		_, err = harness.db.Exec(ctx, `DELETE FROM feedback_records WHERE id = $1`, feedbackRecordID)
+		require.NoError(t, err)
+
+		requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPut,
+			harness.server.URL+"/internal/v1/taxonomy/runs/"+runID.String()+"/result",
+			harness.internalToken,
+			validTaxonomyResult(feedbackRecordID),
+			http.StatusConflict,
+			response.CodeConflict,
+			response.ProblemTypeConflict,
+		)
+		assertTaxonomyRunUnchanged(ctx, t, harness, runID, scope.TenantID)
+	})
+
 	t.Run("failed payload validation is machine readable", func(t *testing.T) {
 		problem := requestTaxonomyProblem(
 			ctx,

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -808,10 +808,12 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 
 		fieldIDs := map[string]bool{}
 		sourceTypes := map[string]bool{}
+		selectedRecordIDs := make([]uuid.UUID, 0, len(input.Records))
 
 		for _, record := range input.Records {
 			fieldIDs[record.FieldID] = true
 			sourceTypes[record.SourceType] = true
+			selectedRecordIDs = append(selectedRecordIDs, record.FeedbackRecordID)
 			assert.NotEmpty(t, record.Embedding)
 			assert.NotEmpty(t, record.ValueText)
 		}
@@ -820,6 +822,18 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		assert.True(t, fieldIDs["support_comment"])
 		assert.True(t, sourceTypes["formbricks"])
 		assert.True(t, sourceTypes["support"])
+
+		// Feedback can arrive while a long taxonomy generation is in flight. The completion
+		// contract must remain the exact cross-field directory snapshot returned above; the new,
+		// more-recent row must neither become required nor displace an already-selected row.
+		seedEmbeddedFeedback(ctx, t, harness, firstFieldScope, 1)
+
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+
+		var completed models.TaxonomyRun
+		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, harness.internalToken,
+			validTaxonomyResultForRecords(selectedRecordIDs), http.StatusOK, &completed)
+		assert.Equal(t, models.TaxonomyRunStatusSucceeded, completed.Status)
 	})
 
 	t.Run("complete run stores artifacts and activates", func(t *testing.T) {
@@ -836,6 +850,8 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		// Auth is required.
 		requestTaxonomyProblem(ctx, t, http.MethodPut, resultURL, "", result,
 			http.StatusUnauthorized, response.CodeUnauthorized, response.ProblemTypeUnauthorized)
+
+		materializeTaxonomyRunInput(ctx, t, harness, runID)
 
 		var run models.TaxonomyRun
 		requestTaxonomyJSON(ctx, t, http.MethodPut, resultURL, harness.internalToken, result, http.StatusOK, &run)
@@ -982,6 +998,7 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 		feedbackRecordIDs := seedEmbeddedFeedback(ctx, t, harness, scope, 2)
 		runID := startRunForScope(ctx, t, harness, scope)
+		materializeTaxonomyRunInput(ctx, t, harness, runID)
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 
 		problem := requestTaxonomyProblem(
@@ -1123,6 +1140,7 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 		feedbackRecordID := seedEmbeddedFeedback(ctx, t, harness, scope, 1)[0]
 		runID := startRunForScope(ctx, t, harness, scope)
+		materializeTaxonomyRunInput(ctx, t, harness, runID)
 		result := validTaxonomyResult(feedbackRecordID)
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 
@@ -1303,6 +1321,20 @@ func startRunForScope(ctx context.Context, t *testing.T, harness *taxonomyTestSe
 	return run.ID
 }
 
+func materializeTaxonomyRunInput(
+	ctx context.Context,
+	t *testing.T,
+	harness *taxonomyTestServer,
+	runID uuid.UUID,
+) {
+	t.Helper()
+
+	var input models.TaxonomyRunInputResponse
+	requestTaxonomyJSON(ctx, t, http.MethodGet,
+		harness.server.URL+"/internal/v1/taxonomy/runs/"+runID.String()+"/input",
+		harness.internalToken, nil, http.StatusOK, &input)
+}
+
 // createRunningRun creates a run in the running state without requiring seeded embeddings,
 // for internal endpoints that only need a run in the correct state.
 func createRunningRun(ctx context.Context, t *testing.T, harness *taxonomyTestServer, scope models.TaxonomyScope) uuid.UUID {
@@ -1349,13 +1381,22 @@ func assertTaxonomyRunUnchanged(
 }
 
 func validTaxonomyResult(feedbackRecordID uuid.UUID) models.TaxonomyRunResultRequest {
+	return validTaxonomyResultForRecords([]uuid.UUID{feedbackRecordID})
+}
+
+func validTaxonomyResultForRecords(feedbackRecordIDs []uuid.UUID) models.TaxonomyRunResultRequest {
+	memberships := make([]models.TaxonomyResultMembership, 0, len(feedbackRecordIDs))
+	for _, feedbackRecordID := range feedbackRecordIDs {
+		memberships = append(memberships, models.TaxonomyResultMembership{
+			ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9),
+		})
+	}
+
 	return models.TaxonomyRunResultRequest{
 		Clusters: []models.TaxonomyResultCluster{
-			{ClusterKey: 1, Label: new("login"), Size: 1},
+			{ClusterKey: 1, Label: new("login"), Size: len(feedbackRecordIDs)},
 		},
-		Memberships: []models.TaxonomyResultMembership{
-			{ClusterKey: 1, FeedbackRecordID: feedbackRecordID, Confidence: new(0.9)},
-		},
+		Memberships: memberships,
 		Nodes: []models.TaxonomyResultNode{
 			{
 				NodeKey:  "root",

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -1141,6 +1141,7 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		feedbackRecordID := seedEmbeddedFeedback(ctx, t, harness, scope, 1)[0]
 		runID := startRunForScope(ctx, t, harness, scope)
 		materializeTaxonomyRunInput(ctx, t, harness, runID)
+
 		result := validTaxonomyResult(feedbackRecordID)
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -659,6 +659,25 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		assert.NotEmpty(t, input.Records[0].ValueText)
 	})
 
+	t.Run("run input selection metadata reflects records actually returned", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-input-selection")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		seedEmbeddedFeedback(ctx, t, harness, scope, 1)
+		insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+
+		runID := startRunForScope(ctx, t, harness, scope)
+		inputURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/input"
+
+		var input models.TaxonomyRunInputResponse
+		requestTaxonomyJSON(ctx, t, http.MethodGet, inputURL, harness.internalToken, nil, http.StatusOK, &input)
+		require.Len(t, input.Records, 1)
+		assert.Equal(t, 2, input.Run.EligibleCount)
+		assert.Equal(t, 1, input.Run.SelectedCount)
+		assert.Equal(t, repository.MaxTaxonomyRunInputRows, input.Run.SelectionCap)
+		assert.True(t, input.Run.SelectionTruncated)
+		assert.Equal(t, "most_recent", input.Run.SelectionStrategy)
+	})
+
 	t.Run("get run input never includes another tenant's matching records", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-internal-input-tenant")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
@@ -807,8 +826,8 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-internal-complete")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 
-		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
-		runID := createRunningRun(ctx, t, harness, scope)
+		feedbackRecordID := seedEmbeddedFeedback(ctx, t, harness, scope, 1)[0]
+		runID := startRunForScope(ctx, t, harness, scope)
 
 		result := validTaxonomyResult(feedbackRecordID)
 
@@ -954,6 +973,30 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 			ctx, t, http.MethodPut, resultURL, harness.internalToken, invalidDepth,
 			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation,
 		)
+
+		assertTaxonomyRunUnchanged(ctx, t, harness, runID, scope.TenantID)
+	})
+
+	t.Run("incomplete selected input coverage is rejected before persistence", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-incomplete-coverage")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordIDs := seedEmbeddedFeedback(ctx, t, harness, scope, 2)
+		runID := startRunForScope(ctx, t, harness, scope)
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+
+		problem := requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPut,
+			resultURL,
+			harness.internalToken,
+			validTaxonomyResult(feedbackRecordIDs[0]),
+			http.StatusBadRequest,
+			response.CodeValidation,
+			response.ProblemTypeValidation,
+		)
+		assertTaxonomyInvalidParam(t, problem, "memberships", "selected run input")
+		assertTaxonomyRunUnchanged(ctx, t, harness, runID, scope.TenantID)
 	})
 
 	t.Run("failed payload validation is machine readable", func(t *testing.T) {
@@ -1011,6 +1054,27 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("failed diagnostics nested counts are bounded", func(t *testing.T) {
+		problem := requestTaxonomyProblem(
+			ctx,
+			t,
+			http.MethodPost,
+			harness.server.URL+"/internal/v1/taxonomy/runs/"+unknownRunID.String()+"/failed",
+			harness.internalToken,
+			models.TaxonomyRunFailedRequest{
+				Error:     "generation failed",
+				ErrorCode: models.TaxonomyRunFailureCodeGenerationFailed,
+				Diagnostics: &models.TaxonomyRunFailureDiagnostics{
+					PartialMetrics: &models.TaxonomyRunPartialMetrics{ClusterCount: 5000},
+				},
+			},
+			http.StatusBadRequest,
+			response.CodeValidation,
+			response.ProblemTypeValidation,
+		)
+		assertTaxonomyInvalidParam(t, problem, "cluster_count", "1000")
+	})
+
 	tests := []struct {
 		name   string
 		method string
@@ -1057,8 +1121,8 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 	t.Run("repeating an identical result is idempotent but a different result conflicts", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-internal-complete-conflict")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
-		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
-		runID := createRunningRun(ctx, t, harness, scope)
+		feedbackRecordID := seedEmbeddedFeedback(ctx, t, harness, scope, 1)[0]
+		runID := startRunForScope(ctx, t, harness, scope)
 		result := validTaxonomyResult(feedbackRecordID)
 		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
 
@@ -1254,6 +1318,34 @@ func createRunningRun(ctx context.Context, t *testing.T, harness *taxonomyTestSe
 	require.NoError(t, err)
 
 	return run.ID
+}
+
+func assertTaxonomyRunUnchanged(
+	ctx context.Context,
+	t *testing.T,
+	harness *taxonomyTestServer,
+	runID uuid.UUID,
+	tenantID string,
+) {
+	t.Helper()
+
+	run, err := harness.repo.GetRunForTenant(ctx, runID, tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, models.TaxonomyRunStatusRunning, run.Status)
+	assert.Zero(t, run.ClusterCount)
+	assert.Zero(t, run.NodeCount)
+	assert.Equal(t, int64(0), countTenantDataRows(
+		ctx, t, harness.db, `SELECT COUNT(*) FROM taxonomy_clusters WHERE run_id = $1`, runID,
+	))
+	assert.Equal(t, int64(0), countTenantDataRows(
+		ctx, t, harness.db, `SELECT COUNT(*) FROM taxonomy_cluster_memberships WHERE run_id = $1`, runID,
+	))
+	assert.Equal(t, int64(0), countTenantDataRows(
+		ctx, t, harness.db, `SELECT COUNT(*) FROM taxonomy_nodes WHERE run_id = $1`, runID,
+	))
+	assert.Equal(t, int64(0), countTenantDataRows(
+		ctx, t, harness.db, `SELECT COUNT(*) FROM taxonomy_active_runs WHERE run_id = $1`, runID,
+	))
 }
 
 func validTaxonomyResult(feedbackRecordID uuid.UUID) models.TaxonomyRunResultRequest {

--- a/tests/taxonomy_api_test.go
+++ b/tests/taxonomy_api_test.go
@@ -839,6 +839,16 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 			ErrorCode: models.TaxonomyRunFailureCodeGenerationFailed,
 			Diagnostics: &models.TaxonomyRunFailureDiagnostics{
 				Phase: "clustering",
+				PartialMetrics: &models.TaxonomyRunPartialMetrics{
+					SelectedRecordCount:    9995,
+					ClusterCount:           80,
+					MembershipCount:        9995,
+					ClusterCapActivated:    new(true),
+					ClusterCapMergeCount:   2,
+					LabelFallbackCount:     1,
+					PostProcessingFailed:   new(false),
+					ClusteringFallbackUsed: new(false),
+				},
 				PhaseDurations: map[string]float64{
 					"input_fetch": 0.5, "input_validation": 0.1, "clustering": 2.5,
 					"evidence_selection": 0.2, "cluster_labeling": 1.2, "taxonomy_generation": 3.4,
@@ -858,7 +868,11 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 		require.NotNil(t, run.Error)
 		assert.Equal(t, "clustering did not converge", *run.Error)
 		assert.JSONEq(t,
-			`{"failure_diagnostics":{"phase":"clustering","phase_durations_seconds":{`+
+			`{"failure_diagnostics":{"phase":"clustering","partial_metrics":{`+
+				`"selected_record_count":9995,"cluster_count":80,"membership_count":9995,`+
+				`"clustering_fallback_used":false,"cluster_cap_activated":true,`+
+				`"cluster_cap_merge_count":2,"post_processing_failed":false,"label_fallback_count":1},`+
+				`"phase_durations_seconds":{`+
 				`"input_fetch":0.5,"input_validation":0.1,"clustering":2.5,"evidence_selection":0.2,`+
 				`"cluster_labeling":1.2,"taxonomy_generation":3.4,"payload_validation":0.3,"persistence":0.7}}}`,
 			string(run.Metrics),
@@ -889,8 +903,8 @@ func TestTaxonomyAPI_InternalServiceEndpoints(t *testing.T) {
 	})
 }
 
-// TestTaxonomyAPI_InternalErrors covers missing runs, malformed identifiers, and invalid
-// terminal-state transitions across the internal taxonomy service contract.
+// TestTaxonomyAPI_InternalErrors covers missing runs, malformed identifiers, and the
+// idempotent-versus-conflicting terminal-state contract of the internal taxonomy service.
 func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 	ctx := context.Background()
 	harness := setupTaxonomyAPIServer(t)
@@ -914,6 +928,32 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 			response.ProblemTypeValidation,
 		)
 		assertTaxonomyInvalidParam(t, problem, "memberships", "required")
+	})
+
+	t.Run("invalid generated topology and membership coverage are rejected before persistence", func(t *testing.T) {
+		scope := uniqueTaxonomyScope("tax-internal-invalid-output")
+		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
+		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
+		runID := createRunningRun(ctx, t, harness, scope)
+		resultURL := harness.server.URL + "/internal/v1/taxonomy/runs/" + runID.String() + "/result"
+
+		duplicateMembership := validTaxonomyResult(feedbackRecordID)
+		duplicateMembership.Clusters[0].Size = 2
+		duplicateMembership.Memberships = append(
+			duplicateMembership.Memberships,
+			duplicateMembership.Memberships[0],
+		)
+		requestTaxonomyProblem(
+			ctx, t, http.MethodPut, resultURL, harness.internalToken, duplicateMembership,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation,
+		)
+
+		invalidDepth := validTaxonomyResult(feedbackRecordID)
+		invalidDepth.Nodes[len(invalidDepth.Nodes)-1].Level = 3
+		requestTaxonomyProblem(
+			ctx, t, http.MethodPut, resultURL, harness.internalToken, invalidDepth,
+			http.StatusBadRequest, response.CodeValidation, response.ProblemTypeValidation,
+		)
 	})
 
 	t.Run("failed payload validation is machine readable", func(t *testing.T) {
@@ -1014,7 +1054,7 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		})
 	}
 
-	t.Run("completing a terminal run returns conflict", func(t *testing.T) {
+	t.Run("repeating an identical result is idempotent but a different result conflicts", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-internal-complete-conflict")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 		feedbackRecordID := insertScopeFeedbackRecord(ctx, t, harness.db, scope)
@@ -1035,11 +1075,28 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		)
 		require.Equal(t, models.TaxonomyRunStatusSucceeded, completed.Status)
 
-		requestTaxonomyProblem(ctx, t, http.MethodPut, resultURL, harness.internalToken, result,
+		var repeated models.TaxonomyRun
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPut,
+			resultURL,
+			harness.internalToken,
+			result,
+			http.StatusOK,
+			&repeated,
+		)
+		require.Equal(t, completed.ID, repeated.ID)
+		require.Equal(t, models.TaxonomyRunStatusSucceeded, repeated.Status)
+
+		differentResult := result
+		differentResult.Nodes = append([]models.TaxonomyResultNode(nil), result.Nodes...)
+		differentResult.Nodes[1].Label = "Different login theme"
+		requestTaxonomyProblem(ctx, t, http.MethodPut, resultURL, harness.internalToken, differentResult,
 			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict)
 	})
 
-	t.Run("failing a terminal run returns conflict", func(t *testing.T) {
+	t.Run("repeating an identical failure is idempotent but a different failure conflicts", func(t *testing.T) {
 		scope := uniqueTaxonomyScope("tax-internal-fail-conflict")
 		cleanupTaxonomyTenant(ctx, t, harness.db, scope.TenantID)
 		runID := createRunningRun(ctx, t, harness, scope)
@@ -1058,7 +1115,23 @@ func TestTaxonomyAPI_InternalErrors(t *testing.T) {
 		)
 		require.Equal(t, models.TaxonomyRunStatusFailed, failed.Status)
 
-		requestTaxonomyProblem(ctx, t, http.MethodPost, failedURL, harness.internalToken, failedBody,
+		var repeated models.TaxonomyRun
+		requestTaxonomyJSON(
+			ctx,
+			t,
+			http.MethodPost,
+			failedURL,
+			harness.internalToken,
+			failedBody,
+			http.StatusOK,
+			&repeated,
+		)
+		require.Equal(t, failed.ID, repeated.ID)
+		require.Equal(t, models.TaxonomyRunStatusFailed, repeated.Status)
+
+		differentFailure := failedBody
+		differentFailure.Error = "a different terminal failure"
+		requestTaxonomyProblem(ctx, t, http.MethodPost, failedURL, harness.internalToken, differentFailure,
 			http.StatusConflict, response.CodeConflict, response.ProblemTypeConflict)
 	})
 }
@@ -1086,15 +1159,35 @@ func TestTaxonomyAPI_GenerationLifecycle(t *testing.T) {
 		harness.internalToken, nil, http.StatusOK, &input)
 	require.NotEmpty(t, input.Records)
 
-	// 3. Internal service posts the generated result referencing a real input record.
+	// 3. Internal service posts a structurally complete generated result covering every input record.
+	memberships := make([]models.TaxonomyResultMembership, 0, len(input.Records))
+	for _, record := range input.Records {
+		memberships = append(memberships, models.TaxonomyResultMembership{
+			ClusterKey: 1, FeedbackRecordID: record.FeedbackRecordID, Confidence: new(0.8),
+		})
+	}
+
 	result := models.TaxonomyRunResultRequest{
-		Clusters: []models.TaxonomyResultCluster{{ClusterKey: 1, Label: new("login"), Size: len(input.Records)}},
-		Memberships: []models.TaxonomyResultMembership{
-			{ClusterKey: 1, FeedbackRecordID: input.Records[0].FeedbackRecordID, Confidence: new(0.8)},
-		},
+		Clusters:    []models.TaxonomyResultCluster{{ClusterKey: 1, Label: new("login"), Size: len(input.Records)}},
+		Memberships: memberships,
 		Nodes: []models.TaxonomyResultNode{
 			{NodeKey: "root", NodeType: models.TaxonomyNodeTypeRoot, Label: "Feedback", Level: 0},
-			{NodeKey: "leaf", ParentKey: new("root"), ClusterKey: new(1), NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 1},
+			{
+				NodeKey: "level-2", ParentKey: new("root"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Experience", Level: 1,
+			},
+			{
+				NodeKey: "level-3", ParentKey: new("level-2"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Account Access", Level: 2,
+			},
+			{
+				NodeKey: "level-4", ParentKey: new("level-3"), NodeType: models.TaxonomyNodeTypeBranch,
+				Label: "Authentication", Level: 3,
+			},
+			{
+				NodeKey: "leaf", ParentKey: new("level-4"), ClusterKey: new(1),
+				NodeType: models.TaxonomyNodeTypeLeaf, Label: "Login", Level: 4,
+			},
 		},
 	}
 
@@ -1179,12 +1272,33 @@ func validTaxonomyResult(feedbackRecordID uuid.UUID) models.TaxonomyRunResultReq
 				Level:    0,
 			},
 			{
+				NodeKey:   "level-2",
+				ParentKey: new("root"),
+				NodeType:  models.TaxonomyNodeTypeBranch,
+				Label:     "Customer Experience",
+				Level:     1,
+			},
+			{
+				NodeKey:   "level-3",
+				ParentKey: new("level-2"),
+				NodeType:  models.TaxonomyNodeTypeBranch,
+				Label:     "Account Experience",
+				Level:     2,
+			},
+			{
+				NodeKey:   "level-4",
+				ParentKey: new("level-3"),
+				NodeType:  models.TaxonomyNodeTypeBranch,
+				Label:     "Authentication",
+				Level:     3,
+			},
+			{
 				NodeKey:    "leaf",
-				ParentKey:  new("root"),
+				ParentKey:  new("level-4"),
 				ClusterKey: new(1),
 				NodeType:   models.TaxonomyNodeTypeLeaf,
 				Label:      "Login",
-				Level:      1,
+				Level:      4,
 			},
 		},
 	}

--- a/tests/taxonomy_persistence_test.go
+++ b/tests/taxonomy_persistence_test.go
@@ -622,7 +622,7 @@ func TestTaxonomyRepository_TenantDeletionCleansTaxonomy(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, table := range []string{
-		"taxonomy_runs", "taxonomy_clusters", "taxonomy_cluster_memberships",
+		"taxonomy_runs", "taxonomy_run_input_records", "taxonomy_clusters", "taxonomy_cluster_memberships",
 		"taxonomy_nodes", "taxonomy_active_runs", "taxonomy_node_events",
 	} {
 		var (

--- a/tests/taxonomy_support_test.go
+++ b/tests/taxonomy_support_test.go
@@ -242,6 +242,11 @@ func seedTaxonomyGraph(ctx context.Context, t *testing.T, db *pgxpool.Pool, scop
 	).Scan(&ids.RunID)
 	require.NoError(t, err)
 
+	_, err = db.Exec(ctx, `
+		INSERT INTO taxonomy_run_input_records (run_id, tenant_id, feedback_record_id, sort_order)
+		VALUES ($1, $2, $3, 0)`, ids.RunID, scope.TenantID, ids.FeedbackRecordID)
+	require.NoError(t, err)
+
 	err = db.QueryRow(ctx, `
 		INSERT INTO taxonomy_clusters (run_id, cluster_key, label, llm_label, keywords, size)
 		VALUES ($1, 1, 'login', 'Login issues', '["login"]'::jsonb, 1)


### PR DESCRIPTION
## What does this PR do?

Hardens the internal Taxonomy run contract before the reliability rollout:

- persists the exact bounded record IDs dispatched to a run and validates completion against that immutable snapshot
- stores eligible/selected/cap/truncation metadata for the 10,000-record compute contract
- rejects structurally incomplete results before persistence and caps result bodies at 16 MiB
- makes identical result and failure callbacks idempotent using a canonical digest
- keeps legacy succeeded runs without a digest fail-safe because equality cannot be proven
- bulk-inserts clusters, memberships, and nodes in the existing atomic transaction, with activation last
- adds heartbeats and a configurable stale-run reaper; the default remains 1,800 seconds for compatibility with older Taxonomy images
- preserves bounded, non-sensitive partial failure diagnostics in the existing metrics JSON

Companion Taxonomy follow-up: https://github.com/formbricks/taxonomy/pull/18

No public Formbricks taxonomy API or UI failure code changes.

## How should this be tested?

- `go test ./...` (unit packages pass; the pre-existing local integration database was behind migrations 022/023)
- fresh disposable pgvector database: full Goose migration chain through 023, then `go test ./tests -run TestTaxonomyAPI -count=1 -v` (pass)
- `GOLANGCI_LINT=/Users/bhagya/work/bin/golangci-lint LINT_BASE_REV=origin/main make lint-new` (0 issues)
- `make migrate-validate` (pass)
- companion Docker Hub–Taxonomy integration suite (3 passed), including feedback arriving after input dispatch

## Migration & runtime configuration

- Adds migration `023_taxonomy_run_input_snapshot.sql` for run-scoped selected record IDs. Rows cascade with the run and intentionally do not cascade with feedback records, so the dispatched membership contract cannot silently shrink.
- Changes the default `TAXONOMY_STUCK_RUN_TIMEOUT_SECONDS` from 300 to 1,800 until a callback-heartbeating Taxonomy image is deployed. Operators may lower it afterward while keeping several heartbeat intervals of headroom.

## Checklist

- [x] Filled out the How to test section
- [x] Read Repository Guidelines
- [x] Self-reviewed the persistence and lock-order invariants
- [x] Ran focused unit, lint, migration, fresh-database, and cross-repository integration checks
- [x] Removed debug prints and temporary logging
- [x] Verified the branch includes current `origin/main`
- [x] Existing public API behavior remains unchanged