### PR TITLE
fix(embeddings): distribute worker requests across replicas (ENG-2561)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,7 @@ WEBHOOK_MAX_COUNT=500
 # EMBEDDING_BATCH_SIZE=1             (document micro-batch size; 1 disables batching; provider must support batches)
 # EMBEDDING_BATCH_MAX_WAIT_MS=25     (maximum time to collect a partial batch; default 25ms)
 # EMBEDDING_BATCH_MAX_IN_FLIGHT=1    (maximum concurrent provider batch requests; default 1)
+# EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false (open a new provider connection per request; useful for Kubernetes service distribution)
 
 # Translation (language enrichment) is optional. To enable, set both TRANSLATION_PROVIDER and TRANSLATION_MODEL; if either is unset, translation is disabled and no translation jobs run.
 # Open-text feedback (value_text) is translated into each tenant's configured target_language (Hub tenant settings), falling back to TRANSLATION_DEFAULT_LANGUAGE when a tenant has none. Same providers/auth model as embeddings.

--- a/.env.example
+++ b/.env.example
@@ -124,7 +124,7 @@ WEBHOOK_MAX_COUNT=500
 # EMBEDDING_BATCH_SIZE=1             (document micro-batch size; 1 disables batching; provider must support batches)
 # EMBEDDING_BATCH_MAX_WAIT_MS=25     (maximum time to collect a partial batch; default 25ms)
 # EMBEDDING_BATCH_MAX_IN_FLIGHT=1    (maximum concurrent provider batch requests; default 1)
-# EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false (open a new provider connection per request; useful for Kubernetes service distribution)
+# EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false (open a new OpenAI-compatible provider connection per request; useful for Kubernetes service distribution)
 
 # Translation (language enrichment) is optional. To enable, set both TRANSLATION_PROVIDER and TRANSLATION_MODEL; if either is unset, translation is disabled and no translation jobs run.
 # Open-text feedback (value_text) is translated into each tenant's configured target_language (Hub tenant settings), falling back to TRANSLATION_DEFAULT_LANGUAGE when a tenant has none. Same providers/auth model as embeddings.

