### PR TITLE
fix: reject unstorable feedback-record metadata as 400 instead of 500

### DIFF
--- a/internal/api/validation/json_storable.go
+++ b/internal/api/validation/json_storable.go
@@ -1,0 +1,160 @@
+package validation
+
+import (
+	"reflect"
+	"unicode/utf8"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// Postgres refuses exactly two things when text is written into a jsonb column, and both arrive as
+// escapes inside otherwise-valid JSON:
+//
+//	SELECT '{"note":"bad\u0000value"}'::jsonb  -- ERROR: unsupported Unicode escape sequence
+//	SELECT '{"note":"bad\ud83dvalue"}'::jsonb  -- ERROR: invalid input syntax for type json
+//
+// A raw-JSON request field (json.RawMessage) reaches the driver byte-for-byte, so neither is caught
+// by anything upstream: the request parses, the struct validates, and the failure lands as an
+// unmapped driver error — a 500 on input the API documents as invalid. `no_null_bytes` cannot cover
+// it either, because it skips any field that is not a string kind and json.RawMessage is a []byte.
+//
+// The check runs over the raw bytes rather than the unmarshalled value on purpose. Unmarshalling
+// rewrites both cases — encoding/json turns a \u0000 escape into a real NUL and replaces an
+// unpaired surrogate with U+FFFD — so a value read back through a Go string looks storable while
+// the bytes actually sent to Postgres are not.
+const storableJSONTag = "storable_json"
+
+const (
+	highSurrogateStart = 0xd800
+	highSurrogateEnd   = 0xdbff
+	lowSurrogateStart  = 0xdc00
+	lowSurrogateEnd    = 0xdfff
+
+	escapeLen   = 6  // \uXXXX
+	decimalBase = 10 // first hex value a letter digit stands for
+	hexDigits   = 4
+	pairLen     = escapeLen * 2
+	nibbleBits  = 4
+)
+
+// validateStorableJSON is the `storable_json` tag: it accepts anything that is not a raw JSON field
+// so the tag is inert if applied to the wrong kind, matching how no_null_bytes behaves.
+func validateStorableJSON(fl validator.FieldLevel) bool {
+	field := fl.Field()
+
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return true // nil pointer is valid (handled by omitempty)
+		}
+
+		field = field.Elem()
+	}
+
+	if field.Kind() != reflect.Slice || field.Type().Elem().Kind() != reflect.Uint8 {
+		return true // Not raw JSON, skip validation
+	}
+
+	return IsStorableJSON(field.Bytes())
+}
+
+// IsStorableJSON reports whether raw JSON can be written to a Postgres jsonb column.
+//
+// It assumes the bytes are already syntactically valid JSON, which the request decoder has
+// established by the time a struct is validated. That is what makes a plain scan sound: a backslash
+// escape can only appear inside a JSON string, so keys and values are both covered without tracking
+// string context — and a NULL byte in a *key* is rejected by Postgres just as one in a value is.
+func IsStorableJSON(raw []byte) bool {
+	if len(raw) == 0 {
+		return true
+	}
+
+	// Catches raw invalid bytes, including a surrogate smuggled in as CESU-8, which Postgres
+	// rejects as an encoding error rather than a JSON one.
+	if !utf8.Valid(raw) {
+		return false
+	}
+
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '\\' {
+			continue
+		}
+
+		if i+1 >= len(raw) {
+			return false // trailing backslash: not valid JSON, and not storable
+		}
+
+		// Any other escape (\\, \", \n, ...) consumes its own second byte, which is what keeps a
+		// literal "\\u0000" — an escaped backslash followed by text — from reading as an escape.
+		if raw[i+1] != 'u' {
+			i++
+
+			continue
+		}
+
+		code, ok := parseHex4(raw[i+2:])
+		if !ok {
+			return false // malformed \u escape; Postgres would reject it too
+		}
+
+		if code == 0 {
+			return false // NULL byte
+		}
+
+		if code >= lowSurrogateStart && code <= lowSurrogateEnd {
+			return false // low surrogate with no high surrogate before it
+		}
+
+		if code >= highSurrogateStart && code <= highSurrogateEnd {
+			if !hasLowSurrogateAt(raw, i+escapeLen) {
+				return false // high surrogate never completed into a pair
+			}
+
+			i += pairLen - 1 // consume both halves
+
+			continue
+		}
+
+		i += escapeLen - 1
+	}
+
+	return true
+}
+
+// hasLowSurrogateAt reports whether a \uDC00-\uDFFF escape starts exactly at offset i.
+func hasLowSurrogateAt(raw []byte, i int) bool {
+	if i+escapeLen > len(raw) || raw[i] != '\\' || raw[i+1] != 'u' {
+		return false
+	}
+
+	code, ok := parseHex4(raw[i+2:])
+
+	return ok && code >= lowSurrogateStart && code <= lowSurrogateEnd
+}
+
+// parseHex4 reads the four hex digits of a \uXXXX escape.
+func parseHex4(digits []byte) (int, bool) {
+	if len(digits) < hexDigits {
+		return 0, false
+	}
+
+	code := 0
+
+	for _, digit := range digits[:hexDigits] {
+		var nibble int
+
+		switch {
+		case digit >= '0' && digit <= '9':
+			nibble = int(digit - '0')
+		case digit >= 'a' && digit <= 'f':
+			nibble = int(digit-'a') + decimalBase
+		case digit >= 'A' && digit <= 'F':
+			nibble = int(digit-'A') + decimalBase
+		default:
+			return 0, false
+		}
+
+		code = code<<nibbleBits | nibble
+	}
+
+	return code, true
+}

