### PR TITLE
fix(ci): sign release image digest once

### DIFF
--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -135,11 +135,11 @@ jobs:
 
       - name: Sign image with cosign
         env:
-          TAGS: ${{ steps.tags.outputs.tags }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.extract_version.outputs.VERSION }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"
+          cosign sign --yes "${IMAGE_REF}@${DIGEST}"
 
       - name: Output build summary
         env:

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -139,7 +139,20 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes "${IMAGE_REF}@${DIGEST}"
+
+          for attempt in 1 2 3; do
+            if cosign sign --yes "${IMAGE_REF}@${DIGEST}"; then
+              exit 0
+            fi
+
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "cosign sign failed (attempt ${attempt}/3); retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+
+          echo "cosign sign failed after 3 attempts"
+          exit 1
 
       - name: Output build summary
         env:


### PR DESCRIPTION
## Summary

- sign the canonical versioned GHCR image reference once per release
- retry Cosign up to three times when transient Rekor failures abort a signing invocation
- allow the dependent ECR and release-verification jobs to run

## Context

The 0.8.5 release build pushed one multi-arch digest under four tags. Two signing invocations failed when Rekor returned 409 equivalent-entry conflicts after a long request, while fresh invocations for the same digest succeeded. The workflow now signs the digest once and retries with a fresh keyless invocation when signing fails.

Failed run: https://github.com/formbricks/hub/actions/runs/32244009436
Upstream Cosign issue: https://github.com/sigstore/cosign/issues/4711

## Test evidence

- Ruby YAML syntax parse and signing-step lookup
- Bash syntax check of the extracted signing step
- transient-failure dry run: first attempt failed, second succeeded
- permanent-failure dry run: exactly three attempts, exit status 1
- git diff --check