--- a/cmd/backfill-embeddings/main.go
+++ b/cmd/backfill-embeddings/main.go
@@ -115,13 +115,14 @@ func run() int {
 	}
 
 	embeddingCfg := service.EmbeddingClientConfig{
-		Provider:            providerCanonical,
-		ProviderAPIKey:      cfg.Embedding.ProviderAPIKey,
-		Model:               embeddingModel,
-		BaseURL:             cfg.Embedding.BaseURL,
-		Normalize:           cfg.Embedding.Normalize,
-		GoogleCloudProject:  cfg.Embedding.GoogleCloudProject,
-		GoogleCloudLocation: cfg.Embedding.GoogleCloudLocation,
+		Provider:              providerCanonical,
+		ProviderAPIKey:        cfg.Embedding.ProviderAPIKey,
+		Model:                 embeddingModel,
+		BaseURL:               cfg.Embedding.BaseURL,
+		HTTPDisableKeepAlives: cfg.Embedding.HTTPDisableKeepAlives,
+		Normalize:             cfg.Embedding.Normalize,
+		GoogleCloudProject:    cfg.Embedding.GoogleCloudProject,
+		GoogleCloudLocation:   cfg.Embedding.GoogleCloudLocation,
 	}
 	if err := service.ValidateEmbeddingConfig(embeddingCfg); err != nil {
 		slog.Error(err.Error())

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -137,14 +137,15 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 
 	if providerName != "" {
 		embeddingCfg := service.EmbeddingClientConfig{
-			UsageRecorder:       genAIUsage,
-			Provider:            providerName,
-			ProviderAPIKey:      cfg.Embedding.ProviderAPIKey,
-			Model:               embeddingModel,
-			BaseURL:             cfg.Embedding.BaseURL,
-			Normalize:           cfg.Embedding.Normalize,
-			GoogleCloudProject:  cfg.Embedding.GoogleCloudProject,
-			GoogleCloudLocation: cfg.Embedding.GoogleCloudLocation,
+			UsageRecorder:         genAIUsage,
+			Provider:              providerName,
+			ProviderAPIKey:        cfg.Embedding.ProviderAPIKey,
+			Model:                 embeddingModel,
+			BaseURL:               cfg.Embedding.BaseURL,
+			HTTPDisableKeepAlives: cfg.Embedding.HTTPDisableKeepAlives,
+			Normalize:             cfg.Embedding.Normalize,
+			GoogleCloudProject:    cfg.Embedding.GoogleCloudProject,
+			GoogleCloudLocation:   cfg.Embedding.GoogleCloudLocation,
 		}
 		if err := service.ValidateEmbeddingConfig(embeddingCfg); err != nil {
 			shutdownObservability(context.Background(), meterProvider, tracerProvider)
@@ -175,6 +176,7 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 				"batch_size", cfg.Embedding.BatchSize,
 				"max_wait_ms", cfg.Embedding.BatchMaxWaitMs,
 				"max_in_flight", cfg.Embedding.BatchMaxInFlight,
+				"http_disable_keep_alives", cfg.Embedding.HTTPDisableKeepAlives,
 			)
 		} else if cfg.Embedding.BatchSize > 1 {
 			slog.Info("embedding document batching unavailable for provider; using single requests",

--- a/cmd/worker/app.go
+++ b/cmd/worker/app.go
@@ -153,6 +153,11 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 			return nil, fmt.Errorf("embedding config: %w", err)
 		}
 
+		slog.Info("embedding worker configured",
+			"provider", providerName,
+			"http_disable_keep_alives", cfg.Embedding.HTTPDisableKeepAlives,
+		)
+
 		embeddingClient, err := service.NewEmbeddingClient(context.Background(), embeddingCfg)
 		if err != nil {
 			shutdownObservability(context.Background(), meterProvider, tracerProvider)
@@ -176,7 +181,6 @@ func NewWorkerApp(cfg *config.Config, db *pgxpool.Pool) (*WorkerApp, error) {
 				"batch_size", cfg.Embedding.BatchSize,
 				"max_wait_ms", cfg.Embedding.BatchMaxWaitMs,
 				"max_in_flight", cfg.Embedding.BatchMaxInFlight,
-				"http_disable_keep_alives", cfg.Embedding.HTTPDisableKeepAlives,
 			)
 		} else if cfg.Embedding.BatchSize > 1 {
 			slog.Info("embedding document batching unavailable for provider; using single requests",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,18 +132,19 @@ type MessagePublisherConfig struct {
 
 // EmbeddingConfig holds embedding provider and queue settings.
 type EmbeddingConfig struct {
-	ProviderAPIKey      string `env:"EMBEDDING_PROVIDER_API_KEY"`
-	Provider            string `env:"EMBEDDING_PROVIDER"`
-	Model               string `env:"EMBEDDING_MODEL"`
-	BaseURL             string `env:"EMBEDDING_BASE_URL"`
-	MaxConcurrent       int    `env:"EMBEDDING_MAX_CONCURRENT"        env-default:"5"`
-	MaxAttempts         int    `env:"EMBEDDING_MAX_ATTEMPTS"          env-default:"3"`
-	BatchSize           int    `env:"EMBEDDING_BATCH_SIZE"            env-default:"1"`
-	BatchMaxWaitMs      int    `env:"EMBEDDING_BATCH_MAX_WAIT_MS"     env-default:"25"`
-	BatchMaxInFlight    int    `env:"EMBEDDING_BATCH_MAX_IN_FLIGHT"   env-default:"1"`
-	Normalize           bool   `env:"EMBEDDING_NORMALIZE"             env-default:"false"`
-	GoogleCloudProject  string `env:"EMBEDDING_GOOGLE_CLOUD_PROJECT"`
-	GoogleCloudLocation string `env:"EMBEDDING_GOOGLE_CLOUD_LOCATION"`
+	ProviderAPIKey        string `env:"EMBEDDING_PROVIDER_API_KEY"`
+	Provider              string `env:"EMBEDDING_PROVIDER"`
+	Model                 string `env:"EMBEDDING_MODEL"`
+	BaseURL               string `env:"EMBEDDING_BASE_URL"`
+	MaxConcurrent         int    `env:"EMBEDDING_MAX_CONCURRENT"           env-default:"5"`
+	MaxAttempts           int    `env:"EMBEDDING_MAX_ATTEMPTS"             env-default:"3"`
+	BatchSize             int    `env:"EMBEDDING_BATCH_SIZE"               env-default:"1"`
+	BatchMaxWaitMs        int    `env:"EMBEDDING_BATCH_MAX_WAIT_MS"        env-default:"25"`
+	BatchMaxInFlight      int    `env:"EMBEDDING_BATCH_MAX_IN_FLIGHT"      env-default:"1"`
+	HTTPDisableKeepAlives bool   `env:"EMBEDDING_HTTP_DISABLE_KEEP_ALIVES" env-default:"false"`
+	Normalize             bool   `env:"EMBEDDING_NORMALIZE"                env-default:"false"`
+	GoogleCloudProject    string `env:"EMBEDDING_GOOGLE_CLOUD_PROJECT"`
+	GoogleCloudLocation   string `env:"EMBEDDING_GOOGLE_CLOUD_LOCATION"`
 }
 
 // TranslationConfig holds the feedback open-text translation enrichment settings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -366,6 +366,7 @@ func TestLoad_EmbeddingBatchSettings(t *testing.T) {
 	t.Setenv("EMBEDDING_BATCH_SIZE", "8")
 	t.Setenv("EMBEDDING_BATCH_MAX_WAIT_MS", "37")
 	t.Setenv("EMBEDDING_BATCH_MAX_IN_FLIGHT", "3")
+	t.Setenv("EMBEDDING_HTTP_DISABLE_KEEP_ALIVES", "true")
 
 	cfg, err := Load()
 	if err != nil {
@@ -382,6 +383,10 @@ func TestLoad_EmbeddingBatchSettings(t *testing.T) {
 
 	if cfg.Embedding.BatchMaxInFlight != 3 {
 		t.Errorf("Embedding.BatchMaxInFlight = %d, want 3", cfg.Embedding.BatchMaxInFlight)
+	}
+
+	if !cfg.Embedding.HTTPDisableKeepAlives {
+		t.Error("Embedding.HTTPDisableKeepAlives = false, want true")
 	}
 }
 
@@ -687,6 +692,10 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.Embedding.BatchSize != 1 || cfg.Embedding.BatchMaxWaitMs != 25 || cfg.Embedding.BatchMaxInFlight != 1 {
 		t.Errorf("Embedding batch defaults = (%d, %d, %d), want (1, 25, 1)",
 			cfg.Embedding.BatchSize, cfg.Embedding.BatchMaxWaitMs, cfg.Embedding.BatchMaxInFlight)
+	}
+
+	if cfg.Embedding.HTTPDisableKeepAlives {
+		t.Error("Embedding.HTTPDisableKeepAlives = true, want false")
 	}
 }
 

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -44,11 +44,12 @@ var (
 
 // Client calls the OpenAI embeddings API via the official SDK.
 type Client struct {
-	sdk        openaisdk.Client
-	baseURL    string
-	dimensions int
-	model      string
-	normalize  bool
+	sdk               openaisdk.Client
+	baseURL           string
+	dimensions        int
+	model             string
+	normalize         bool
+	disableKeepAlives bool
 	// temperatureUnsupported latches once the configured model rejects the temperature
 	// parameter (reasoning models do), so later calls omit it instead of failing.
 	temperatureUnsupported atomic.Bool
@@ -87,6 +88,12 @@ func NewClient(apiKey string, opts ...ClientOption) *Client {
 	}
 	if client.baseURL != "" {
 		sdkOpts = append(sdkOpts, option.WithBaseURL(client.baseURL))
+	}
+
+	if client.disableKeepAlives {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DisableKeepAlives = true
+		sdkOpts = append(sdkOpts, option.WithHTTPClient(&http.Client{Transport: transport}))
 	}
 
 	client.sdk = openaisdk.NewClient(sdkOpts...)
@@ -513,6 +520,15 @@ func WithModel(model string) ClientOption {
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) {
 		c.baseURL = baseURL
+	}
+}
+
+// WithDisableKeepAlives creates a new HTTP connection for every provider request. This lets
+// Kubernetes balance background embedding batches across all endpoints instead of pinning a
+// long-lived worker connection to one pod.
+func WithDisableKeepAlives(disable bool) ClientOption {
+	return func(c *Client) {
+		c.disableKeepAlives = disable
 	}
 }
 

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -106,6 +107,56 @@ func TestCreateEmbedding_UsesEnvironmentBaseURLWhenExplicitBaseURLIsUnset(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, []float32{3, 4}, embedding)
 	assert.Equal(t, int32(1), envHits.Load())
+}
+
+func TestCreateEmbedding_DisableKeepAlivesControlsConnectionReuse(t *testing.T) {
+	tests := []struct {
+		name              string
+		disableKeepAlives bool
+		wantConnections   int32
+	}{
+		{name: "reuses connections by default", wantConnections: 1},
+		{name: "opens a connection per request when disabled", disableKeepAlives: true, wantConnections: 2},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			var connections atomic.Int32
+
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"object": "list",
+					"model":  "test-model",
+					"data": []map[string]any{{
+						"object": "embedding", "index": 0, "embedding": []float64{1, 2},
+					}},
+					"usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+				}))
+			}))
+			server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				if state == http.StateNew {
+					connections.Add(1)
+				}
+			}
+			server.Start()
+			t.Cleanup(server.Close)
+
+			client := NewClient("sk-test",
+				WithBaseURL(server.URL+"/v1"),
+				WithDimensions(2),
+				WithModel("test-model"),
+				WithDisableKeepAlives(testCase.disableKeepAlives),
+			)
+
+			for range 2 {
+				_, err := client.CreateEmbedding(context.Background(), "hello world")
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.wantConnections, connections.Load())
+		})
+	}
 }
 
 func TestCreateEmbeddingsMapsOutOfOrderResponseAndMatchesSingle(t *testing.T) {

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -321,7 +321,10 @@ func (c *concurrencyTrackingEmbeddingClient) CreateEmbeddings(
 		}
 	}
 