--- a/internal/api/validation/json_storable.go
+++ b/internal/api/validation/json_storable.go
@@ -35,11 +35,11 @@ const (
 	lowSurrogateStart  = 0xdc00
 	lowSurrogateEnd    = 0xdfff
 
-	escapeLen   = 6  // \uXXXX
-	decimalBase = 10 // first hex value a letter digit stands for
-	hexDigits   = 4
-	pairLen     = escapeLen * 2
-	nibbleBits  = 4
+	escapeLen       = 6  // \uXXXX
+	hexLetterOffset = 10 // 'a'/'A' stands for 0xa, so a letter digit's value is offset by ten
+	hexDigits       = 4
+	pairLen         = escapeLen * 2
+	nibbleBits      = 4
 )
 
 // validateStorableJSON is the `storable_json` tag: it accepts anything that is not a raw JSON field
@@ -151,9 +151,9 @@ func parseHex4(digits []byte) (int, bool) {
 		case digit >= '0' && digit <= '9':
 			nibble = int(digit - '0')
 		case digit >= 'a' && digit <= 'f':
-			nibble = int(digit-'a') + decimalBase
+			nibble = int(digit-'a') + hexLetterOffset
 		case digit >= 'A' && digit <= 'F':
-			nibble = int(digit-'A') + decimalBase
+			nibble = int(digit-'A') + hexLetterOffset
 		default:
 			return 0, false
 		}

--- a/internal/api/validation/json_storable.go
+++ b/internal/api/validation/json_storable.go
@@ -7,8 +7,8 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// Postgres refuses exactly two things when text is written into a jsonb column, and both arrive as
-// escapes inside otherwise-valid JSON:
+// Postgres refuses two character-level things when text is written into a jsonb column, and both
+// arrive as escapes inside otherwise-valid JSON:
 //
 //	SELECT '{"note":"bad\u0000value"}'::jsonb  -- ERROR: unsupported Unicode escape sequence
 //	SELECT '{"note":"bad\ud83dvalue"}'::jsonb  -- ERROR: invalid input syntax for type json
@@ -17,6 +17,11 @@ import (
 // by anything upstream: the request parses, the struct validates, and the failure lands as an
 // unmapped driver error — a 500 on input the API documents as invalid. `no_null_bytes` cannot cover
 // it either, because it skips any field that is not a string kind and json.RawMessage is a []byte.
+//
+// (Postgres also refuses a third, non-character thing: numbers that do not fit numeric, e.g.
+// 1e1000000. That is a range property of the parsed value, invisible to a byte scan, so it is
+// handled where it surfaces — the feedback-records repository maps SQLSTATE 22003 to a metadata
+// validation error.)
 //
 // The check runs over the raw bytes rather than the unmarshalled value on purpose. Unmarshalling
 // rewrites both cases — encoding/json turns a \u0000 escape into a real NUL and replaces an

--- a/internal/api/validation/json_storable_test.go
+++ b/internal/api/validation/json_storable_test.go
@@ -1,0 +1,107 @@
+package validation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsStorableJSON(t *testing.T) {
+	// Every rejected case here was confirmed against Postgres 18 by casting the same text to
+	// jsonb; every accepted case casts cleanly.
+	tests := []struct {
+		name     string
+		raw      string
+		storable bool
+	}{
+		{name: "empty", raw: "", storable: true},
+		{name: "plain object", raw: `{"source":"link","country":"PT"}`, storable: true},
+		{name: "nested and arrays", raw: `{"a":{"b":["c",1,true,null]}}`, storable: true},
+		{name: "non-object scalar", raw: `42`, storable: true},
+
+		{name: "null byte in a value", raw: `{"note":"bad\u0000value"}`, storable: false},
+		{name: "null byte in a key", raw: `{"ba\u0000d":"v"}`, storable: false},
+		{name: "null byte in a nested object key", raw: `{"a":{"b\u0000c":1}}`, storable: false},
+		{name: "null byte nested in an array", raw: `{"tags":["ok","b\u0000d"]}`, storable: false},
+
+		{name: "lone high surrogate", raw: `{"note":"bad\ud83dvalue"}`, storable: false},
+		{name: "lone low surrogate", raw: `{"note":"bad\ude00value"}`, storable: false},
+		{name: "high surrogate at end of input", raw: `{"note":"bad\ud83d"}`, storable: false},
+		{name: "high surrogate followed by a non-surrogate escape", raw: `{"note":"\ud83dA"}`, storable: false},
+		{name: "valid surrogate pair", raw: `{"note":"ok\ud83d\ude00"}`, storable: true},
+		{name: "valid pair uppercase hex", raw: `{"note":"ok\uD83D\uDE00"}`, storable: true},
+		{name: "two valid pairs back to back", raw: `{"note":"\ud83d\ude00\ud83d\ude01"}`, storable: true},
+
+		// An escaped backslash is not the start of an escape. Without consuming its second byte the
+		// scanner would read the following "u0000" as a NUL escape and reject a legitimate value.
+		{name: "escaped backslash before u0000 text", raw: `{"note":"path\\u0000notanescape"}`, storable: true},
+		{name: "escaped backslash then a real null escape", raw: `{"note":"a\\\u0000"}`, storable: false},
+		{name: "other escapes are ignored", raw: `{"note":"line\nquote\"tab\t"}`, storable: true},
+
+		{name: "malformed short escape", raw: `{"note":"\u00"}`, storable: false},
+		{name: "malformed non-hex escape", raw: `{"note":"\uZZZZ"}`, storable: false},
+		{name: "trailing backslash", raw: `{"note":"a\`, storable: false},
+
+		// Emoji as real UTF-8 rather than escapes: valid, and the common case for survey text.
+		{name: "literal multi-byte utf8", raw: `{"note":"feedback 😀"}`, storable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.storable, IsStorableJSON([]byte(tt.raw)))
+		})
+	}
+}
+
+func TestIsStorableJSONRejectsInvalidUTF8(t *testing.T) {
+	// A surrogate encoded directly as CESU-8 rather than as a \u escape. Postgres rejects it as an
+	// encoding error, so the scan has to catch it before the escape walk.
+	raw := []byte(`{"note":"`)
+	raw = append(raw, 0xed, 0xa0, 0xbd) // U+D83D encoded directly, which UTF-8 forbids
+	raw = append(raw, `"}`...)
+
+	assert.False(t, IsStorableJSON(raw))
+}
+
+// The tag is what actually protects the endpoint, so drive it through ValidateStruct rather than
+// calling the predicate directly.
+func TestStorableJSONTagOnRequestStruct(t *testing.T) {
+	type request struct {
+		Metadata json.RawMessage `json:"metadata,omitempty" validate:"omitempty,storable_json"`
+	}
+
+	t.Run("accepts storable metadata", func(t *testing.T) {
+		require.NoError(t, ValidateStruct(request{Metadata: json.RawMessage(`{"source":"link"}`)}))
+	})
+
+	t.Run("accepts an absent metadata field", func(t *testing.T) {
+		require.NoError(t, ValidateStruct(request{}))
+	})
+
+	t.Run("rejects a null byte with a self-correcting reason", func(t *testing.T) {
+		err := ValidateStruct(request{Metadata: json.RawMessage(`{"note":"bad\u0000value"}`)})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrValidationFailed)
+		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+	})
+
+	t.Run("rejects an unpaired surrogate", func(t *testing.T) {
+		err := ValidateStruct(request{Metadata: json.RawMessage(`{"note":"bad\ud83dvalue"}`)})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrValidationFailed)
+	})
+}
+
+// The tag is deliberately inert on non-raw-JSON fields, mirroring no_null_bytes, so misapplying it
+// cannot start rejecting unrelated input.
+func TestStorableJSONTagIgnoresNonRawJSONFields(t *testing.T) {
+	type request struct {
+		Name string `json:"name" validate:"omitempty,storable_json"`
+	}
+
+	require.NoError(t, ValidateStruct(request{Name: "anything at all"}))
+}

--- a/internal/api/validation/json_storable_test.go
+++ b/internal/api/validation/json_storable_test.go
@@ -31,7 +31,7 @@ func TestIsStorableJSON(t *testing.T) {
 		{name: "lone high surrogate", raw: `{"note":"bad\ud83dvalue"}`, storable: false},
 		{name: "lone low surrogate", raw: `{"note":"bad\ude00value"}`, storable: false},
 		{name: "high surrogate at end of input", raw: `{"note":"bad\ud83d"}`, storable: false},
-		{name: "high surrogate followed by a non-surrogate escape", raw: `{"note":"\ud83dA"}`, storable: false},
+		{name: "high surrogate followed by a plain character", raw: `{"note":"\ud83dA"}`, storable: false},
 		{name: "valid surrogate pair", raw: `{"note":"ok\ud83d\ude00"}`, storable: true},
 		{name: "valid pair uppercase hex", raw: `{"note":"ok\uD83D\uDE00"}`, storable: true},
 		{name: "two valid pairs back to back", raw: `{"note":"\ud83d\ude00\ud83d\ude01"}`, storable: true},

--- a/internal/api/validation/json_storable_test.go
+++ b/internal/api/validation/json_storable_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formbricks/hub/internal/models"
 )
 
 func TestIsStorableJSON(t *testing.T) {
@@ -104,4 +106,45 @@ func TestStorableJSONTagIgnoresNonRawJSONFields(t *testing.T) {
 	}
 
 	require.NoError(t, ValidateStruct(request{Name: "anything at all"}))
+}
+
+// The tests above pin the tag's behavior on a local struct; these pin that the tag is actually
+// PRESENT on the two request structs the endpoint decodes into. Reverting only the models hunk of
+// the ENG-2745 fix — the part that protects the endpoint — left the whole suite green before this.
+func TestRealRequestStructsCarryStorableJSONTag(t *testing.T) {
+	badMetadata := json.RawMessage(`{"note":"bad\u0000value"}`)
+
+	t.Run("CreateFeedbackRecordRequest rejects unstorable metadata", func(t *testing.T) {
+		err := ValidateStruct(models.CreateFeedbackRecordRequest{
+			SourceType:   "survey",
+			FieldID:      "q1",
+			FieldType:    models.FieldTypeText,
+			TenantID:     "tenant-1",
+			SubmissionID: "s1",
+			Metadata:     badMetadata,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+	})
+
+	t.Run("UpdateFeedbackRecordRequest rejects unstorable metadata", func(t *testing.T) {
+		err := ValidateStruct(models.UpdateFeedbackRecordRequest{Metadata: badMetadata})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+	})
+
+	t.Run("both accept storable metadata", func(t *testing.T) {
+		fine := json.RawMessage(`{"source":"link"}`)
+		require.NoError(t, ValidateStruct(models.CreateFeedbackRecordRequest{
+			SourceType:   "survey",
+			FieldID:      "q1",
+			FieldType:    models.FieldTypeText,
+			TenantID:     "tenant-1",
+			SubmissionID: "s1",
+			Metadata:     fine,
+		}))
+		require.NoError(t, ValidateStruct(models.UpdateFeedbackRecordRequest{Metadata: fine}))
+	})
 }

--- a/internal/api/validation/json_storable_test.go
+++ b/internal/api/validation/json_storable_test.go
@@ -87,7 +87,7 @@ func TestStorableJSONTagOnRequestStruct(t *testing.T) {
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrValidationFailed)
-		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+		assert.Contains(t, err.Error(), "metadata must contain valid UTF-8 and no NULL bytes or unpaired UTF-16 surrogates")
 	})
 
 	t.Run("rejects an unpaired surrogate", func(t *testing.T) {
@@ -125,14 +125,14 @@ func TestRealRequestStructsCarryStorableJSONTag(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+		assert.Contains(t, err.Error(), "metadata must contain valid UTF-8 and no NULL bytes or unpaired UTF-16 surrogates")
 	})
 
 	t.Run("UpdateFeedbackRecordRequest rejects unstorable metadata", func(t *testing.T) {
 		err := ValidateStruct(models.UpdateFeedbackRecordRequest{Metadata: badMetadata})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "metadata must not contain NULL bytes or unpaired UTF-16 surrogates")
+		assert.Contains(t, err.Error(), "metadata must contain valid UTF-8 and no NULL bytes or unpaired UTF-16 surrogates")
 	})
 
 	t.Run("both accept storable metadata", func(t *testing.T) {

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -104,6 +104,10 @@ func init() {
 		slog.Error("Failed to register no_null_bytes validator", "error", err)
 	}
 
+	if err := validate.RegisterValidation(storableJSONTag, validateStorableJSON); err != nil {
+		slog.Error("Failed to register storable_json validator", "error", err)
+	}
+
 	// Element validators for the repeatable enum filters, applied via `dive`. They are a second
 	// gate behind registerEnumSliceTypes, not a replacement: see the comment there for why the
 	// decoder alone cannot be trusted to have run.
@@ -390,6 +394,8 @@ func FormatFieldError(fieldErr validator.FieldError) string {
 		return "must be in RFC3339 (ISO 8601) format"
 	case "no_null_bytes":
 		return "must not contain NULL bytes"
+	case storableJSONTag:
+		return "must not contain NULL bytes or unpaired UTF-16 surrogates"
 	case "http_url":
 		return "must be a valid HTTP or HTTPS URL"
 	case "url":

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -395,7 +395,7 @@ func FormatFieldError(fieldErr validator.FieldError) string {
 	case "no_null_bytes":
 		return "must not contain NULL bytes"
 	case storableJSONTag:
-		return "must not contain NULL bytes or unpaired UTF-16 surrogates"
+		return "must contain valid UTF-8 and no NULL bytes or unpaired UTF-16 surrogates"
 	case "http_url":
 		return "must be a valid HTTP or HTTPS URL"
 	case "url":

--- a/internal/models/feedback_records.go
+++ b/internal/models/feedback_records.go
@@ -494,7 +494,7 @@ type CreateFeedbackRecordRequest struct {
 	ValueNumber     *float64        `json:"value_number,omitempty"`
 	ValueBoolean    *bool           `json:"value_boolean,omitempty"`
 	ValueDate       *time.Time      `json:"value_date,omitempty"`
-	Metadata        json.RawMessage `json:"metadata,omitempty"`
+	Metadata        json.RawMessage `json:"metadata,omitempty"          validate:"omitempty,storable_json"`
 	Language        *string         `json:"language,omitempty"          validate:"omitempty,no_null_bytes,max=10"`
 	UserID          *string         `json:"user_id,omitempty"           validate:"omitempty,no_null_bytes,max=255"`
 	TenantID        string          `json:"tenant_id"                   validate:"required,no_null_bytes,max=255"`
@@ -516,7 +516,7 @@ type UpdateFeedbackRecordRequest struct {
 	ValueNumber  *float64        `json:"value_number,omitempty"`
 	ValueBoolean *bool           `json:"value_boolean,omitempty"`
 	ValueDate    *time.Time      `json:"value_date,omitempty"`
-	Metadata     json.RawMessage `json:"metadata,omitempty"`
+	Metadata     json.RawMessage `json:"metadata,omitempty"      validate:"omitempty,storable_json"`
 	Language     *string         `json:"language,omitempty"      validate:"omitempty,no_null_bytes,max=10"`
 	UserID       *string         `json:"user_id,omitempty"       validate:"omitempty,no_null_bytes,max=255"`
 }

--- a/internal/repository/feedback_records_repository.go
+++ b/internal/repository/feedback_records_repository.go
@@ -21,6 +21,17 @@ import (
 // constraint violations (23505 unique_violation).
 const uniqueViolationSQLState = "23505"
 
+// numericOverflowSQLState (22003 numeric_value_out_of_range) fires when jsonb metadata carries a
+// number that does not fit Postgres numeric — e.g. `{"n":1e1000000}`, fifteen bytes of perfectly
+// valid JSON. The storable_json request validator cannot see this class: it is a range property of
+// the parsed number, not of the bytes. Metadata is the only place it can originate on these
+// queries — value_number is float8, and every Go float64 fits float8 — so the error is mapped to a
+// metadata validation failure rather than surfacing as an unmapped 500 (ENG-2745).
+const numericOverflowSQLState = "22003"
+
+// numericOverflowMessage is the invalid_params reason for the mapping above.
+const numericOverflowMessage = "contains a number outside the storable range"
+
 // FeedbackRecordsRepository handles data access for feedback records.
 type FeedbackRecordsRepository struct {
 	db *pgxpool.Pool
@@ -137,6 +148,10 @@ func (r *FeedbackRecordsRepository) Create(ctx context.Context, req *models.Crea
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolationSQLState {
 			return nil, huberrors.NewConflictError("a feedback record with this tenant_id, submission_id, and field_id already exists")
+		}
+
+		if errors.As(err, &pgErr) && pgErr.Code == numericOverflowSQLState {
+			return nil, huberrors.NewValidationError("metadata", numericOverflowMessage)
 		}
 
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -945,6 +960,11 @@ func (r *FeedbackRecordsRepository) Update(
 		if scanErr != nil {
 			if errors.Is(scanErr, pgx.ErrNoRows) {
 				return huberrors.NewNotFoundError("feedback record", "feedback record not found")
+			}
+
+			var pgErr *pgconn.PgError
+			if errors.As(scanErr, &pgErr) && pgErr.Code == numericOverflowSQLState {
+				return huberrors.NewValidationError("metadata", numericOverflowMessage)
 			}
 
 			return fmt.Errorf("failed to update feedback record: %w", scanErr)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3061,9 +3061,11 @@ components:
                         a JavaScript client will still lose precision above 2^53 when it parses the
                         response.
 
-                        Nothing here is redacted or sent anywhere else — unlike `value_text`, which
-                        the enrichment pipelines also ship to LLM and embedding providers. Erasure
-                        covers metadata, with one precondition worth knowing:
+                        Nothing here is redacted. Metadata is **not** sent to the LLM or embedding
+                        enrichment providers, unlike `value_text` — but it **is** included in the
+                        `feedback_record.created` and `feedback_record.updated` webhook payloads, so
+                        it reaches whatever URL a tenant has configured. Erasure covers metadata,
+                        with one precondition worth knowing:
                         `DELETE /v1/feedback-records` matches on `user_id` and hard-deletes the whole
                         row, metadata included — so a record written **without** a `user_id` cannot
                         be reached that way. Set `user_id` on anything you may later have to erase.
@@ -3286,17 +3288,20 @@ components:
                     description: ISO language code. NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
                 metadata:
+                    type: [object, array, string, number, boolean, "null"]
+                    # Required alongside `array` in the union; any element is valid, since the union
+                    # exists to describe legacy rows rather than to constrain new writes.
+                    items: {}
                     description: >-
                         Arbitrary context stored with this record, returned with equivalent values
                         (key order is normalized, and so are number exponents — `1e2` reads back as
                         `100`). Omitted when the record has no metadata; a record explicitly stored
                         with a JSON `null` returns `null`.
 
-                        Deliberately untyped: an object is the supported shape and what the request
-                        schemas accept, but the column stores whatever JSON was written, so a record
-                        created before that convention can return any JSON value. Constraining this
-                        to an object would make a generated client reject such a record.
-                    additionalProperties: {}
+                        An object is the supported shape and the only one the request schemas accept.
+                        The wider union is for reading: the column stores whatever JSON was written,
+                        so a record created before that convention can return an array or a scalar,
+                        and an object-only response schema would make a generated client reject it.
                 sentiment:
                     $ref: '#/components/schemas/SentimentValue'
                     description: Sentiment polarity inferred from value_text (sentiment enrichment). Read-only; absent until the record is enriched.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3047,7 +3047,21 @@ components:
                     pattern: '^[^\x00]*$'
                 metadata:
                     type: object
-                    description: User agent, device, location, referrer, tags, etc. NULL bytes (\x00 or \u0000) are not allowed in JSON keys or values.
+                    description: >-
+                        Arbitrary context for this record, stored as JSON and returned verbatim: the
+                        dimensions you want to slice a dashboard by, such as channel, device, browser,
+                        OS, country, referrer, campaign, plan or tags. Values may be strings, numbers,
+                        booleans, null, or nested objects and arrays.
+
+                        Use snake_case keys and keep them stable across records, since a key is what a
+                        dashboard groups by: `customer_tier`, not a mix of `customerTier` and `tier`.
+                        Numbers keep full precision here (unlike `value_number`, which is a float64),
+                        so a large integer id round-trips exactly.
+
+                        Do not put personal data in metadata unless you mean to retain it — it is not
+                        redacted, and unlike an answer it is duplicated onto every record of a
+                        submission. Rejected with 400: NULL bytes and unpaired UTF-16 surrogates, in
+                        keys or values, because neither can be stored as JSON.
                     additionalProperties: {}
                 source_id:
                     type: [string, "null"]
@@ -3264,7 +3278,9 @@ components:
                     pattern: '^[^\x00]*$'
                 metadata:
                     type: object
-                    description: Additional context
+                    description: >-
+                        Arbitrary context stored with this record, returned exactly as it was sent.
+                        Absent when the record carries none.
                     additionalProperties: {}
                 sentiment:
                     $ref: '#/components/schemas/SentimentValue'
@@ -3633,7 +3649,11 @@ components:
                     pattern: '^[^\x00]*$'
                 metadata:
                     type: object
-                    description: Update metadata. NULL bytes (\x00 or \u0000) are not allowed in JSON keys or values.
+                    description: >-
+                        Replaces the stored metadata object **wholesale** — it is not merged, so send
+                        every key you want to keep or the omitted ones are lost. See the create
+                        operation for the value rules and key conventions. Rejected with 400: NULL
+                        bytes and unpaired UTF-16 surrogates, in keys or values.
                     additionalProperties: {}
                 user_id:
                     type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3046,7 +3046,7 @@ components:
                     maxLength: 10
                     pattern: '^[^\x00]*$'
                 metadata:
-                    type: object
+                    type: [object, "null"]
                     description: >-
                         Arbitrary context for this record, stored as JSON and returned with
                         equivalent values (key order and number formatting are normalized): the
@@ -3061,11 +3061,16 @@ components:
                         a JavaScript client will still lose precision above 2^53 when it parses the
                         response.
 
-                        Do not put personal data in metadata unless you mean to retain it — it is not
-                        redacted, and unlike an answer it is duplicated onto every record of a
-                        submission. Rejected with 400, because none of them can be stored: invalid
-                        UTF-8; NULL bytes or unpaired UTF-16 surrogates in keys or values; and
-                        numbers outside the storable numeric range.
+                        Nothing here is redacted or sent anywhere else — unlike `value_text`, which
+                        the enrichment pipelines also ship to LLM and embedding providers. Erasure
+                        covers metadata, with one precondition worth knowing:
+                        `DELETE /v1/feedback-records` matches on `user_id` and hard-deletes the whole
+                        row, metadata included — so a record written **without** a `user_id` cannot
+                        be reached that way. Set `user_id` on anything you may later have to erase.
+
+                        Three kinds of content are rejected with 400, because none of them can be
+                        stored: invalid UTF-8; NULL bytes or unpaired UTF-16 surrogates, in keys or
+                        values; and numbers outside the storable numeric range.
                     additionalProperties: {}
                 source_id:
                     type: [string, "null"]
@@ -3281,11 +3286,16 @@ components:
                     description: ISO language code. NULL bytes not allowed.
                     pattern: '^[^\x00]*$'
                 metadata:
-                    type: object
                     description: >-
                         Arbitrary context stored with this record, returned with equivalent values
-                        (key order and number formatting are normalized). Omitted when the record has
-                        no metadata; a record explicitly stored with a JSON `null` returns `null`.
+                        (key order is normalized, and so are number exponents — `1e2` reads back as
+                        `100`). Omitted when the record has no metadata; a record explicitly stored
+                        with a JSON `null` returns `null`.
+
+                        Deliberately untyped: an object is the supported shape and what the request
+                        schemas accept, but the column stores whatever JSON was written, so a record
+                        created before that convention can return any JSON value. Constraining this
+                        to an object would make a generated client reject such a record.
                     additionalProperties: {}
                 sentiment:
                     $ref: '#/components/schemas/SentimentValue'
@@ -3653,7 +3663,7 @@ components:
                     maxLength: 10
                     pattern: '^[^\x00]*$'
                 metadata:
-                    type: object
+                    type: [object, "null"]
                     description: >-
                         Replaces the stored metadata object **wholesale** — it is not merged, so send
                         every key you want to keep or the omitted ones are lost. See the create

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3048,7 +3048,8 @@ components:
                 metadata:
                     type: object
                     description: >-
-                        Arbitrary context for this record, stored as JSON and returned verbatim: the
+                        Arbitrary context for this record, stored as JSON and returned with
+                        equivalent values (key order and number formatting are normalized): the
                         dimensions you want to slice a dashboard by, such as channel, device, browser,
                         OS, country, referrer, campaign, plan or tags. Values may be strings, numbers,
                         booleans, null, or nested objects and arrays.
@@ -3060,8 +3061,9 @@ components:
 
                         Do not put personal data in metadata unless you mean to retain it — it is not
                         redacted, and unlike an answer it is duplicated onto every record of a
-                        submission. Rejected with 400: NULL bytes and unpaired UTF-16 surrogates, in
-                        keys or values, because neither can be stored as JSON.
+                        submission. Rejected with 400: NULL bytes and unpaired UTF-16 surrogates in
+                        keys or values, and numbers outside Postgres numeric range, because none of
+                        them can be stored as JSON.
                     additionalProperties: {}
                 source_id:
                     type: [string, "null"]
@@ -3279,8 +3281,9 @@ components:
                 metadata:
                     type: object
                     description: >-
-                        Arbitrary context stored with this record, returned exactly as it was sent.
-                        Absent when the record carries none.
+                        Arbitrary context stored with this record, returned with equivalent values
+                        (key order and number formatting are normalized). Absent when the record
+                        carries none.
                     additionalProperties: {}
                 sentiment:
                     $ref: '#/components/schemas/SentimentValue'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3056,14 +3056,16 @@ components:
 
                         Use snake_case keys and keep them stable across records, since a key is what a
                         dashboard groups by: `customer_tier`, not a mix of `customerTier` and `tier`.
-                        Numbers keep full precision here (unlike `value_number`, which is a float64),
-                        so a large integer id round-trips exactly.
+                        Numbers keep full precision in storage (unlike `value_number`, which is a
+                        float64), so a large integer id round-trips exactly through this API — though
+                        a JavaScript client will still lose precision above 2^53 when it parses the
+                        response.
 
                         Do not put personal data in metadata unless you mean to retain it — it is not
                         redacted, and unlike an answer it is duplicated onto every record of a
-                        submission. Rejected with 400: NULL bytes and unpaired UTF-16 surrogates in
-                        keys or values, and numbers outside Postgres numeric range, because none of
-                        them can be stored as JSON.
+                        submission. Rejected with 400, because none of them can be stored: invalid
+                        UTF-8; NULL bytes or unpaired UTF-16 surrogates in keys or values; and
+                        numbers outside the storable numeric range.
                     additionalProperties: {}
                 source_id:
                     type: [string, "null"]
@@ -3282,8 +3284,8 @@ components:
                     type: object
                     description: >-
                         Arbitrary context stored with this record, returned with equivalent values
-                        (key order and number formatting are normalized). Absent when the record
-                        carries none.
+                        (key order and number formatting are normalized). Omitted when the record has
+                        no metadata; a record explicitly stored with a JSON `null` returns `null`.
                     additionalProperties: {}
                 sentiment:
                     $ref: '#/components/schemas/SentimentValue'
@@ -3655,8 +3657,9 @@ components:
                     description: >-
                         Replaces the stored metadata object **wholesale** — it is not merged, so send
                         every key you want to keep or the omitted ones are lost. See the create
-                        operation for the value rules and key conventions. Rejected with 400: NULL
-                        bytes and unpaired UTF-16 surrogates, in keys or values.
+                        operation for the value rules and key conventions, including the same 400
+                        rejections (invalid UTF-8, NULL bytes, unpaired surrogates, out-of-range
+                        numbers).
                     additionalProperties: {}
                 user_id:
                     type: string

--- a/tests/feedback_record_metadata_validation_test.go
+++ b/tests/feedback_record_metadata_validation_test.go
@@ -102,9 +102,86 @@ func TestFeedbackRecordMetadataUnstorableInputIsA400(t *testing.T) {
 		assert.Contains(t, payload, "outside the storable range")
 	})
 
-	t.Run("ordinary metadata still stores", func(t *testing.T) {
+	t.Run("ordinary metadata stores and round-trips exactly", func(t *testing.T) {
+		// The spec promises "a large integer id round-trips exactly", so pin it. Decoded with
+		// UseNumber deliberately: through `map[string]any` this value becomes a float64 and reads
+		// back ...92, which is the regression this guards — and which assert.JSONEq would miss,
+		// since it would lose the same precision on both sides of the comparison.
 		status, payload := postRecord(t, `{"source":"link","big":9007199254740993}`)
+		require.Equal(t, http.StatusCreated, status, payload)
 
-		assert.Equal(t, http.StatusCreated, status, payload)
+		var record struct {
+			Metadata json.RawMessage `json:"metadata"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(payload), &record))
+
+		decoder := json.NewDecoder(bytes.NewReader(record.Metadata))
+		decoder.UseNumber()
+
+		var stored map[string]any
+		require.NoError(t, decoder.Decode(&stored))
+
+		assert.Equal(t, "link", stored["source"])
+		assert.Equal(t, json.Number("9007199254740993"), stored["big"])
+	})
+
+	// The update path has its own validator tag and its own 22003 mapping. Without this, deleting
+	// either leaves the suite green while PATCH regresses to a 500.
+	t.Run("the update path rejects the same three classes", func(t *testing.T) {
+		status, payload := postRecord(t, `{"source":"link"}`)
+		require.Equal(t, http.StatusCreated, status, payload)
+
+		var created struct {
+			ID string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(payload), &created))
+		require.NotEmpty(t, created.ID)
+
+		patch := func(t *testing.T, body string) (int, string) {
+			t.Helper()
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch,
+				server.URL+"/v1/feedback-records/"+created.ID, bytes.NewBufferString(body))
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+testAPIKey)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+
+			payload, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			return resp.StatusCode, string(payload)
+		}
+
+		// Baseline first: an empty PATCH succeeds, so a 400 below cannot be "any PATCH body fails".
+		status, payload = patch(t, `{}`)
+		require.Equal(t, http.StatusOK, status, payload)
+
+		for _, unstorable := range []struct {
+			name     string
+			metadata string
+		}{
+			{name: "null byte", metadata: `{"note":"bad\u0000value"}`},
+			{name: "unpaired surrogate", metadata: `{"note":"bad\ud83dvalue"}`},
+			{name: "numeric overflow", metadata: `{"n":1e1000000}`},
+		} {
+			t.Run(unstorable.name, func(t *testing.T) {
+				status, payload := patch(t, `{"metadata": `+unstorable.metadata+`}`)
+
+				assert.Equal(t, http.StatusBadRequest, status, payload)
+				// Naming `metadata` rules out an incidental 400 (a bad id would name `id`).
+				assert.Contains(t, metadataParamNames(t, payload), "metadata")
+			})
+		}
+
+		t.Run("and still accepts storable metadata", func(t *testing.T) {
+			status, payload := patch(t, `{"metadata": {"source":"app"}}`)
+
+			assert.Equal(t, http.StatusOK, status, payload)
+		})
 	})
 }

--- a/tests/feedback_record_metadata_validation_test.go
+++ b/tests/feedback_record_metadata_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ func TestFeedbackRecordMetadataUnstorableInputIsA400(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 30 * time.Second}
 
 	// Unique per run: the accepted-metadata subtest inserts a real row, and the identity triple
 	// (tenant_id, submission_id, field_id) would 409 on the next run against the same database.

--- a/tests/feedback_record_metadata_validation_test.go
+++ b/tests/feedback_record_metadata_validation_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ENG-2745: metadata that Postgres cannot store must come back as a 400 naming `metadata`, never as
+// an unmapped 500. Two mechanisms are under test, so this deliberately drives the full HTTP stack
+// against the real database: the storable_json request validator (NUL bytes, unpaired surrogates)
+// and the repository's SQLSTATE 22003 mapping (numbers outside numeric range, which no byte scan
+// can see — the value is fifteen bytes of perfectly valid JSON).
+func TestFeedbackRecordMetadataUnstorableInputIsA400(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	client := &http.Client{}
+
+	// Unique per run: the accepted-metadata subtest inserts a real row, and the identity triple
+	// (tenant_id, submission_id, field_id) would 409 on the next run against the same database.
+	tenantID := "metadata-validation-" + uuid.NewString()
+
+	postRecord := func(t *testing.T, metadataJSON string) (int, string) {
+		t.Helper()
+
+		body := fmt.Sprintf(`{
+			"tenant_id": "%s-%s",
+			"submission_id": "s1",
+			"source_type": "survey",
+			"field_id": "q1",
+			"field_type": "text",
+			"value_text": "ok",
+			"metadata": %s
+		}`, tenantID, t.Name(), metadataJSON)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			server.URL+"/v1/feedback-records", bytes.NewBufferString(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+testAPIKey)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+
+		payload, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		return resp.StatusCode, string(payload)
+	}
+
+	metadataParamNames := func(t *testing.T, payload string) []string {
+		t.Helper()
+
+		var problem struct {
+			InvalidParams []struct {
+				Name string `json:"name"`
+			} `json:"invalid_params"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(payload), &problem))
+
+		names := make([]string, 0, len(problem.InvalidParams))
+		for _, param := range problem.InvalidParams {
+			names = append(names, param.Name)
+		}
+
+		return names
+	}
+
+	t.Run("null byte is rejected by the request validator", func(t *testing.T) {
+		status, payload := postRecord(t, `{"note":"bad\u0000value"}`)
+
+		assert.Equal(t, http.StatusBadRequest, status, payload)
+		assert.Contains(t, metadataParamNames(t, payload), "metadata")
+	})
+
+	t.Run("unpaired surrogate is rejected by the request validator", func(t *testing.T) {
+		status, payload := postRecord(t, `{"note":"bad\ud83dvalue"}`)
+
+		assert.Equal(t, http.StatusBadRequest, status, payload)
+		assert.Contains(t, metadataParamNames(t, payload), "metadata")
+	})
+
+	t.Run("numeric overflow is rejected by the repository mapping", func(t *testing.T) {
+		// Valid JSON, storable characters — only the parsed value overflows Postgres numeric, so
+		// this can only fail closed if the 22003 mapping is in place.
+		status, payload := postRecord(t, `{"n":1e1000000}`)
+
+		assert.Equal(t, http.StatusBadRequest, status, payload)
+		assert.Contains(t, metadataParamNames(t, payload), "metadata")
+		assert.Contains(t, payload, "outside the storable range")
+	})
+
+	t.Run("ordinary metadata still stores", func(t *testing.T) {
+		status, payload := postRecord(t, `{"source":"link","big":9007199254740993}`)
+
+		assert.Equal(t, http.StatusCreated, status, payload)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-2745 (https://linear.app/formbricks/issue/ENG-2745/hub-returns-500-instead-of-400-for-null-bytes-in-feedback-record)

`metadata` was the only field on the feedback-record create/update requests with no content validation — and it couldn't have had it: `no_null_bytes` skips any non-string kind, and `json.RawMessage` is a `[]byte`. So input the OpenAPI spec already declares invalid reached Postgres verbatim and failed the jsonb write as an unmapped 500.

Postgres refuses three things in jsonb that pass every upstream check, and this PR maps all of them to a 400 naming `metadata`:

- **NUL bytes** and **unpaired UTF-16 surrogates** (in keys or values) — a new `storable_json` validator tag scans the raw bytes on both request structs. Raw bytes on purpose: `encoding/json` rewrites both cases on decode (NUL escape → real NUL, lone surrogate → U+FFFD), so an unmarshalled value looks storable while the wire bytes are not.
- **numbers outside numeric range** (`{"n":1e1000000}` — 15 bytes of valid JSON) — invisible to any byte scan, so SQLSTATE 22003 is mapped at the repository on both write paths. Attribution to `metadata` is sound: it's the only place a numeric can originate on these queries (`value_number` is float8, and every float64 fits float8).

Also rewrites the three `metadata` descriptions in `openapi.yaml` (what belongs in it, snake_case keys, PATCH replaces wholesale, jsonb normalizes key order/number formatting — the old text said little beyond "additional context").

Before / after for the same request:

```json
// before                                           // after
{                                                   {
  "status": 500,                                      "status": 400,
  "code": "internal_server_error",                    "code": "validation",
  "detail": "An unexpected error occurred"            "invalid_params": [{
}                                                       "name": "metadata",
                                                        "reason": "must not contain NULL bytes or unpaired UTF-16 surrogates"
                                                      }]
                                                    }
```

## How should this be tested?

Against a local stack (`docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=test_db -p 5432:5432 pgvector/pgvector:pg18`, `.env` with `DATABASE_URL=postgres://postgres:postgres@localhost:5432/test_db?sslmode=disable` and `API_KEY`, then `make init-db && make run-api`):

- `POST /v1/feedback-records` with `"metadata":{"note":"badvalue"}` → 400, `invalid_params` names `metadata` (was 500, `SQLSTATE 22P05` in the log)
- same with `"bad\ud83dvalue"`, a NUL in a **key**, and `{"n":1e1000000}` → 400 each; `PATCH` behaves identically
- a control: the same NUL in `value_text` still 400s as before, and ordinary metadata (nested objects, emoji, valid surrogate pairs, 200 keys, a 20k value) still stores and round-trips
- `tests/feedback_record_metadata_validation_test.go` drives all three rejection classes through the full HTTP stack against the real database
- differential check: 8,000 generated escape-soup JSON documents — the scanner's verdict matched Postgres's own `::jsonb` verdict on every one, in both directions

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Repository Guidelines](https://github.com/formbricks/hub/blob/main/AGENTS.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `make build`
- [x] Ran `make tests` (integration tests in `tests/`)
- [x] Ran `make fmt` and `make lint`; no new warnings
- [x] Removed debug prints / temporary logging
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] If database schema changed: added migration in `migrations/` with goose annotations and ran `make migrate-validate` (no schema change)

### Appreciated

- [x] If API changed: added or updated OpenAPI spec and ran contract tests (`make tests` or API contract workflow)
- [x] If API behavior changed: added request/response examples or Swagger UI screenshots to this PR
- [ ] Updated docs in `docs/` if changes were necessary (openapi.yaml carries the doc change)
- [ ] Ran `make tests-coverage` for meaningful logic changes

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.