-	c.started <- struct{}{}
+	select {
+	case c.started <- struct{}{}:
+	default:
+	}
 
 	select {
 	case <-c.release:

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -385,7 +385,7 @@ func TestBatchingEmbeddingClientLimitsConcurrentProviderRequests(t *testing.T) {
 		})
 	}
 
-	deadline := time.After(time.Second)
+	deadline := time.After(2 * time.Second)
 
 	for range maxInFlight {
 		select {

--- a/internal/service/embedding_batcher_test.go
+++ b/internal/service/embedding_batcher_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -291,6 +292,51 @@ func TestBatchingEmbeddingClientShutdownFlushesAndCloses(t *testing.T) {
 	}
 }
 
+type concurrencyTrackingEmbeddingClient struct {
+	active  atomic.Int32
+	maximum atomic.Int32
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (c *concurrencyTrackingEmbeddingClient) CreateEmbedding(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (c *concurrencyTrackingEmbeddingClient) CreateEmbeddingForQuery(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (c *concurrencyTrackingEmbeddingClient) CreateEmbeddings(
+	ctx context.Context,
+	inputs []string,
+) ([][]float32, error) {
+	active := c.active.Add(1)
+	defer c.active.Add(-1)
+
+	for {
+		maximum := c.maximum.Load()
+		if active <= maximum || c.maximum.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+
+	c.started <- struct{}{}
+
+	select {
+	case <-c.release:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("test provider: %w", ctx.Err())
+	}
+
+	vectors := make([][]float32, len(inputs))
+	for i := range inputs {
+		vectors[i] = []float32{1}
+	}
+
+	return vectors, nil
+}
+
 type singleOnlyEmbeddingClient struct{}
 
 func (singleOnlyEmbeddingClient) CreateEmbedding(context.Context, string) ([]float32, error) {
@@ -308,5 +354,58 @@ func TestNewBatchingEmbeddingClientFallback(t *testing.T) {
 
 	if _, ok := NewBatchingEmbeddingClient(&batcherTestClient{}, EmbeddingBatchConfig{BatchSize: 1}, nil); ok {
 		t.Fatal("batch size 1 must disable batching")
+	}
+}
+
+func TestBatchingEmbeddingClientLimitsConcurrentProviderRequests(t *testing.T) {
+	const maxInFlight = 12
+
+	started := make(chan struct{}, maxInFlight+1)
+	release := make(chan struct{})
+	provider := &concurrencyTrackingEmbeddingClient{started: started, release: release}
+
+	batcher, ok := NewBatchingEmbeddingClient(provider, EmbeddingBatchConfig{
+		BatchSize: 2, MaxWait: time.Second, MaxInFlight: maxInFlight,
+	}, nil)
+	if !ok {
+		t.Fatal("batch client was not enabled")
+	}
+
+	const requestCount = maxInFlight * 4
+
+	var waitGroup sync.WaitGroup
+	for i := range requestCount {
+		waitGroup.Go(func() {
+			if _, err := batcher.CreateEmbedding(context.Background(), fmt.Sprintf("input-%d", i)); err != nil {
+				t.Errorf("CreateEmbedding() error = %v", err)
+			}
+		})
+	}
+
+	deadline := time.After(time.Second)
+
+	for range maxInFlight {
+		select {
+		case <-started:
+		case <-deadline:
+			close(release)
+			waitGroup.Wait()
+			t.Fatal("provider requests did not reach the configured concurrency")
+		}
+	}
+
+	select {
+	case <-started:
+		close(release)
+		waitGroup.Wait()
+		t.Fatalf("provider exceeded MaxInFlight=%d", maxInFlight)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	waitGroup.Wait()
+
+	if got := provider.maximum.Load(); got != maxInFlight {
+		t.Fatalf("maximum concurrent provider requests = %d, want %d", got, maxInFlight)
 	}
 }

--- a/internal/service/embedding_client_factory.go
+++ b/internal/service/embedding_client_factory.go
@@ -31,13 +31,14 @@ var (
 
 // EmbeddingClientConfig holds configuration for creating an embedding client.
 type EmbeddingClientConfig struct {
-	Provider            string
-	ProviderAPIKey      string // API key for openai/google providers; not logged or serialized
-	Model               string
-	BaseURL             string
-	Normalize           bool
-	GoogleCloudProject  string
-	GoogleCloudLocation string
+	Provider              string
+	ProviderAPIKey        string // API key for openai/google providers; not logged or serialized
+	Model                 string
+	BaseURL               string
+	HTTPDisableKeepAlives bool
+	Normalize             bool
+	GoogleCloudProject    string
+	GoogleCloudLocation   string
 	// UsageRecorder receives each provider call's token counts and duration. nil disables it.
 	UsageRecorder llm.UsageRecorder
 }
@@ -75,6 +76,7 @@ func openAIEmbeddingFactory(_ context.Context, cfg EmbeddingClientConfig) (Embed
 		openai.WithModel(cfg.Model),
 		openai.WithBaseURL(cfg.BaseURL),
 		openai.WithUsageRecorder(cfg.UsageRecorder),
+		openai.WithDisableKeepAlives(cfg.HTTPDisableKeepAlives),
 		openai.WithNormalize(cfg.Normalize),
 	), nil
 }


### PR DESCRIPTION
## What does this PR do?

- Tracks the EU embedding throughput regression under `ENG-2561`.
- Adds the default-off `EMBEDDING_HTTP_DISABLE_KEEP_ALIVES` worker setting.
- Uses a cloned HTTP transport with keep-alive disabled for configured OpenAI-compatible embedding clients, allowing Kubernetes to rebalance each background batch connection across TEI endpoints.
- Leaves Hub API semantic-search traffic and every existing deployment unchanged unless the setting is explicitly enabled on the worker.
- Logs the effective transport setting whenever an embedding worker is configured, including when batching is disabled.
- Propagates the setting through the producer-only `backfill-embeddings` command for configuration consistency; embedding requests are still executed by `hub-worker`.

## Why this changes the staging throughput path

- The failed staging gate ran against six Ready TEI replicas but successful provider requests reached only two pods, while the worker was capped at three in-flight batches; the result was 500 embeddings in 382 seconds (`1.31 embeddings/s`).
- The companion [Formbricks chart PR #9001](https://github.com/formbricks/formbricks/pull/9001) exposes the setting only on background worker/backfill workloads and renders the tested `48 / 8 / 100 / 12` worker tuning.
- The guarded 500-record staging rerun remains the acceptance gate: at least `5.0 embeddings/s`, all six pods used within the distribution bounds, queue drained, and foreground search healthy.

## How should this be tested?

- `make build`
- `make build-backfill-embeddings`
- `make test-unit`
- `go test -race ./internal/config ./internal/openai ./internal/service`
- `make GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint" lint`
- Confirm `TestCreateEmbedding_DisableKeepAlivesControlsConnectionReuse` observes one connection by default and two connections for two requests when enabled.
- Confirm `TestBatchingEmbeddingClientLimitsConcurrentProviderRequests` reaches but never exceeds 12 provider requests.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [ ] Ran `make tests` (integration tests require pgvector; this transport-only change is covered by unit and race tests above)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Started from the latest `origin/main`
- [x] No database schema change

### Appreciated

- [x] No API or OpenAPI change
- [x] Updated `.env.example` for the optional setting
- [ ] `make tests-coverage` was not run; focused connection and concurrency regression tests cover the new behavior
